### PR TITLE
feat(scripts): the overlap check reads the open set against a path list before any commit exists

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,11 +285,26 @@ hatch run format            # ruff check --fix, ruff format
    as a separate `headRepositoryId`. Step 5 already says "from your fork"; step 1
    is where that stops being a preference.
 
-   Before you start, check that no open pull request already claims the issue:
+   Before you start, check that no open pull request already claims the issue,
+   and that none already edits the file the defect lives in:
 
    ```
    python3 scripts/check_duplicate_claim.py --repo strands-labs/robots --issue <N>
+   python3 scripts/check_merge_base_overlap.py --github-repo strands-labs/robots --paths <the paths you are about to edit>
    ```
+
+   The second read is the one with recall on this repository's duplicate pairs.
+   Five of them are recorded on #3169, and on every one the claim key was silent
+   (`Closes` against `Refs`), the fragment key was silent (two slugs, or the issue
+   number against the PR number) and the shared-edited-test key was silent (two
+   new test files). The one thing two fixes of one defect cannot avoid sharing is
+   the file the defect lives in, and that path is known before any commit exists.
+   #3368 was open and approved for 31 minutes before #3370's first commit against
+   the same three files; this read would have named it, and instead the pair spent
+   a second external approval - the scarcest resource here - on a diff `main`
+   already had. A hit is a pull request to read before writing a line, not a
+   refusal to work: if it is a different change to the same file it is a
+   merge-order question, which `--all-open` answers once yours is open.
 
    Name the repository rather than leaving it to be inferred. `$GITHUB_REPOSITORY`
    is where the command is *running*, which for a scheduled agent need not be a
@@ -358,12 +373,15 @@ hatch run format            # ruff check --fix, ruff format
    complementary rather than nested: no issue-keyed pair shares an added path, and
    no claim-free pair claims an issue.
 
-   This one cannot be asked before you start, and not for want of trying: a path
-   set is a property of a pushed branch, so there is nothing to read at intake. It
-   caps the review cost of a collision rather than preventing the work, which is
-   why it belongs here and `--issue` belongs above. It still arrives early enough
-   to matter - both claim-free pairs opened inside the same ~35-minute window every
-   other observed collision shares, 14m 41s and 29m 26s apart.
+   The pairwise form cannot be asked before you start: a path set is a property of
+   a pushed branch, so with no branch there is no pair. But one side of the pair is
+   known at intake - the file you are about to edit - and `--paths` (step 1 above)
+   reads the open set against it, which is the same relation with a path list
+   standing in for the branch that does not exist yet. So the sweep here caps the
+   review cost of a collision the intake read missed, rather than being the first
+   chance to see one. It still arrives early enough to matter - both claim-free
+   pairs opened inside the same ~35-minute window every other observed collision
+   shares, 14m 41s and 29m 26s apart.
 2. Make changes, run `hatch run format && hatch run lint && hatch run test`.
    If you narrow the test run to the area you changed (`pytest tests/drivers/ -k g1`),
    run `hatch run whole-tree-check` alongside it. Ninety-odd graders take

--- a/changelog.d/3169-the-overlap-check-reads-the-open-set-at-intake.md
+++ b/changelog.d/3169-the-overlap-check-reads-the-open-set-at-intake.md
@@ -1,0 +1,21 @@
+### Added: the merge-base overlap check reads the open set against a path list before any commit exists
+
+`scripts/check_merge_base_overlap.py --paths <paths>` reports which open
+non-draft pull requests already edit the files a change is about to touch.
+`--all-open` compares two pushed branches, so it cannot run until the second
+exists - and every duplicate pair it has caught opened inside one ~35-minute
+window, with both implementations already written. #3368 and #3370 both fixed
+the posture-flag read in `strands_robots/simulation/base.py`; the first was open
+and approved for 31 minutes before the second's first commit, every duplicate
+key read clean (`Closes` against `Refs`, fragments led by the issue number
+against the PR number, no shared edited pre-existing test), and the pair spent a
+second external approval on a diff `main` already had. The file a defect lives
+in is the one thing two fixes of it cannot avoid sharing, and it is known before
+a branch is. The intake mode reads only the open set's path sets - no compare,
+because there is no head to compare - blocks on a behaviour-bearing hit, lists a
+prose-only one without blocking, excludes drafts and names an unreadable path set
+rather than reporting it clear, on the same rules as the sweep. `AGENTS.md` step
+1 now runs it beside the duplicate-claim read and no longer says the path
+relation cannot be asked at intake.
+
+Refs #3169.

--- a/scripts/check_merge_base_overlap.py
+++ b/scripts/check_merge_base_overlap.py
@@ -54,6 +54,21 @@ includes renames: git reports one as its delete plus its add under
 ``filename`` to reach the same set, because a branch that renames a file and a
 branch that edits its old name compose without a conflict marker.
 
+``--paths`` is the same pairwise relation asked one step earlier, with a path
+list standing in for the branch that does not exist yet. Every duplicate pair
+the sweep has caught opened inside one ~35-minute window, and a pair that
+opened together was written together: by the time both branches exist, so do
+both implementations. What is known before either exists is where the defect
+lives, and two fixes of one defect cannot avoid editing that file -- unlike the
+closing reference, the fragment slug and the shared edited test, each a spelling
+two authors need not share (#3169). #3368 was open and approved for 31 minutes
+before #3370 made its first commit against the same three files; reading the
+open set against ``strands_robots/simulation/base.py`` at that moment would have
+named it. So the intake mode reads the open set's path sets and nothing else --
+no compare, because the caller has no head to compare -- and blocks on a
+behaviour-bearing hit, because the remedy is to read that pull request before
+authoring, not after.
+
 The two sides come from different endpoints, and so have different ceilings. The
 head side -- the input to the pairwise mode -- is read from the paginated
 pull-request files endpoint, which carries ten times what the compare endpoint's
@@ -1233,6 +1248,124 @@ def _run_sweep(repo: str, base_ref: str, token: str) -> int:
     return 1 if blocking else 0
 
 
+def intake_overlaps(
+    repo: str, paths: Iterable[str], token: str
+) -> tuple[list[tuple[int, tuple[str, ...], tuple[str, ...]]], list[tuple[int, str]], int]:
+    """Return ``(found, unevaluated, open_count)`` for the open pull requests editing one of ``paths``.
+
+    ``found`` rows are ``(number, blocking, prose)``; ``open_count`` is the size
+    of the open set read, returned alongside so the report can state the
+    population without a second listing request.
+
+    The intake half of the pairwise relation. ``--all-open`` compares two pushed
+    branches, so it cannot run before the second one exists -- and the duplicate
+    pairs it has caught all opened inside one ~35-minute window, so by the time
+    it can run the second implementation is already written. But one side of
+    that intersection is known before any commit is: the path a defect lives in.
+    #3368 and #3370 both fixed the posture-flag read in
+    ``strands_robots/simulation/base.py``; the first was open and approved for
+    31 minutes before the second's first commit, and this read of the open set
+    against that one path would have returned it (#3169).
+
+    One request per open pull request plus the listing, and no compare: the
+    caller has no branch to compare. Drafts are excluded and unreadable path sets
+    are named, for the reasons ``collect_open_pull_requests`` gives.
+    """
+    wanted = frozenset(paths)
+    found: list[tuple[int, tuple[str, ...], tuple[str, ...]]] = []
+    unevaluated: list[tuple[int, str]] = []
+    lookup_failures = (ApiError, urllib.error.URLError, urllib.error.HTTPError, ValueError, KeyError)
+    open_set = resolve_open_pull_requests(repo, token)
+    for number, _head_sha in open_set:
+        try:
+            edits = pull_request_paths(repo, number, token)
+        except lookup_failures as error:
+            unevaluated.append((number, f"path set unreadable: {error}"))
+            continue
+        blocking, prose = partition_overlap(overlapping_paths(wanted, edits))
+        if blocking or prose:
+            found.append((number, blocking, prose))
+    return found, unevaluated, len(open_set)
+
+
+def render_intake(
+    *,
+    repo: str,
+    paths: Sequence[str],
+    found: Sequence[tuple[int, tuple[str, ...], tuple[str, ...]]],
+    unevaluated: Sequence[tuple[int, str]],
+    open_count: int,
+) -> str:
+    """Render the intake report: which open pull requests already edit the named paths."""
+    lines = ["## Merge-base overlap check - intake", ""]
+    header = (
+        f"`{repo}`: {open_count} open non-draft pull request(s) read against {len(paths)} path(s) "
+        + "you are about to edit."
+    )
+    lines.append(header)
+    lines.append("")
+
+    blocking_rows = [row for row in found if row[1]]
+    prose_rows = [row for row in found if not row[1]]
+
+    if not blocking_rows:
+        clean = (
+            "No open pull request edits a behaviour-bearing path in this set. If one opens "
+            + "before yours does, `--all-open` is the read that sees the pair."
+        )
+        lines.append(clean)
+        lines.append("")
+    else:
+        lines.append("### Already edited by an open pull request")
+        lines.append("")
+        for number, blocking, prose in blocking_rows:
+            lines.append(f"- #{number}: " + ", ".join(f"`{path}`" for path in blocking + prose))
+        lines.append("")
+        remedy = (
+            "Read each one before writing a line. Two fixes of one defect cannot avoid "
+            + "sharing the file the defect lives in, and every other duplicate key -- the "
+            + "closing reference, the fragment slug, the shared edited test -- is a spelling "
+            + "two authors need not share. If it is the same fix, there is nothing to author. "
+            + "If it is a different change to the same file, it is a merge-order question, "
+            + "which `--all-open` reports once yours is open."
+        )
+        lines.append(remedy)
+        lines.append("")
+
+    if prose_rows:
+        lines.append("### Prose paths shared with an open pull request (not blocking)")
+        lines.append("")
+        for number, _blocking, prose in prose_rows:
+            lines.append(f"- #{number}: " + ", ".join(f"`{path}`" for path in prose))
+        lines.append("")
+
+    if unevaluated:
+        lines.append("### Not evaluated")
+        lines.append("")
+        for number, reason in unevaluated:
+            lines.append(f"- #{number}: {reason}")
+        lines.append("")
+        caveat = (
+            "A pull request whose path set could not be read is absent from the rows "
+            + "above, not known to be clear of them."
+        )
+        lines.append(caveat)
+        lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+def _run_intake(repo: str, paths: Sequence[str], token: str) -> int:
+    """Read the open set against the paths a change will edit. Exit 1 on a behaviour-bearing hit."""
+    try:
+        found, unevaluated, open_count = intake_overlaps(repo, paths, token)
+    except (ApiError, urllib.error.URLError, urllib.error.HTTPError, ValueError) as error:
+        print(f"::error::merge-base overlap intake could not list open pull requests: {error}", file=sys.stderr)
+        return 1
+    _emit(render_intake(repo=repo, paths=paths, found=found, unevaluated=unevaluated, open_count=open_count))
+    return 1 if any(row[1] for row in found) else 0
+
+
 def render_report(
     *,
     base_ref: str,
@@ -1378,6 +1511,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="sweep the open set from the API instead of checking one branch",
     )
     parser.add_argument(
+        "--paths",
+        nargs="+",
+        default=None,
+        metavar="PATH",
+        help="intake: report which open pull requests already edit these paths (before any commit exists)",
+    )
+    parser.add_argument(
         "--github-repo",
         default=os.environ.get("GITHUB_REPOSITORY"),
         help="owner/name for --all-open (default: $GITHUB_REPOSITORY)",
@@ -1397,6 +1537,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     # reading $GITHUB_REPOSITORY and reporting on a repository nobody asked about
     # (issue #2569). Every value-bearing flag the sweep does read is passed to
     # _run_sweep below, which is what pins this partition rather than a list.
+    if args.all_open and args.paths is not None:
+        parser.error("--all-open compares the open set with itself; --paths compares it with a change not yet pushed")
+    if args.paths is not None and args.head is not None:
+        parser.error("--paths names a change that has no commit yet; --head names one that does")
+    if args.paths is not None and args.repo is not None:
+        parser.error(
+            "--paths reads the open set from the API and reads no local checkout; --repo names one. "
+            "To name the repository the intake reads, pass --github-repo owner/name."
+        )
     if args.all_open and args.head is not None:
         parser.error("--all-open sweeps the open set and reads no local commit; --head names one branch")
     if args.all_open and args.repo is not None:
@@ -1410,6 +1559,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         if not args.token:
             parser.error("--all-open needs --token (or $GITHUB_TOKEN)")
         return _run_sweep(args.github_repo, args.base_ref, args.token)
+    if args.paths is not None:
+        if not args.github_repo:
+            parser.error("--paths needs --github-repo owner/name (or $GITHUB_REPOSITORY)")
+        if not args.token:
+            parser.error("--paths needs --token (or $GITHUB_TOKEN)")
+        return _run_intake(args.github_repo, args.paths, args.token)
 
     head = args.head if args.head is not None else "HEAD"
     repo = Path(args.repo) if args.repo is not None else None

--- a/tests/test_merge_base_overlap.py
+++ b/tests/test_merge_base_overlap.py
@@ -1090,7 +1090,7 @@ def test_the_partition_is_derived_and_finds_both_sides() -> None:
     (above), and the local ones when *present*.
     """
     assert _SWEEP_READS == {"github_repo", "base_ref", "token"}, _SWEEP_READS
-    assert set(_SWEEP_IGNORES) == {"head", "repo"}, _SWEEP_IGNORES
+    assert set(_SWEEP_IGNORES) == {"head", "repo", "paths"}, _SWEEP_IGNORES
 
 
 def test_the_flag_both_modes_read_is_not_refused_by_the_sweep(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -1142,6 +1142,155 @@ def test_the_sweep_refuses_to_run_without_its_own_inputs(monkeypatch: pytest.Mon
     with pytest.raises(SystemExit) as raised:
         check.main(argv)
     assert raised.value.code == 2
+
+
+# --- the intake relation -----------------------------------------------------------
+#
+# #3368 and #3370 both fixed the posture-flag truthiness read in
+# `strands_robots/simulation/base.py` (#3356). #3368 opened 16:46Z and was approved
+# 16:57Z; #3370's first commit is 17:18Z, and it drew a second approval at 17:25Z
+# before the pair was caught. Every duplicate key read clean: `Closes` against
+# `Refs`, fragments led by the issue number against the PR number, no shared
+# edited pre-existing test. The one thing two fixes of one defect cannot avoid
+# sharing is the file the defect lives in, and that path is known before any
+# commit exists. `--paths` reads the open set against it at that moment. Issue #3169.
+
+_INTAKE_PATH = "strands_robots/simulation/base.py"
+
+
+def _intake(monkeypatch: pytest.MonkeyPatch, get: Callable[[str, str], object], tmp_path: Path, *paths: str) -> int:
+    """Run the intake read from a directory that is not a repository at all.
+
+    Same property the sweep pins, and more so: the caller has no branch yet, so
+    there is nothing local the mode could read even if it wanted to.
+    """
+    monkeypatch.setattr(check, "_get", get)
+    monkeypatch.chdir(tmp_path)
+    return int(check.main(["--paths", *paths, "--github-repo", "owner/name", "--token", "t"]))
+
+
+def test_the_3368_3370_pair_is_named_at_intake(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The first implementation is open; the read against the defect's path names it."""
+    get = _api(
+        [_pull(3368, "a" * 40)],
+        {"main...aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": _compare([_INTAKE_PATH, "tests/simulation/test_x.py"])},
+    )
+    code = _intake(monkeypatch, get, tmp_path, _INTAKE_PATH)
+    out = capsys.readouterr().out
+    assert code == 1
+    assert "#3368" in out
+    assert f"`{_INTAKE_PATH}`" in out
+    assert "before writing a line" in out
+
+
+def test_a_disjoint_open_set_is_clean_and_names_the_read_that_follows(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No hit, exit 0 - and the report says which mode sees a pair that opens later."""
+    get = _api(
+        [_pull(1, "b" * 40)], {"main...bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": _compare(["docs/other.md", "x.py"])}
+    )
+    code = _intake(monkeypatch, get, tmp_path, _INTAKE_PATH)
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "1 open non-draft pull request(s)" in out
+    assert "--all-open" in out
+
+
+def test_a_prose_only_intake_hit_is_listed_but_does_not_block(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """AGENTS.md is edited by most open pull requests; a shared prose path is not a duplicate."""
+    get = _api(
+        [_pull(7, "c" * 40)], {"main...cccccccccccccccccccccccccccccccccccccccc": _compare(["AGENTS.md", "y.py"])}
+    )
+    code = _intake(monkeypatch, get, tmp_path, "AGENTS.md", _INTAKE_PATH)
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "#7" in out and "`AGENTS.md`" in out
+    assert "not blocking" in out
+
+
+def test_a_draft_is_excluded_from_the_intake_read(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Same rule as the sweep: a draft cannot merge, so a hit on one means something else."""
+    get = _api(
+        [_pull(9, "d" * 40, draft=True)],
+        {"main...dddddddddddddddddddddddddddddddddddddddd": _compare([_INTAKE_PATH])},
+    )
+    code = _intake(monkeypatch, get, tmp_path, _INTAKE_PATH)
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "#9" not in out
+    assert "0 open non-draft" in out
+
+
+def test_an_unreadable_path_set_is_named_rather_than_read_as_clear(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """One pull request's file list fails; it is listed as not evaluated and the rest are read."""
+    get = _api(
+        [_pull(3, "e" * 40), _pull(4, "f" * 40)],
+        {"main...ffffffffffffffffffffffffffffffffffffffff": _compare([_INTAKE_PATH])},
+    )
+    code = _intake(monkeypatch, get, tmp_path, _INTAKE_PATH)
+    out = capsys.readouterr().out
+    assert code == 1
+    assert "#4" in out
+    assert "### Not evaluated" in out and "#3" in out
+    assert "not known to be clear" in out
+
+
+def test_the_intake_read_lists_the_open_set_once(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The population is reported from the one listing the relation already made."""
+    inner = _api([_pull(1, "b" * 40)], {"main...bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": _compare(["x.py"])})
+    listings: list[str] = []
+
+    def get(url: str, token: str) -> object:
+        if "/pulls?" in url:
+            listings.append(url)
+        return inner(url, token)
+
+    assert _intake(monkeypatch, get, tmp_path, _INTAKE_PATH) == 0
+    assert len(listings) == 1, listings
+
+
+@pytest.mark.parametrize(
+    ("argv", "named"),
+    [
+        (["--paths", "x.py", "--head", "HEAD"], "--head"),
+        (["--paths", "x.py", "--repo", "."], "--repo"),
+        (["--all-open", "--paths", "x.py"], "--paths"),
+    ],
+)
+def test_the_intake_read_refuses_a_flag_it_is_handed_none_of(
+    argv: list[str], named: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A change with no commit has no head and no checkout; the sweep is a different question."""
+    message = _refusal([*argv, "--github-repo", "owner/name", "--token", "t"], capsys)
+    assert named in message, message
+
+
+@pytest.mark.parametrize("missing", ["--github-repo", "--token"])
+def test_the_intake_read_refuses_to_run_without_its_own_inputs(monkeypatch: pytest.MonkeyPatch, missing: str) -> None:
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    argv = ["--paths", "x.py", "--github-repo", "owner/name", "--token", "t"]
+    argv.remove(missing)
+    argv.remove("owner/name" if missing == "--github-repo" else "t")
+    with pytest.raises(SystemExit) as raised:
+        check.main(argv)
+    assert raised.value.code == 2
+
+
+def test_the_intake_and_the_sweep_share_one_prose_rule(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Emptying PROSE_SUFFIXES makes a shared AGENTS.md block at intake, as it does in the sweep."""
+    monkeypatch.setattr(check, "PROSE_SUFFIXES", frozenset())
+    get = _api([_pull(7, "c" * 40)], {"main...cccccccccccccccccccccccccccccccccccccccc": _compare(["AGENTS.md"])})
+    assert _intake(monkeypatch, get, tmp_path, "AGENTS.md") == 1
 
 
 # --- the named-module relation ---------------------------------------------------


### PR DESCRIPTION
## What

`scripts/check_merge_base_overlap.py --paths <paths>` - an intake mode that reports which open non-draft pull requests already edit the files a change is about to touch, before a branch exists.

The pairwise sweep (`--all-open`) needs two pushed branches. Every duplicate pair it has caught opened inside one ~35-minute window, so by the time it can run, both implementations are already written. What is known before either exists is the file the defect lives in - and that is the one thing two fixes of one defect cannot avoid sharing. Every other duplicate key is a spelling two authors need not share: the closing reference (`Closes` vs `Refs`), the fragment slug (two names for one subject), the fragment's leading number (issue number vs predicted PR number), the shared edited pre-existing test (two new test files).

## Why now

#3368 (opened 16:46Z, approved 16:57Z) and #3370 (first commit 17:18Z, approved 17:25Z) both fixed the posture-flag truthiness read on the same three files from the same base. Every duplicate key read clean. #3370 was closed today as superseded only because #3368 merged first and left it `CONFLICTING`; had #3370's required check finished twenty minutes sooner, both would have landed. It is the fifth pair on #3169 and the first to spend an external approval - the binding constraint on this queue - on a diff `main` already had.

Reading the open set against `strands_robots/simulation/base.py` at 17:18Z would have named #3368. Measured today against the live repository with the three paths that pair shared:

```
## Merge-base overlap check - intake

`strands-labs/robots`: 2 open non-draft pull request(s) read against 3 path(s) you are about to edit.

### Already edited by an open pull request

- #3343: `strands_robots/simulation/base.py`, `strands_robots/simulation/mujoco/simulation.py`
```

(exit 1 - #3343 is the composition #3368's own description had to reason about by hand.) And against this PR's own paths before authoring: exit 0, with `AGENTS.md` listed under prose-only for #3343, not blocking.

## Shape

| piece | what |
|---|---|
| `intake_overlaps(repo, paths, token)` | one listing request + one file-list request per open PR; no compare, because there is no head to compare. Returns `(found, unevaluated, open_count)` so the report states the population from the listing it already made |
| `render_intake` | same section conventions as `render_sweep`: blocking rows with the remedy, prose-only rows marked not blocking, unevaluated rows with the caveat that unread is not clear |
| `_run_intake` | exit 1 on a behaviour-bearing hit |
| CLI | `--paths PATH [PATH ...]`; refused beside `--head` (no commit yet), `--repo` (no checkout), `--all-open` (different question); needs `--github-repo` and `--token` like the sweep |
| `PROSE_SUFFIXES`, `partition_overlap`, `overlapping_paths`, `resolve_open_pull_requests`, `pull_request_paths` | reused, so the three modes cannot disagree about what counts as an overlap, as prose, or as a draft |

AGENTS.md step 1 now runs the read beside `check_duplicate_claim.py --issue`, and the paragraph further down that said "this one cannot be asked before you start ... there is nothing to read at intake" now says which half can be. Module docstring carries the account, per the file's convention.

## Pinned

`tests/test_merge_base_overlap.py`, +10 cells in a new intake section, reusing `_api` / `_pull` / `_compare`:

- the #3368/#3370 shape: one open PR on the defect's path -> exit 1, PR named, path named, remedy present
- disjoint open set -> exit 0 and the report names `--all-open` as the read that sees a later pair
- prose-only hit (`AGENTS.md`) -> listed, not blocking, exit 0
- draft excluded from the read and from the count
- one unreadable path set -> named under `Not evaluated`, the others still read, exit reflects the readable hit
- the listing endpoint is called exactly once
- refusals: `--paths` + `--head`, `--paths` + `--repo`, `--all-open` + `--paths`, each naming the refused flag; missing `--github-repo` / `--token` -> argparse exit 2
- the intake and the sweep share one prose rule (emptying `PROSE_SUFFIXES` makes `AGENTS.md` block at intake too)
- the derived partition pin (`_SWEEP_IGNORES`) now lists `paths` beside `head` and `repo`, and its parametrized refusal cell picked `--paths` up on arrival with no edit

Pre-fix (production stashed, tests present): **10 failed / 99 passed**. Post: **110 passed** (72 test functions on `main` -> the difference is these cells plus the derived parametrization).

## Verification

- `ruff check` / `ruff format --check` (ruff 0.15.22, the pinned range): clean on both files
- `mypy scripts/check_merge_base_overlap.py`: `Success: no issues found`
- script is ASCII-only, no emoji
- `tests/test_changelog_fragments.py`: 28 passed with the new fragment
- whole-tree graders (roster derived by `check_whole_tree_graders.py`, 118 of 121 collected - the 3 excluded need `lerobot` / `fastapi`): 4141 passed, 57 failed, 149 errors on this branch; **the failing set on pristine `main` is byte-identical** (208 rows, `comm` empty both ways), all `mujoco` / `awsiot` / `zenoh` / `lerobot`-absent on this host
- intake read on this PR's own paths before authoring: clean (above)
- `check_duplicate_claim.py --issue 3169`: not applicable - this PR does not claim the close; #3169 stays open as the record its body asks for

## Round changelog

- r0 (`3dc7406`): opened. Awaiting the required check and a first review.

Refs #3169.