### PR TITLE
fix(mesh): every simulation backend reports the rollouts it is driving

### DIFF
--- a/changelog.d/3375-rollouts-in-flight-on-every-backend.md
+++ b/changelog.d/3375-rollouts-in-flight-on-every-backend.md
@@ -1,0 +1,51 @@
+### Fixed: every simulation backend reports the rollouts it is driving
+
+The mesh answers "is a rollout in flight" on two surfaces - the `status`
+command and the `robots` section of the state topic - and both probed for
+`_active_policy_robots`, a method only the MuJoCo engine defines. A Newton
+peer with a rollout genuinely in flight was invisible on both, while the
+stop verb on that same peer halted it:
+
+| peer | rollout | `status` | state topic | fleet `stop` |
+|---|---|---|---|---|
+| Newton | in flight | `{"status": "unknown"}` | `{"arm": {"active": false}}` | halts it |
+| Newton | idle | `{"status": "unknown"}` | `{"arm": {"active": false}}` | nothing to halt |
+| Isaac | in flight | `{"status": "unknown"}` | no section | refuses |
+| MuJoCo | in flight | `running`, `["arm"]` | `{"active": true}` | halts it |
+
+The two Newton rows were identical, so a caller could not tell a live
+rollout from an idle world. The state topic's row is the worse of the two:
+`active=false` is an affirmative "this robot is idle", published on no
+evidence, about a robot the peer was in fact driving.
+
+Both backends keep the per-robot `policy_running` claim already, and Isaac
+already trusts it as a population for `run_multi_policy`'s busy guard - what
+was missing was a shared way to ask. `SimEngine._rollouts_in_flight` is that
+seam, tri-state in the direction `_request_policy_stop` already is: the
+names when the backend can enumerate its rollouts, and `None` when it keeps
+no such claim, which is a stated absence of a verdict rather than an empty
+population. Reporting a rollout is a strictly weaker requirement than
+halting one, which is why Isaac answers it while `stop_policy` still refuses
+there: a bare flag is not a durable claim to move (#2833), but it is a true
+answer to what is running.
+
+Newton and Isaac override it off the claim they maintain; MuJoCo delegates to
+`_active_policy_robots` so the union of the Future table and the per-robot
+flag stays spelled once. Both mesh surfaces now read one call, so a child
+`SimRobot` peer's `status` answers for the world exactly as its state topic
+already did. A peer reporting no population has its robots named with **no
+`active` key** and answers `status="unknown"`: absence is how every other
+section of that snapshot spells "the probe had nothing", where `false` was
+indistinguishable from a rollout the peer cannot see.
+
+The fleet stop's population is deliberately NOT this population. It asks
+every robot in the world for a backend keeping no pruned rollout registry -
+`stop_policy` is idempotent and reports `was_running` itself, and a blocking
+`run_policy` registers no future - so narrowing it to the in-flight set is a
+decision about a safety path (#3359), not part of reporting. Two cases pin
+that it did not move.
+
+`tests/mesh/test_every_sim_backend_reports_its_rollouts_in_flight.py` pins
+both phases on both backends, the tri-state's three answers, the two
+surfaces agreeing from one call, and the unchanged stop population; 11 of
+its 15 cases fail on the previous code.

--- a/docs/mesh.md
+++ b/docs/mesh.md
@@ -235,20 +235,25 @@ each with an `active` flag:
 ```
 
 `active` means *this robot is executing a policy right now*. It is read from the
-same in-flight population the `status` command answers `robots_running` from,
-so polling the topic and asking a peer directly never disagree. A rollout counts
-however it was launched: one submitted in the background by `start_policy` and one
-being driven right now by the blocking `run_policy`, which registers no future,
-both read `true`. The scene's idle
-arms read `false`, which is what makes the one arm running a rollout
-identifiable, and the flag clears when that policy is stopped or its duration
-expires. Which robots *exist* is a separate question, answered by `sim_robots` on
-the presence topic.
+same in-flight population the `status` command answers `robots_running` from -
+one call, `_rollouts_in_flight`, which every simulation backend answers from the
+per-robot rollout claim it already keeps - so polling the topic and asking a peer
+directly never disagree, on any backend. A rollout counts however it was
+launched: one submitted in the background by `start_policy` and one being driven
+right now by the blocking `run_policy`, which registers no future, both read
+`true`. The scene's idle arms read `false`, which is what makes the one arm
+running a rollout identifiable, and the flag clears when that policy is stopped
+or its duration expires. Which robots *exist* is a separate question, answered by
+`sim_robots` on the presence topic.
 
-A peer that keeps no such registry reports every robot `false` - nothing runs a
-policy on them through the simulation API. A registry that cannot be read is a
-failing probe, so it is named under `sim_world` in `degraded` rather than
-answered with a flag nobody measured.
+A peer that reports no in-flight population at all - a backend keeping no rollout
+claim, or one whose world has been torn down - still has its robots named, with
+**no `active` key beside them**, and the `status` command answers `unknown`. An
+absent flag reads as "not reported"; `false` would be an affirmative "this robot
+is idle" published on no evidence, which is indistinguishable from a rollout the
+peer cannot see. A population that cannot be read is a failing probe, so it is
+named under `sim_world` in `degraded` rather than answered with a flag nobody
+measured.
 
 ### Pose orientation
 

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -1495,7 +1495,16 @@ class Mesh(SensorLoopsMixin):
                 world_robots = getattr(world, "robots", None)
                 if isinstance(world_robots, dict):
                     running = self._running_policy_robots()
-                    snapshot["robots"] = {name: {"active": name in running} for name in world_robots}
+                    # A backend that reports no in-flight population gets its
+                    # robots named with no ``active`` flag at all. An absent
+                    # flag reads as "not reported", which is what absence means
+                    # in every other section of this snapshot; ``false`` would
+                    # be an affirmative "this robot is idle" published on no
+                    # evidence, and a peer whose rollouts are invisible is
+                    # exactly where that lie lands.
+                    snapshot["robots"] = {
+                        name: ({"active": name in running} if running is not None else {}) for name in world_robots
+                    }
                 # Per-robot joint extraction for SimRobot children on the mesh.
                 # SimRobot has joint_names + namespace; read qpos/qvel from world.
                 joint_names = getattr(r, "joint_names", None)
@@ -1534,14 +1543,23 @@ class Mesh(SensorLoopsMixin):
 
         return snapshot if len(snapshot) > 2 else None
 
-    def _running_policy_robots(self) -> frozenset[str]:
+    def _running_policy_robots(self) -> frozenset[str] | None:
         """Names of this world's robots currently executing a policy.
 
-        The running-policy registry is the same source the ``status`` command
-        reads in :meth:`_dispatch`, so the state topic and an on-demand status
-        answer agree about which rollout is live. A ``SimRobot`` child peer
-        keeps no registry of its own and consults the parent ``Simulation``
-        through the ``_sim_parent`` backref that peer wiring installs.
+        The one population both reporting surfaces read - this method IS what
+        the ``status`` command answers ``robots_running`` from in
+        :meth:`_dispatch` - so the state topic and an on-demand status answer
+        cannot disagree about which rollout is live. It is asked of the backend
+        through
+        :meth:`~strands_robots.simulation.base.SimEngine._rollouts_in_flight`,
+        the seam every backend answers from the rollout claim it already keeps,
+        rather than of one engine's own registry method: probing for the MuJoCo
+        spelling left a Newton peer with a rollout genuinely in flight reporting
+        ``{"status": "unknown"}`` and ``active=false`` on every robot.
+
+        A ``SimRobot`` child peer keeps no registry of its own and consults the
+        parent ``Simulation`` through the ``_sim_parent`` backref that peer
+        wiring installs.
 
         A registry that raises is left to reach :meth:`_read_state`'s section
         handler, which names ``sim_world`` in ``degraded``. That is the
@@ -1550,15 +1568,20 @@ class Mesh(SensorLoopsMixin):
         substituting a flag here is what would make the fault unreportable.
 
         Returns:
-            The names, empty when no peer in this chain keeps such a registry.
-            Nothing then runs a policy on those robots through the simulation
-            API, so none of them is executing one.
+            The names; an empty set when a peer in this chain reports the
+            population and nothing is in flight; and ``None`` when no peer
+            reports one at all. ``None`` is a stated absence of a verdict, not
+            an idle world - the tri-state of the seam it reads, kept because
+            "no robot is running a policy" is an affirmative claim and a peer
+            that cannot enumerate its rollouts has no evidence for it.
         """
         for holder in (self.robot, getattr(self.robot, "_sim_parent", None)):
-            probe = getattr(holder, "_active_policy_robots", None)
+            probe = getattr(holder, "_rollouts_in_flight", None)
             if callable(probe):
-                return frozenset(probe())
-        return frozenset()
+                names = probe()
+                if names is not None:
+                    return frozenset(names)
+        return None
 
     # Cameras - outgoing (opt-in)
     def _resolve_camera_hz(self) -> float:
@@ -2173,19 +2196,23 @@ class Mesh(SensorLoopsMixin):
         if action == "status":
             if hasattr(r, "get_task_status"):
                 return dict(r.get_task_status())
-            # Sim peer: synthesize a structured status from the running-
-            # policy registry so a rollout is wire-visible. Previously sims
+            # Sim peer: synthesize a structured status from the in-flight
+            # population so a rollout is wire-visible. Previously sims
             # answered {"status": "unknown"} and their state topic hardcoded
             # active=True - a running sim policy was invisible on the wire.
-            if hasattr(r, "_active_policy_robots"):
-                try:
-                    active = list(r._active_policy_robots())
-                    return {
-                        "status": "running" if active else "idle",
-                        "robots_running": active,
-                    }
-                except Exception:  # noqa: BLE001 - status must not raise
-                    pass
+            # Read through :meth:`_running_policy_robots`, the state topic's
+            # own reader, so the two surfaces answer from one call; a second
+            # probe here is how they came to disagree for a child peer, and
+            # how a backend the state topic can read stayed "unknown".
+            try:
+                running = self._running_policy_robots()
+            except Exception:  # noqa: BLE001 - status must not raise
+                running = None
+            if running is not None:
+                return {
+                    "status": "running" if running else "idle",
+                    "robots_running": sorted(running),
+                }
             ts = getattr(r, "_task_state", None)
             return {"status": getattr(getattr(ts, "status", None), "value", "unknown")}
         if action == "stop":

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -4115,6 +4115,35 @@ class SimEngine(ABC):
         """
         return None
 
+    def _rollouts_in_flight(self) -> tuple[str, ...] | None:
+        """Names of this world's robots a rollout is driving right now.
+
+        The reporting counterpart of :meth:`_request_policy_stop`, and the one
+        population every remote reader of "is a rollout in flight" asks for:
+        :meth:`~strands_robots.mesh.Mesh._dispatch`'s ``status`` command and the
+        ``robots`` section of its state topic. Reporting a rollout is a strictly
+        weaker requirement than halting one - a backend whose per-robot record
+        carries a bare flag cannot keep a stop it promises (#2833), but that flag
+        is a perfectly good answer to what is running - so a backend may well
+        answer here and still refuse :meth:`stop_policy`.
+
+        Tri-state, for the reason ``_request_policy_stop`` is: ``None`` is a
+        stated absence of a verdict and not an empty population. A backend
+        keeping no rollout claim that answered ``()`` would have every reader
+        publish "nothing is running" on no evidence, which is the affirmative
+        lie :meth:`stop_policy` and
+        :func:`~strands_robots.mesh.core._reported_a_rollout_in_flight` are both
+        written against - and the state topic renders an empty population as
+        ``active=false`` on every robot in the world.
+
+        Returns:
+            The names, in any order, when this backend can enumerate the
+            rollouts it is driving; ``()`` when it can and none is; ``None``
+            when it keeps no such claim, or when the world it would read is
+            gone. Default: ``None`` - the ABC itself owns no registry.
+        """
+        return None
+
     def replay_episode(
         self,
         repo_id: str,

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -4126,6 +4126,29 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
             # coasting on stale targets while its siblings advance.
             raise RuntimeError(f"run_multi_policy: failed to set joint targets on '{robot_name}': {e}") from e
 
+    def _rollouts_in_flight(self) -> tuple[str, ...] | None:
+        """Isaac override: the robots holding the rollout claim right now.
+
+        The base seam
+        (:meth:`~strands_robots.simulation.base.SimEngine._rollouts_in_flight`)
+        answered from ``policy_running`` - the same per-robot flag every
+        policy-driving loop here sets and :meth:`run_multi_policy` already
+        trusts as a population for its busy guard - so the mesh ``status``
+        command reports a rollout on this backend instead of ``unknown``.
+
+        Reporting is a weaker requirement than halting, which is why this
+        engine answers here while :meth:`stop_policy` still refuses: a bare
+        flag is not a durable claim to move (#2833), but it is a true answer to
+        what is running.
+
+        Returns:
+            The names, or ``None`` before :meth:`create_world` - there is then
+            no world whose rollouts could be enumerated.
+        """
+        if not self._world_created:
+            return None
+        return tuple(name for name, robot in tuple(self._robots.items()) if robot.policy_running)
+
     def run_multi_policy(
         self,
         policies: dict[str, Policy],

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -5133,6 +5133,22 @@ class MuJoCoSimEngine(
         )
         return names
 
+    def _rollouts_in_flight(self) -> tuple[str, ...]:
+        """MuJoCo override: the population :meth:`_active_policy_robots` owns.
+
+        The base seam every remote reader asks
+        (:meth:`~strands_robots.simulation.base.SimEngine._rollouts_in_flight`),
+        answered by delegation rather than by a second walk of the registry:
+        the union of the Future table and the per-robot claim is spelled once,
+        in :meth:`_active_policy_robots`, and the two-sources drift that method
+        documents is exactly what a re-derivation here would reintroduce.
+
+        Returns:
+            The names, never ``None``: this engine always holds the registry, so
+            an empty result really does mean nothing is in flight.
+        """
+        return tuple(self._active_policy_robots())
+
     def _active_rollout_rates(self) -> dict[str, float]:
         """Capture rate of every ``start_policy`` rollout still in flight.
 

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -2562,6 +2562,25 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
             return None
         return world.robots[robot_name].request_policy_stop()
 
+    def _rollouts_in_flight(self) -> tuple[str, ...] | None:
+        """Newton override: the robots holding the rollout claim right now.
+
+        The reporting half of the same per-robot flag
+        :meth:`_request_policy_stop` moves and
+        :meth:`~strands_robots.simulation.newton.recording.NewtonRecordingMixin._make_run_policy_hook`
+        raises, so the mesh ``status`` command and its state topic answer for a
+        Newton rollout instead of reporting ``unknown`` and ``active=false``
+        while one is in flight.
+
+        Returns:
+            The names, or ``None`` when the world is gone - there is then no
+            registry to read, and no verdict to give.
+        """
+        world = self._world
+        if world is None:
+            return None
+        return tuple(name for name, robot in tuple(world.robots.items()) if getattr(robot, "policy_running", False))
+
     def cleanup(self, policy_stop_timeout: float | None = None) -> None:
         """Release resources (alias for :meth:`destroy`)."""
         self.destroy()

--- a/tests/mesh/test_every_sim_backend_reports_its_rollouts_in_flight.py
+++ b/tests/mesh/test_every_sim_backend_reports_its_rollouts_in_flight.py
@@ -1,0 +1,181 @@
+"""A sim peer's rollout is reported on every backend, through one seam.
+
+The mesh has two surfaces that answer "is a rollout in flight": the ``status``
+command and the ``robots`` section of the state topic. Both probed for
+``_active_policy_robots``, a method only the MuJoCo engine defines, so a Newton
+peer driving a rollout was invisible on both while the stop verb on that same
+peer halted it:
+
+===============  ==========  ============================  ============  ===============
+peer             rollout     ``status``                    state topic   ``stop``
+===============  ==========  ============================  ============  ===============
+Newton           in flight   ``{"status": "unknown"}``      no flag       halts it
+Newton           idle        ``{"status": "unknown"}``      no flag       nothing to halt
+MuJoCo           in flight   ``running``, ``["arm"]``        ``true``      halts it
+MuJoCo           idle        ``idle``, ``[]``                ``false``     nothing to halt
+===============  ==========  ============================  ============  ===============
+
+The two Newton rows were identical, so a caller could not tell a live rollout
+from an idle world, and the state topic published ``active=false`` on every
+robot - an affirmative "nothing is running" given on no evidence.
+
+Both backends keep the per-robot ``policy_running`` claim already, and Isaac
+already trusts it as a population for its own busy guard; what was missing was a
+shared way to ask. These cases hold every backend to
+:meth:`~strands_robots.simulation.base.SimEngine._rollouts_in_flight`, the
+tri-state seam whose ``None`` means "this backend reports no population" rather
+than "no robot is running", and hold the two mesh surfaces to reading it once.
+
+Pinned at the bottom: the fleet stop's population is NOT this population. It
+asks every robot in the world for a backend keeping no pruned rollout registry,
+which is how a Newton rollout is halted today, and narrowing it to the in-flight
+set is a decision about a safety path (#3359) rather than part of reporting.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from strands_robots.mesh import core as mesh_core
+from strands_robots.simulation.base import SimEngine
+from strands_robots.simulation.models import SimRobot, SimWorld
+
+_JOINTS = ("j1", "j2")
+_ARM = "arm"
+
+
+def _newton(policy_running: bool) -> Any:
+    """A Newton engine skeleton whose one robot carries the rollout claim.
+
+    ``__new__`` plus the attributes the reporting path reads - the fixture shape
+    this backend's own recording and stop tests use, so neither Warp nor a
+    compiled model is needed to grade a flag read.
+    """
+    from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+    world = SimWorld()
+    robot = SimRobot(name=_ARM, urdf_path="arm.xml", data_config="so100", joint_names=list(_JOINTS))
+    robot.policy_running = policy_running
+    world.robots[_ARM] = robot
+    engine = NewtonSimEngine.__new__(NewtonSimEngine)
+    engine._world = world
+    engine._model = object()
+    return engine
+
+
+def _isaac(policy_running: bool) -> Any:
+    """An Isaac engine skeleton whose one robot carries the rollout claim."""
+    from strands_robots.simulation.isaac.simulation import IsaacSimulation, _RobotState
+
+    engine = IsaacSimulation.__new__(IsaacSimulation)
+    engine._world_created = True
+    engine._world = object()
+    state = _RobotState(name=_ARM, prim_path=f"/World/{_ARM}", joint_names=list(_JOINTS))
+    state.policy_running = policy_running
+    engine._robots = {_ARM: state}
+    return engine
+
+
+_BACKENDS = {"newton": _newton, "isaac": _isaac}
+
+
+def _status(engine: Any) -> dict[str, Any]:
+    """What the ``status`` command answers for a peer holding ``engine``."""
+    mesh = mesh_core.Mesh(engine, peer_id="sim-1", peer_type="simulation")
+    return mesh._dispatch({"action": "status"})
+
+
+def _robots_section(engine: Any) -> dict[str, Any]:
+    """The state topic's ``robots`` section for a peer holding ``engine``."""
+    snapshot = mesh_core.Mesh(engine, peer_id="sim-2", peer_type="simulation")._read_state()
+    assert snapshot is not None, "the peer published nothing on the state topic"
+    section = snapshot.get("robots")
+    assert isinstance(section, dict), f"no robots section in the snapshot: {sorted(snapshot)}"
+    return section
+
+
+class TestEveryBackendReportsTheRolloutItIsDriving:
+    """The regression: a rollout in flight is distinguishable from an idle world."""
+
+    @pytest.mark.parametrize("backend", sorted(_BACKENDS))
+    def test_a_rollout_in_flight_is_reported_running_and_named(self, backend: str) -> None:
+        answer = _status(_BACKENDS[backend](True))
+        assert answer["status"] == "running"
+        assert answer["robots_running"] == [_ARM]
+
+    @pytest.mark.parametrize("backend", sorted(_BACKENDS))
+    def test_an_idle_world_is_reported_idle_rather_than_unknown(self, backend: str) -> None:
+        """The other half: "running" for everything would pass the case above."""
+        answer = _status(_BACKENDS[backend](False))
+        assert answer["status"] == "idle"
+        assert answer["robots_running"] == []
+
+    @pytest.mark.parametrize("backend", sorted(_BACKENDS))
+    def test_the_backend_answers_the_seam_every_reader_asks(self, backend: str) -> None:
+        assert _BACKENDS[backend](True)._rollouts_in_flight() == (_ARM,)
+        assert _BACKENDS[backend](False)._rollouts_in_flight() == ()
+
+
+class TestTheStateTopicMeasuresTheFlagOnEveryBackend:
+    """``active`` beside each robot is read from the same population."""
+
+    def test_the_robot_running_a_policy_is_flagged_active(self) -> None:
+        assert _robots_section(_newton(True)) == {_ARM: {"active": True}}
+
+    def test_an_idle_robot_is_flagged_inactive_because_that_was_measured(self) -> None:
+        assert _robots_section(_newton(False)) == {_ARM: {"active": False}}
+
+    def test_the_two_surfaces_agree_because_they_read_one_call(self) -> None:
+        for running in (True, False):
+            flagged = {name for name, entry in _robots_section(_newton(running)).items() if entry["active"]}
+            assert flagged == set(_status(_newton(running))["robots_running"])
+
+
+class TestNoVerdictIsNotAnIdleWorld:
+    """``None`` from the seam is an absence of evidence, and stays one."""
+
+    def test_the_base_default_reports_no_population(self) -> None:
+        """Called unbound: the ABC cannot be instantiated, and reads no state."""
+        assert SimEngine._rollouts_in_flight(cast(SimEngine, SimpleNamespace())) is None
+
+    def test_a_torn_down_newton_world_has_no_population_rather_than_an_empty_one(self) -> None:
+        engine = _newton(True)
+        engine._world = None
+        assert engine._rollouts_in_flight() is None
+
+    def test_isaac_before_a_world_exists_has_no_population(self) -> None:
+        engine = _isaac(True)
+        engine._world_created = False
+        assert engine._rollouts_in_flight() is None
+
+    def test_a_peer_reporting_no_population_answers_unknown_not_idle(self) -> None:
+        """ "idle" here would be the same affirmative claim, from the other side."""
+        engine = _newton(True)
+        engine._world = None
+        assert _status(engine) == {"status": "unknown"}
+
+
+class TestTheFleetStopPopulationIsNotTheReportingPopulation:
+    """Reporting a rollout must not narrow which robots a stop asks (#3359)."""
+
+    @staticmethod
+    def _fleet_stop(engine: Any) -> dict[str, Any]:
+        mesh = mesh_core.Mesh(engine, peer_id="sim-3", peer_type="simulation")
+        return mesh._dispatch({"action": "stop"})
+
+    def test_a_rollout_in_flight_is_still_halted_and_named(self) -> None:
+        engine = _newton(True)
+        result = self._fleet_stop(engine)
+        assert result["ok"] is True
+        assert result["stopped"] == [_ARM]
+        assert engine._world.robots[_ARM].policy_running is False
+
+    def test_an_idle_robot_is_still_asked_even_though_it_reports_as_idle(self) -> None:
+        """A registry-only population would leave a blocking rollout untouched."""
+        result = self._fleet_stop(_newton(False))
+        assert result["ok"] is True
+        assert result["stopped"] == []
+        assert _ARM in result["results"]

--- a/tests/mesh/test_state_topic_reports_which_robot_runs_a_policy.py
+++ b/tests/mesh/test_state_topic_reports_which_robot_runs_a_policy.py
@@ -13,9 +13,9 @@ the set ``status`` reports running, in every phase of a real rollout, from a
 parent ``Simulation`` peer and from a ``SimRobot`` child peer alike.
 
 Also pinned, so the measurement cannot be traded for the old shortcut: a peer
-that keeps no policy registry still gets its ``robots`` section, and a registry
-that raises is named in ``degraded`` rather than answered with a fabricated
-flag.
+that reports no in-flight population still gets its ``robots`` section, with no
+flag beside the names rather than an invented one, and a population that cannot
+be read is named in ``degraded`` rather than answered with a fabricated flag.
 """
 
 from __future__ import annotations
@@ -40,6 +40,14 @@ def _active_names(snapshot: dict[str, Any] | None) -> set[str]:
     robots = snapshot.get("robots")
     assert isinstance(robots, dict), f"no robots section in the snapshot: {sorted(snapshot)}"
     return {name for name, entry in robots.items() if entry["active"]}
+
+
+def _unflagged_names(snapshot: dict[str, Any] | None) -> set[str]:
+    """The robots the snapshot names without saying whether one is running."""
+    assert snapshot is not None, "the peer published nothing on the state topic"
+    robots = snapshot.get("robots")
+    assert isinstance(robots, dict), f"no robots section in the snapshot: {sorted(snapshot)}"
+    return {name for name, entry in robots.items() if "active" not in entry}
 
 
 def _await(predicate: Any, what: str) -> None:
@@ -175,7 +183,7 @@ class _WorldStub:
 
 
 class _NoRegistryRobot:
-    """A peer holding a sim world but keeping no running-policy registry."""
+    """A peer holding a sim world but reporting no in-flight population."""
 
     tool_name_str = "worldbot"
 
@@ -184,20 +192,20 @@ class _NoRegistryRobot:
 
 
 class _DataAttributeRobot(_NoRegistryRobot):
-    """A peer carrying the registry's name as data rather than as a method."""
+    """A peer carrying the population's name as data rather than as a method."""
 
-    _active_policy_robots: list[str] = ["arm0"]
+    _rollouts_in_flight: tuple[str, ...] = ("arm0",)
 
 
 class _RaisingRegistryRobot(_NoRegistryRobot):
-    """A peer whose running-policy registry cannot be read."""
+    """A peer whose in-flight population cannot be read."""
 
-    def _active_policy_robots(self) -> list[str]:
+    def _rollouts_in_flight(self) -> tuple[str, ...]:
         raise RuntimeError("policy registry unreadable")
 
 
-class TestAPeerThatKeepsNoPolicyRegistry:
-    """Deriving the flag must not cost the section, nor invent a rollout."""
+class TestAPeerThatReportsNoPopulation:
+    """Deriving the flag must not cost the section, nor invent a verdict."""
 
     def test_its_robots_section_is_still_published(self) -> None:
         snapshot = mesh_core.Mesh(_NoRegistryRobot(), peer_id="no-registry")._read_state()
@@ -205,17 +213,24 @@ class TestAPeerThatKeepsNoPolicyRegistry:
         assert set(snapshot["robots"]) == {"arm0", "arm1"}
         assert snapshot["sim_time"] == 12.5
 
-    def test_none_of_its_robots_is_reported_active(self) -> None:
-        """No policy runs through the simulation API on such a peer."""
-        assert _active_names(mesh_core.Mesh(_NoRegistryRobot(), peer_id="no-reg2")._read_state()) == set()
+    def test_its_robots_carry_no_flag_rather_than_a_false_one(self) -> None:
+        """``active=false`` here is an affirmative "this robot is idle".
 
-    def test_the_registry_name_carried_as_data_is_not_a_registry(self) -> None:
+        Such a peer cannot enumerate its rollouts, so it has no evidence for
+        that claim: a robot it drives through some path this API cannot see
+        reads exactly the same. Absence is how every other section of the
+        snapshot spells "the probe had nothing to report".
+        """
+        snapshot = mesh_core.Mesh(_NoRegistryRobot(), peer_id="no-reg2")._read_state()
+        assert _unflagged_names(snapshot) == {"arm0", "arm1"}
+
+    def test_the_population_name_carried_as_data_is_not_a_population(self) -> None:
         """Only something callable is consulted, so a peer that happens to carry
-        the name as an attribute reads as keeping no registry rather than having
+        the name as an attribute reads as reporting nothing rather than having
         its names taken for a rollout.
         """
         snapshot = mesh_core.Mesh(_DataAttributeRobot(), peer_id="data-attr")._read_state()
-        assert _active_names(snapshot) == set()
+        assert _unflagged_names(snapshot) == {"arm0", "arm1"}
         assert snapshot is not None
         assert set(snapshot["robots"]) == {"arm0", "arm1"}
 

--- a/tests/simulation/mujoco/test_a_blocking_rollout_counts_as_in_flight.py
+++ b/tests/simulation/mujoco/test_a_blocking_rollout_counts_as_in_flight.py
@@ -73,11 +73,16 @@ def _readings(sim: Any) -> dict[str, Any]:
     disagreement rather than as two unrelated failures.
     """
     mesh = Mesh(sim, peer_id="sim-1", peer_type="simulation")
+    reported = mesh._running_policy_robots()
+    # Never ``None`` here: the population reader is tri-state so a backend
+    # keeping no rollout claim cannot be quoted as reporting an idle world, and
+    # this engine always holds the registry.
+    assert reported is not None, "a MuJoCo peer always reports its in-flight population"
     return {
         "population": sim._active_policy_robots(),
         "list_policies_running": sim.list_policies_running()["content"][0]["text"],
         "mesh_status": mesh._dispatch({"action": "status"}),
-        "state_topic": sorted(mesh._running_policy_robots()),
+        "state_topic": sorted(reported),
     }
 
 


### PR DESCRIPTION
Closes #3359.

The mesh answers "is a rollout in flight" on two surfaces - the `status` command and the `robots` section of the state topic - and both probed for `_active_policy_robots`, a method only the MuJoCo engine defines. A Newton peer with a rollout genuinely in flight was invisible on both, while the stop verb on that same peer halted it.

![Newton in-flight reporting, before and after](https://raw.githubusercontent.com/cagataycali/robots/assets/in-flight-reporting-34396481641/newton_in_flight_reporting.png)

*Newton peer, both mesh surfaces polled at 20 Hz across a 2 s rollout window (the claim raised and lowered exactly as `_make_run_policy_hook` / `_release_run_policy_hook` do). Before: 80/80 samples `unknown` and `active=false`, the in-flight window indistinguishable from the idle one. After: 40/40 in-window samples `running` + `["arm"]` + `active=true`, and `idle`/`false` outside it.*

## Measured

| peer | rollout | `status` before | `status` after | state topic before -> after |
|---|---|---|---|---|
| Newton | in flight | `{"status": "unknown"}` | `running`, `["arm"]` | `active=false` -> `active=true` |
| Newton | idle | `{"status": "unknown"}` | `idle`, `[]` | `active=false` -> `active=false` |
| Isaac | in flight | `{"status": "unknown"}` | `running`, `["arm"]` | no `robots` section (unchanged) |
| Isaac | idle | `{"status": "unknown"}` | `idle`, `[]` | no `robots` section (unchanged) |
| MuJoCo | in flight | `running`, `["so100"]` | identical | `active=true` (identical) |
| MuJoCo | idle | `idle`, `[]` | identical | `active=false` (identical) |

The two Newton rows were identical, so a caller could not tell a live rollout from an idle world. The state topic's row is the worse of the two: `active=false` is an affirmative "this robot is idle", published on no evidence, about a robot the peer was in fact driving - and `stop_policy` on that same peer halts it, so the fact existed.

## Change

Both backends keep the per-robot `policy_running` claim already, and Isaac already trusts it as a population for `run_multi_policy`'s busy guard; what was missing was a shared way to ask.

`SimEngine._rollouts_in_flight` is that seam, tri-state in the direction `_request_policy_stop` already is: the names when the backend can enumerate its rollouts, `()` when it can and none is, and `None` when it keeps no such claim - a stated absence of a verdict, not an empty population. Reporting a rollout is strictly weaker than halting one, which is why Isaac answers here while `stop_policy` still refuses there: a bare flag is not a durable claim to move (#2833), but it is a true answer to what is running.

- Newton / Isaac override it off the claim they maintain. MuJoCo delegates to `_active_policy_robots`, so the union of the Future table and the per-robot flag stays spelled once.
- Both mesh surfaces now read one call (`Mesh._running_policy_robots`), so a child `SimRobot` peer's `status` answers for the world exactly as its state topic already did.
- A peer reporting no population has its robots **named with no `active` key** and answers `status="unknown"`. Absence is how every other section of that snapshot spells "the probe had nothing to report"; `false` was indistinguishable from a rollout the peer cannot see.

The fleet stop's population is deliberately **not** this population: it still asks every robot in the world for a backend keeping no pruned rollout registry (`stop_policy` is idempotent and reports `was_running` itself, and a blocking `run_policy` registers no future). Narrowing it to the in-flight set is a decision about a safety path, filed in #3359 rather than taken here. Two cases pin that it did not move.

## Tests

`tests/mesh/test_every_sim_backend_reports_its_rollouts_in_flight.py` (15 cases): both phases on both backends, the tri-state's three answers (names / `()` / `None` for a torn-down world and for Isaac before `create_world`), the two surfaces agreeing from one call, `unknown` rather than `idle` when there is no verdict, and the unchanged stop population. **11 of the 15 fail on this branch's base** (`AttributeError` on the seam, `'unknown' == 'idle'`, `active False != True`); the 4 that pass are the two stop-population pins - by design - and the two idle rows that agree by coincidence.

`tests/mesh/test_state_topic_reports_which_robot_runs_a_policy.py` updated: the cases that pinned "a peer keeping no registry reports every robot `false`" now pin that it reports no flag at all, which is the claim this fixes.

Every row below was run (67 cells across the new file, the updated state-topic file and `test_stop_policy_base_contract.py`; 67 pass unmutated):

| mutation | cells failing |
|---|---|
| whole change reverted (base) | 11 of the new file's 15 |
| `None` read as an empty population in the mesh reader | 3 |
| absence rendered as `active=false` again | 2 |
| status re-derives from its own `_active_policy_robots` probe | 5 |
| reporting population promoted into the fleet-stop branch | 2 (1 here, 1 in `test_stop_policy_base_contract.py`) |

Local gate: `ruff check` + `ruff format --check` clean (1934 files); `mypy strands_robots tests` clean (1931 files); `MUJOCO_GL=egl pytest tests/` **52122 passed, 299 skipped, 0 failed** (29m34s). LOC delta: +426 / -55, of which +181 is the new test file and +51 the changelog fragment.

Docs: `docs/mesh.md` "Which robot is running" now states the shared seam and the absent-flag rendering.