### PR TITLE
fix(drivers): a caller-stopped G1/Go2 rollout names what stopped it

### DIFF
--- a/changelog.d/3374-rollout-exit-reason-reaches-a-late-poller.md
+++ b/changelog.d/3374-rollout-exit-reason-reaches-a-late-poller.md
@@ -1,0 +1,21 @@
+### Fixed: a caller-stopped G1/Go2 rollout names what stopped it
+
+`get_task_status()` answers from a snapshot the control loop stashes on the
+driver as it clears itself, which is the only thing a poller arriving after the
+rollout's thread is gone can read. `_ControlLoop.stop()` recorded its reason
+*after* `join()` returned, and the loop's `finally` stashes while that `join()`
+is still blocked - so the stash predated the reason, and a rollout ended by a
+caller reported `exit_reason=None`: a finished rollout with no cause, on the one
+surface an operator has for "why did my robot stop moving".
+
+The Go2 lost the most, because it is the driver that distinguishes *which*
+caller stopped it. `stop_task()`, the mesh's `stop` verb and `cleanup()` each
+pass their own word into the same loop, and all three collapsed into the same
+absence - so a halted rollout, a shutdown and a teardown were indistinguishable
+after the fact. `stop_task()`'s own return value did carry the reason, so the
+same rollout answered two different things depending on when it was asked.
+
+The reason is now recorded before the stop is signalled, which is what the UR
+driver's loop already does (`self._finish("stopped")` on the stop path, before
+the exit can be read). Precedence is unchanged: the record is first-writer-wins,
+so a loop that already ended on its own budget keeps that more specific reason.

--- a/docs/robots/mobile.md
+++ b/docs/robots/mobile.md
@@ -173,6 +173,18 @@ soft-stop frame on the way out rather than cutting the motors dead. Poll
 `get_task_status()`; `stop_task()` reports honestly whether the loop actually
 joined.
 
+`get_task_status()` keeps answering after the rollout's thread is gone, and its
+`exit_reason` names whichever of these ended it — so a caller who polls late
+still learns why the robot stopped moving:
+
+| `exit_reason` | What happened |
+|---------------|---------------|
+| `n_steps` / `duration` | the rollout ran its budget out |
+| `gate` | sport mode was taken back, or the battery fell under the floor (`exit_detail` says which) |
+| `policy` | the policy raised, returned `None`, or named a joint this robot does not have |
+| `publish` | the frame did not reach `rt/lowcmd` |
+| `stop_task` / `stop` / `cleanup` | a caller halted it — `stop_task()`, the mesh's `stop` verb, or teardown |
+
 ## Real hardware: the EarthRover native driver
 
 `earthrover` declares `hardware.lerobot_type`, so `mode="real"` builds the lerobot robot

--- a/strands_robots/drivers/g1.py
+++ b/strands_robots/drivers/g1.py
@@ -1935,6 +1935,16 @@ class _ControlLoop:
         ``_stop_event.is_set()`` at the top of every step, and once more
         after the policy returns and before the frame publishes.
 
+        ``reason`` is recorded *before* the signal.  The loop's ``finally``
+        stashes its terminal snapshot on the driver while this call is still
+        inside ``join()``, so a reason written after the join reaches
+        ``_exit_reason`` but never the stashed copy
+        :meth:`G1Driver.get_task_status` reads once the loop has cleared
+        itself - which reported a finished rollout with no exit reason at
+        all.  Recording first costs nothing: :meth:`_ControlLoop._set_exit` is
+        first-writer-wins, so a loop that already ended on its own budget
+        keeps that more specific reason.
+
         Returns:
             ``True`` when the thread joined within ``timeout``.  ``False``
             when the loop is still running - a caller-supplied policy that
@@ -1943,17 +1953,13 @@ class _ControlLoop:
             :meth:`stop_task` envelope rather than a ``success`` claim the
             payload's ``running=True`` contradicts.
         """
+        self._set_exit(reason, None)
         self._stop_event.set()
         thread = self._thread
         joined = True
         if thread is not None:
             thread.join(timeout=timeout)
             joined = not thread.is_alive()
-        with self._lock:
-            # The loop itself may have set an exit_reason (budget expiry
-            # racing the caller's stop); if not, the caller wins.
-            if self._exit_reason is None:
-                self._exit_reason = reason
         return joined
 
     def snapshot(self) -> dict[str, Any]:

--- a/strands_robots/drivers/go2.py
+++ b/strands_robots/drivers/go2.py
@@ -1434,10 +1434,20 @@ class _ControlLoop:
         The signal wins over policy work: the loop re-reads the event at the top
         of every step and again after the policy returns, before publishing.
 
+        ``reason`` is recorded *before* the signal. The loop's ``finally`` stashes
+        its terminal snapshot on the driver while this call is still inside
+        ``join()``, so a reason written after the join reaches ``_exit_reason``
+        but never the stashed copy :meth:`Go2Driver.get_task_status` reads once
+        the loop has cleared itself - which reported a finished rollout with no
+        exit reason at all, and collapsed this driver's three caller words
+        (``stop_task``, the agent ``stop`` verb, ``cleanup``) into one absence.
+        Recording first costs nothing: :meth:`_ControlLoop._set_exit` is first-writer-wins, so
+        a loop that already ended on its own budget keeps that reason.
+
         Args:
             reason: Recorded as the exit reason unless the loop already set one -
-                a budget expiring concurrently with a caller's stop keeps its own,
-                more specific reason.
+                a budget that expired before this call keeps its own, more
+                specific reason.
             timeout: Seconds to wait for the join.
 
         Returns:
@@ -1445,15 +1455,13 @@ class _ControlLoop:
             is still running, which a caller must report honestly rather than
             claiming a stop that has not happened.
         """
+        self._set_exit(reason)
         self._stop_event.set()
         thread = self._thread
         joined = True
         if thread is not None:
             thread.join(timeout=timeout)
             joined = not thread.is_alive()
-        with self._lock:
-            if self._exit_reason is None:
-                self._exit_reason = reason
         return joined
 
     def snapshot(self) -> dict[str, Any]:

--- a/tests/drivers/test_go2_driver.py
+++ b/tests/drivers/test_go2_driver.py
@@ -151,9 +151,8 @@ class _RecordingMotionSwitcher:
         self.release_calls += 1
 
 
-@pytest.fixture
-def stub_unitree_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Install a ``unitree_sdk2py`` stub for the duration of one test.
+def install_unitree_sdk_stub(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Register a ``unitree_sdk2py`` stub on :mod:`sys.modules`.
 
     The Go2 driver imports ``unitree_sdk2py.idl.default``,
     ``unitree_sdk2py.utils.crc`` and ``unitree_sdk2py.idl.unitree_go.msg.dds_``
@@ -161,6 +160,12 @@ def stub_unitree_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
     production lane hardware drives, on a box with no SDK.
     ``monkeypatch.setitem`` restores the previous entries - normally absent - on
     teardown.
+
+    A plain function rather than only a fixture, so a sibling suite grading the
+    same driver installs the same stub instead of keeping a second copy of it.
+
+    Args:
+        monkeypatch: The requesting test's patcher, which owns the teardown.
     """
     names = {
         "unitree_sdk2py": types.ModuleType("unitree_sdk2py"),
@@ -177,6 +182,12 @@ def stub_unitree_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
     names["unitree_sdk2py.utils.crc"].CRC = _StubCRC  # type: ignore[attr-defined]
     for name, module in names.items():
         monkeypatch.setitem(sys.modules, name, module)
+
+
+@pytest.fixture
+def stub_unitree_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The SDK stub, installed for the duration of one test."""
+    install_unitree_sdk_stub(monkeypatch)
 
 
 def _released_driver() -> tuple[Go2Driver, _RecordingPublisher]:

--- a/tests/drivers/test_rollout_exit_reason_reaches_a_late_poller.py
+++ b/tests/drivers/test_rollout_exit_reason_reaches_a_late_poller.py
@@ -1,0 +1,287 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""A finished rollout names what ended it, to a poller that arrives late.
+
+Three native drivers roll a policy on their own thread and answer
+``get_task_status`` from a snapshot: the UR, the G1 and the Go2. The loop clears
+the driver's handle on its way out and stashes its terminal snapshot, so *that
+stash* is the only thing a poller arriving after the thread is gone can read -
+and ``exit_reason`` in it is the whole answer to "why did my robot stop moving".
+
+The Go2's own ``_run`` docstring lists ``n_steps``, ``duration``, ``gate``,
+``policy``, ``publish`` and the caller's ``stop_task`` / ``stop`` / ``cleanup``
+as the terminal reasons, and promises the stash carries whichever fired. The
+caller's three did not: :meth:`_ControlLoop.stop` recorded its reason *after*
+``join()`` returned, and the loop's ``finally`` stashes while that ``join()`` is
+still blocked - so the stash predated the reason and a caller-stopped rollout
+reported ``exit_reason=None``, collapsing the three caller words into one
+absence. The UR is the reference for the fix: its loop names the reason on the
+stop path itself (``self._finish("stopped")``), before it can be read.
+
+So this suite grades the reason at the *late* poll, once per way a rollout can
+end, on both drivers that stash. No robot, no DDS bus, no ``unitree_sdk2py``:
+the SDK stub and the recording publisher are the ones the neighbouring driver
+suites already install.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from typing import Any
+
+import pytest
+
+from strands_robots.drivers.g1 import G1Driver
+from strands_robots.drivers.go2 import Go2Driver, _ControlLoop
+from tests.drivers.test_g1_control_loop_terminal_observability import (
+    _fake_driver as _fake_g1_driver,
+)
+from tests.drivers.test_g1_control_loop_terminal_observability import (
+    _install_sdk_stub as _install_g1_sdk_stub,
+)
+from tests.drivers.test_go2_driver import (
+    _RecordingPublisher,
+    _released_driver,
+    install_unitree_sdk_stub,
+)
+
+#: Longer than any cell here needs, so a hung loop fails loudly instead of
+#: hanging the suite.
+_JOIN_S = 5.0
+
+
+@pytest.fixture
+def stub_unitree_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The Go2 SDK stub the neighbouring driver suite installs."""
+    install_unitree_sdk_stub(monkeypatch)
+
+
+def _await_loop_exit(driver: Go2Driver | G1Driver) -> None:
+    """Block until the loop has cleared itself off ``driver``.
+
+    That clearing is what makes the poll a *late* one: with ``_loop`` gone,
+    ``get_task_status`` can only answer from the stash.
+
+    Args:
+        driver: The driver whose rollout is expected to end.
+
+    Raises:
+        AssertionError: The loop was still installed after :data:`_JOIN_S`.
+    """
+    deadline = time.monotonic() + _JOIN_S
+    while time.monotonic() < deadline:
+        with driver._task_admission:
+            if driver._loop is None:
+                return
+        time.sleep(0.005)
+    raise AssertionError(f"the control loop still holds {driver._tool_name} after {_JOIN_S}s")
+
+
+def _late_poll(driver: Go2Driver | G1Driver) -> dict[str, Any]:
+    """The payload a caller sees once the rollout's thread is gone."""
+    _await_loop_exit(driver)
+    payload = driver.get_task_status()["content"][0]["json"]
+    assert payload["running"] is False, payload
+    return dict(payload)
+
+
+def _hold(_state: dict[str, Any]) -> dict[str, float]:
+    """A policy that commands one leg joint forever."""
+    return {"FL_thigh_joint": 0.0}
+
+
+# --------------------------------------------------------------------------- #
+# The Go2: one row per way a rollout can end.                                 #
+# --------------------------------------------------------------------------- #
+
+
+def _end_on_n_steps(driver: Go2Driver, _pub: _RecordingPublisher) -> None:
+    driver.run_policy(_hold, n_steps=2, duration=_JOIN_S)
+
+
+def _end_on_duration(driver: Go2Driver, _pub: _RecordingPublisher) -> None:
+    driver.run_policy(_hold, duration=0.02)
+
+
+def _end_on_gate(driver: Go2Driver, _pub: _RecordingPublisher) -> None:
+    def revoke_the_release(state: dict[str, Any]) -> dict[str, float]:
+        # The real gate, not a mock: the onboard controller taking the legs back
+        # is what the per-step re-check exists to catch.
+        driver._sport_mode_released = False
+        return _hold(state)
+
+    driver.run_policy(revoke_the_release, duration=_JOIN_S)
+
+
+def _end_on_policy_raising(driver: Go2Driver, _pub: _RecordingPublisher) -> None:
+    def raises(_state: dict[str, Any]) -> dict[str, float]:
+        raise ValueError("inference failed")
+
+    driver.run_policy(raises, duration=_JOIN_S)
+
+
+def _end_on_unusable_action(driver: Go2Driver, _pub: _RecordingPublisher) -> None:
+    driver.run_policy(lambda _state: {"no_such_joint": 0.0}, duration=_JOIN_S)
+
+
+def _end_on_publish(driver: Go2Driver, pub: _RecordingPublisher) -> None:
+    pub.publish_should_return = "no writer matched on rt/lowcmd"
+    driver.run_policy(_hold, duration=_JOIN_S)
+
+
+def _end_on_stop_task(driver: Go2Driver, _pub: _RecordingPublisher) -> None:
+    driver.run_policy(_hold, duration=_JOIN_S)
+    time.sleep(0.02)
+    assert driver.stop_task()["status"] == "success"
+
+
+def _end_on_the_stop_verb(driver: Go2Driver, _pub: _RecordingPublisher) -> None:
+    driver.run_policy(_hold, duration=_JOIN_S)
+    time.sleep(0.02)
+    asyncio.run(driver.stop())
+
+
+def _end_on_cleanup(driver: Go2Driver, _pub: _RecordingPublisher) -> None:
+    driver.run_policy(_hold, duration=_JOIN_S)
+    time.sleep(0.02)
+    driver.cleanup()
+
+
+@pytest.mark.parametrize(
+    ("arrange", "exit_reason"),
+    [
+        (_end_on_n_steps, "n_steps"),
+        (_end_on_duration, "duration"),
+        (_end_on_gate, "gate"),
+        (_end_on_policy_raising, "policy"),
+        (_end_on_unusable_action, "policy"),
+        (_end_on_publish, "publish"),
+        (_end_on_stop_task, "stop_task"),
+        (_end_on_the_stop_verb, "stop"),
+        (_end_on_cleanup, "cleanup"),
+    ],
+    ids=[
+        "n_steps",
+        "duration",
+        "gate",
+        "policy_raised",
+        "unusable_action",
+        "publish",
+        "stop_task",
+        "stop_verb",
+        "cleanup",
+    ],
+)
+def test_the_go2_stash_names_whichever_reason_ended_the_rollout(
+    stub_unitree_sdk: None,
+    arrange: Any,
+    exit_reason: str,
+) -> None:
+    """Every terminal reason the loop documents round-trips to a late poller.
+
+    One table because it is one behaviour, and the three caller rows are the
+    ones that reported nothing: ``stop_task``, the mesh's ``stop`` verb and
+    ``cleanup`` each write a distinct word, and a caller who cannot read it
+    cannot tell an operator's halt from a teardown from a battery gate.
+    """
+    del stub_unitree_sdk
+    driver, pub = _released_driver()
+    arrange(driver, pub)
+
+    payload = _late_poll(driver)
+    assert payload["exit_reason"] == exit_reason, payload
+    # A stash that carries a reason must not also carry the "nothing ran" note.
+    assert "reason" not in payload, payload
+
+
+def test_the_go2_stash_carries_the_gate_refusal_text(stub_unitree_sdk: None) -> None:
+    """``exit_detail`` says which gate refused, so the reason is actionable.
+
+    ``exit_reason="gate"`` alone cannot distinguish the sport-mode release from
+    the battery floor - the two gates the driver checks per step - and naming
+    them is the whole point of refusing separately.
+    """
+    del stub_unitree_sdk
+    driver, _pub = _released_driver()
+
+    def drain_the_battery(state: dict[str, Any]) -> dict[str, float]:
+        driver._battery = {"pct": 1.0}
+        return _hold(state)
+
+    driver.run_policy(drain_the_battery, duration=_JOIN_S)
+
+    payload = _late_poll(driver)
+    assert payload["exit_reason"] == "gate"
+    assert "battery 1.0%" in str(payload["exit_detail"])
+
+
+def test_a_refusal_with_no_text_block_still_names_the_gate(stub_unitree_sdk: None) -> None:
+    """A gate refusing without prose degrades to ``"refused"``, not to a crash.
+
+    The refusal envelope is read for logging, so a driver whose gate answers
+    with a json-only block must still exit ``gate`` rather than raising inside
+    the loop's own error path.
+    """
+    del stub_unitree_sdk
+    driver, _pub = _released_driver()
+    driver._check_motion_gates = lambda scope: (  # type: ignore[method-assign]
+        None if scope == "run_policy" else {"status": "error", "content": [{"json": {"gate": scope}}]}
+    )
+
+    driver.run_policy(_hold, duration=_JOIN_S)
+
+    payload = _late_poll(driver)
+    assert payload["exit_reason"] == "gate"
+    assert payload["exit_detail"] == "refused"
+
+
+def test_a_budget_that_already_expired_outranks_the_callers_word() -> None:
+    """A loop that ended itself keeps its own, more specific reason.
+
+    Recording the caller's reason before signalling must not overwrite one the
+    loop already reached - a rollout that ran its steps out and is then stopped
+    by a shutdown is still a rollout that ran its steps out.
+    """
+    loop = _ControlLoop(driver=None, policy=_hold, duration=1.0, n_steps=1)  # type: ignore[arg-type]
+    loop._set_exit("n_steps")
+
+    assert loop.stop("cleanup") is True, "an unstarted loop has no thread to wait for"
+    assert loop.snapshot()["exit_reason"] == "n_steps"
+
+
+def test_a_single_use_loop_refuses_a_second_start() -> None:
+    """Restarting a loop would silently reuse the previous rollout's counters."""
+    loop = _ControlLoop(driver=None, policy=_hold, duration=1.0, n_steps=1)  # type: ignore[arg-type]
+    assert loop.snapshot()["elapsed_s"] is None, "a loop that never started has run for no time"
+
+    loop._thread = threading.Thread(target=lambda: None)  # stands in for a spawned loop
+    with pytest.raises(RuntimeError, match="called twice"):
+        loop.start()
+
+
+# --------------------------------------------------------------------------- #
+# The G1 runs the same loop shape, so it had the same silence.                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_the_g1_stash_names_the_callers_stop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stopped G1 rollout reports ``stop_task`` to a late poller too.
+
+    The G1's ``stop_task`` return already named it; the stash a later
+    ``get_task_status`` reads did not, so the same rollout answered two
+    different things depending on when it was asked.
+    """
+    _install_g1_sdk_stub(monkeypatch)
+    driver = _fake_g1_driver(monkeypatch)
+
+    assert (
+        driver.run_policy(policy_object=lambda _obs: {"left_shoulder_pitch": 0.0}, duration=_JOIN_S)["status"]
+        == "success"
+    )
+    time.sleep(0.02)
+    stopped = driver.stop_task()
+    assert stopped["content"][0]["json"]["exit_reason"] == "stop_task"
+
+    assert _late_poll(driver)["exit_reason"] == "stop_task"


### PR DESCRIPTION
## The defect

`get_task_status()` answers a poller that arrives after the rollout's thread is gone from a snapshot the loop stashes on the driver as it clears itself. `_ControlLoop.stop()` wrote its reason **after** `join()` returned - and the loop's `finally` stashes while that `join()` is still blocked. So the stash predated the reason, and a rollout ended by a caller reported no reason at all.

```mermaid
sequenceDiagram
    autonumber
    participant C as caller thread
    participant L as loop thread
    rect rgb(255, 236, 236)
    Note over C,L: before
    C->>L: _stop_event.set()
    C->>C: join() blocks
    L->>L: break out of the 500 Hz loop
    L->>L: finally: zero-torque frame
    L->>C: stash snapshot(exit_reason=None), clear _loop
    C->>C: join() returns
    C->>C: _exit_reason = "cleanup"  (nothing reads it again)
    end
    rect rgb(236, 250, 236)
    Note over C,L: after
    C->>C: _set_exit("cleanup")
    C->>L: _stop_event.set()
    C->>C: join() blocks
    L->>L: break out of the 500 Hz loop
    L->>L: finally: zero-torque frame
    L->>C: stash snapshot(exit_reason="cleanup"), clear _loop
    end
```

Measured on both drivers, SDK stubbed, one rollout stopped by the caller:

| driver | `stop_task()` return says | late `get_task_status()` said | now says |
|---|---|---|---|
| `Go2Driver` | `stop_task` | **`None`** | `stop_task` |
| `G1Driver` | `stop_task` | **`None`** | `stop_task` |

The same rollout answered two different things depending on when it was asked, and the Go2 lost the most: it is the driver that distinguishes *which* caller stopped it. `stop_task()`, the mesh's `stop` verb and `cleanup()` each pass their own word into the same loop, and all three collapsed into the same absence - so a halted rollout, a shutdown and a teardown were indistinguishable after the fact, on the one surface an operator has for "why did my robot stop moving".

The G1's own loop asserts the opposite in a comment - *"the loop reports the exit as `stop_task` since the caller's `stop()` already set the reason"* - which was not true of anything a later poll could read.

## The change

The reason is recorded before the stop is signalled. That is what the third driver with a threaded rollout already does: the UR's loop names it on the stop path itself (`self._finish("stopped")`), before the exit can be read.

Precedence is unchanged, because the record is first-writer-wins: a loop that already ended on its own budget keeps that more specific reason. Executable delta is **-6/+2 lines** (one `_set_exit` call replacing a three-line locked write, per driver).

## Evidence

`tests/drivers/test_rollout_exit_reason_reaches_a_late_poller.py` grades the reason at the *late* poll - once per way a rollout can end - on both drivers that stash. Table-driven, no robot, no DDS bus, no `unitree_sdk2py`: it reuses the SDK stub and recording publisher the neighbouring driver suites already install (the Go2 fixture was extracted to a plain function so the stub is installed, not copied).

| | pristine `main` | this branch |
|---|---|---|
| new suite | **4 failed** / 10 passed | 14 passed |

The four are exactly the caller words: Go2 `stop_task` / `stop` / `cleanup`, and the G1's `stop_task`.

Each mutation below fires a distinct set of cells, so no cell is decoration:

| mutation | result |
|---|---|
| reason recorded after the join (the pre-fix order) | 3 failed |
| caller's word overwrites a reason the loop already reached | 1 failed |
| no per-step re-gate | 3 failed (and the rollouts run 15.8s to their budget instead of exiting) |
| refusal text not read out of the envelope | 1 failed |

The table also closes the gap that let this land: every terminal reason the loop documents was unpinned except `n_steps` and an unusable action.

| `strands_robots/drivers/` | before | after |
|---|---|---|
| `go2.py` | 85% (86 uncovered) | **88%** (67 uncovered) |
| `g1.py` | 94% (35 uncovered) | 94% (34 uncovered) |

## Gate

`ruff check` + `ruff format --check` clean (1985 files) - `mypy` clean - `MUJOCO_GL=egl pytest tests/` **52121 passed, 299 skipped, 0 failed** (29m15s) - `tests/drivers/` 2532 passed.

Docs: `docs/robots/mobile.md` gains the `exit_reason` table a caller needs to read the answer.
