### PR TITLE
fix(drivers): the Unitree drivers agree on which telemetry fields are readings

### DIFF
--- a/changelog.d/3376-telemetry-coercion-has-one-owner.md
+++ b/changelog.d/3376-telemetry-coercion-has-one-owner.md
@@ -1,0 +1,48 @@
+### Fixed: the Unitree drivers agree on which telemetry fields are readings
+
+A DDS decoder reads its message with `getattr(msg, <field>, None)` and coerces
+the result, so the coercion is what decides whether a field reaches the mesh as
+a number or as `None`. Both decoders' docstrings state why that matters: a
+*typed* default "looks like a reading", so a name the IDL never declared would
+publish a plausible constant - a zero-amp pack, a zero-cycle count - for as long
+as the robot runs.
+
+That rule was written twice, as four functions with the same names in
+`strands_robots.drivers.g1` and `strands_robots.drivers.go2`, and the two copies
+did not agree on what a reading is:
+
+| value on the field | `g1` before | `go2` before |
+| --- | --- | --- |
+| `True` on a scalar field | `1.0` / `1` | `None` |
+| `bytearray(b"\x01\x02")` on a vector field | `None` | `[1.0, 2.0]` |
+| `memoryview(b"\x01\x02")` on a vector field | `[1.0, 2.0]` | `[1.0, 2.0]` |
+| `[True, 2]` on a vector field | `[1.0, 2.0]` | `None` |
+
+Each copy guarded a class of value the other let through, and the third row is
+the one neither guarded. `memoryview` is bytes-like and iterates as integers, so
+a raw buffer landing on a field declared as a numeric vector decoded into a
+two-element "quaternion" on both drivers - where four elements are declared, and
+where the values are byte contents rather than a rotation. Measured through the
+decoders: `_on_lowstate` cached `quaternion=[1.0, 2.0]` from
+`bytearray(b"\x01\x02")`, `_on_sportmode` cached `foot_force=[1, 2, 3, 4]` from a
+`memoryview`, and `_on_bms` cached `pct=1.0` from `soc=True` - a one-percent
+pack, published on the mesh health wire, from a field that carried no reading at
+all. Neither `go2`'s bytes-like guard naming two of the three buffer types nor
+`g1`'s docstring claim that it "turns a bytes-like or string value into `None`"
+was true of the values above.
+
+The refusal branches of all eight functions were uncovered in both modules,
+which is how two copies of one rule came to disagree unnoticed.
+
+The rule now has one owner. `strands_robots.drivers.base` gains
+`telemetry_float`, `telemetry_int`, `telemetry_float_list` and
+`telemetry_int_list`, holding the union of both copies' guards plus `memoryview`,
+and both drivers read through them - so a value one driver refuses cannot be a
+reading on the other. The vector readers share one all-or-nothing walk, because
+half a quaternion is worse than none: a consumer cannot tell that it is half.
+Net -36 executable statements across the three modules (`base.py` +30, `g1.py`
+-28, `go2.py` -38).
+
+`tests/drivers/test_telemetry_coercion_refuses_the_same_non_readings.py` pins the
+rule as a table, both decoders end to end, and a derivation over the driver
+package that refuses a third private copy.

--- a/docs/getting-started/robot-factory.md
+++ b/docs/getting-started/robot-factory.md
@@ -163,6 +163,17 @@ naming what may still be moving; `strands_robots.drivers.halt_failure_detail` re
 reason out of one. Discarding it returns from shutdown reporting the robot as stopped on the
 one surface that has no way to say otherwise.
 
+A driver that decodes its own telemetry decides, field by field, whether a reading exists. The
+convention is to read every field as `getattr(msg, name, None)` and coerce it, because a *typed*
+default is a well-formed value: a firmware that renames a field would publish a plausible constant
+rather than an absence. `strands_robots.drivers.base` owns that coercion -- `telemetry_float`,
+`telemetry_int`, `telemetry_float_list`, `telemetry_int_list` -- so the answer does not depend on
+which driver asked. Each returns `None` for anything that is not a reading, including a `bool`
+(`float(True)` is `1.0`, indistinguishable from a real one-percent pack) and a bytes-like value
+(`str`, `bytes`, `bytearray`, `memoryview` all iterate, so a raw buffer would otherwise decode as a
+vector of the wrong length). The vector readers are all-or-nothing and return a fresh list, so a
+caller mutating the envelope does not race the callback thread's next write.
+
 Asking for a driver that is not there is refused, never quietly substituted:
 
 ```python

--- a/strands_robots/drivers/base.py
+++ b/strands_robots/drivers/base.py
@@ -57,7 +57,7 @@ import inspect
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator
+    from collections.abc import AsyncGenerator, Callable
 
     from strands.types.tools import ToolSpec, ToolUse
 
@@ -383,3 +383,136 @@ def undeclared_verb_error(driver: Any, action: Any) -> dict[str, Any]:
             }
         ],
     }
+
+
+#: The bytes-like types a vector telemetry field must never be read through.
+#: Every one of them iterates - as integers for the buffers, as characters for
+#: ``str`` - so a raw buffer landing on a field declared as a numeric vector
+#: would otherwise decode into a plausible-looking reading of the wrong length
+#: instead of reporting that there is no reading.
+_BYTES_LIKE: tuple[type, ...] = (str, bytes, bytearray, memoryview)
+
+
+def telemetry_float(value: Any) -> float | None:
+    """Coerce one scalar telemetry field to ``float``, or ``None`` if it is no reading.
+
+    Every caller passes ``getattr(msg, <field>, None)`` off a decoded SDK
+    message rather than a typed default, because a firmware revision that
+    renames or drops a field must cost that field and not the whole callback.
+    This is what makes that arrive at the envelope as ``None``: a typed default
+    of ``0.0`` would be indistinguishable from a real zero reading, and raising
+    would lose every other field the same message carries.
+
+    A ``bool`` is refused for the same reason. ``float(True)`` is ``1.0``, which
+    on a state-of-charge field reads as a real one-percent pack - so a field
+    that turned into a flag would report a plausible number rather than an
+    absence.
+
+    Args:
+        value: Whatever the field held, already defaulted to ``None`` by the
+            caller's ``getattr``.
+
+    Returns:
+        The reading, or ``None`` when ``value`` is absent or is not numeric.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def telemetry_int(value: Any) -> int | None:
+    """Coerce one scalar telemetry field to ``int``, or ``None`` if it is no reading.
+
+    The integer counterpart of :func:`telemetry_float`, for the fields an IDL
+    declares integer - a battery cycle count, a fan step, a mode enum. Same two
+    rules, and the ``bool`` refusal matters here too: ``int(False)`` is ``0``,
+    which on a cycle count reads as a factory-fresh pack.
+
+    Args:
+        value: Whatever the field held, already defaulted to ``None`` by the
+            caller's ``getattr``.
+
+    Returns:
+        The reading, or ``None`` when ``value`` is absent or is not numeric.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def telemetry_float_list(value: Any) -> list[float] | None:
+    """Coerce a vector telemetry field to ``list[float]``, or ``None`` if unusable.
+
+    For the sequence fields - a quaternion, an accelerometer triple, a per-cell
+    temperature vector. Three rules beyond :func:`telemetry_float`'s:
+
+    * A bytes-like value is no reading (:data:`_BYTES_LIKE`), even though it
+      iterates.
+    * All or nothing. A single element that is not a reading discards the whole
+      vector, because half a quaternion is worse than no quaternion - a
+      consumer cannot tell that it is half.
+    * The list is fresh, so a caller mutating the envelope it lands in does not
+      race the callback thread's next write into the same cache.
+
+    Args:
+        value: Whatever the field held, already defaulted to ``None`` by the
+            caller's ``getattr``.
+
+    Returns:
+        The vector, or ``None`` when it is absent, not iterable, bytes-like, or
+        holds an element that is not a reading.
+    """
+    return _telemetry_list(value, telemetry_float)
+
+
+def telemetry_int_list(value: Any) -> list[int] | None:
+    """Coerce a vector telemetry field to ``list[int]``, or ``None`` if unusable.
+
+    The integer counterpart of :func:`telemetry_float_list`, for the vectors an
+    IDL declares integer - foot-contact forces, a fan-state vector. Same three
+    rules.
+
+    Args:
+        value: Whatever the field held, already defaulted to ``None`` by the
+            caller's ``getattr``.
+
+    Returns:
+        The vector, or ``None`` when it is absent, not iterable, bytes-like, or
+        holds an element that is not a reading.
+    """
+    return _telemetry_list(value, telemetry_int)
+
+
+def _telemetry_list[T: (float, int)](value: Any, coerce: Callable[[Any], T | None]) -> list[T] | None:
+    """Apply ``coerce`` across a vector field, all or nothing.
+
+    Written once so the two public vector readers cannot drift apart in which
+    values they refuse - the drift this replaced was exactly that, one copy
+    guarding a bytes-like type the other did not.
+
+    Args:
+        value: The field, as the caller's ``getattr`` left it.
+        coerce: :func:`telemetry_float` or :func:`telemetry_int`.
+
+    Returns:
+        A fresh list, or ``None`` per :func:`telemetry_float_list`'s rules.
+    """
+    if value is None or isinstance(value, _BYTES_LIKE):
+        return None
+    try:
+        items = list(value)
+    except TypeError:
+        return None
+    out: list[T] = []
+    for item in items:
+        coerced = coerce(item)
+        if coerced is None:
+            return None
+        out.append(coerced)
+    return out

--- a/strands_robots/drivers/g1.py
+++ b/strands_robots/drivers/g1.py
@@ -49,7 +49,13 @@ import time
 from collections.abc import AsyncGenerator, Callable
 from typing import TYPE_CHECKING, Any, cast
 
-from strands_robots.drivers.base import undeclared_verb_error
+from strands_robots.drivers.base import (
+    telemetry_float,
+    telemetry_float_list,
+    telemetry_int,
+    telemetry_int_list,
+    undeclared_verb_error,
+)
 from strands_robots.mesh.pacing import Ticker
 from strands_robots.tools.g1 import HANDSHAKE_FSMS, WALK_FSMS, decode_code
 from strands_robots.tools.g1._dds_engine import DDSPublisher, DDSSubscriberSet
@@ -1372,7 +1378,7 @@ class G1Driver:
         """Decode ``rt/lf/bmsstate`` into :attr:`_battery`.
 
         Every field is read through ``getattr(msg, name, None)`` and coerced
-        by :func:`_to_float` / :func:`_to_int`, so a name the message does
+        by :func:`telemetry_float` / :func:`telemetry_int`, so a name the message does
         not carry lands ``None`` in the record rather than a typed default.
         That distinction is the whole contract here: ``getattr`` with a
         ``0`` default cannot fail and ``0`` is a well-formed reading, so a
@@ -1391,9 +1397,9 @@ class G1Driver:
         """
         try:
             self._battery = {
-                "pct": _to_float(getattr(msg, "soc", None)),
-                "current": _to_float(getattr(msg, "current", None)),
-                "cycle": _to_int(getattr(msg, "cycle", None)),
+                "pct": telemetry_float(getattr(msg, "soc", None)),
+                "current": telemetry_float(getattr(msg, "current", None)),
+                "cycle": telemetry_int(getattr(msg, "cycle", None)),
                 "t": time.time(),
             }
         except Exception as exc:  # noqa: BLE001
@@ -1480,10 +1486,10 @@ class G1Driver:
         """
         try:
             self._mainboard = {
-                "fan_state": _to_int_list(getattr(msg, "fan_state", None)),
-                "temperature": _to_float_list(getattr(msg, "temperature", None)),
-                "value": _to_float_list(getattr(msg, "value", None)),
-                "state": _to_int_list(getattr(msg, "state", None)),
+                "fan_state": telemetry_int_list(getattr(msg, "fan_state", None)),
+                "temperature": telemetry_float_list(getattr(msg, "temperature", None)),
+                "value": telemetry_float_list(getattr(msg, "value", None)),
+                "state": telemetry_int_list(getattr(msg, "state", None)),
                 "t": time.time(),
             }
         except Exception as exc:  # noqa: BLE001 - IDL message can be anything
@@ -1509,10 +1515,10 @@ class G1Driver:
         """
         try:
             self._pressure = {
-                "pressure": _to_float_list(getattr(msg, "pressure", None)),
-                "temperature": _to_float_list(getattr(msg, "temperature", None)),
-                "lost": _to_int(getattr(msg, "lost", None)),
-                "reserve": _to_int(getattr(msg, "reserve", None)),
+                "pressure": telemetry_float_list(getattr(msg, "pressure", None)),
+                "temperature": telemetry_float_list(getattr(msg, "temperature", None)),
+                "lost": telemetry_int(getattr(msg, "lost", None)),
+                "reserve": telemetry_int(getattr(msg, "reserve", None)),
                 "t": time.time(),
             }
         except Exception as exc:  # noqa: BLE001 - IDL message can be anything
@@ -1533,82 +1539,6 @@ class G1Driver:
             if value is None:
                 return None
             return dict(value)
-
-
-def _to_int(value: Any) -> int | None:
-    """Coerce ``value`` to ``int``, or return ``None`` if it will not.
-
-    ``BmsState_.cycle`` is declared integer, but the value landing here comes
-    from ``getattr(msg, name, None)`` at :meth:`G1Driver._on_bms`, so a
-    firmware that renames the field yields ``None`` at this call.  Returning
-    ``None`` decidably rather than raising keeps the DDS thread's decoder
-    swallowing nothing silently, and the ``g1_battery`` verb reports the
-    missing field as ``None`` in the envelope instead of dropping the whole
-    reading.  The same rule is why no caller passes a typed default: ``0``
-    would be indistinguishable from a real zero-cycle pack.
-    """
-    if value is None:
-        return None
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
-
-
-def _to_float(value: Any) -> float | None:
-    """Coerce ``value`` to ``float``, or return ``None`` if it will not.
-
-    The float counterpart of :func:`_to_int`, for ``BmsState_``'s ``soc`` and
-    ``current``.  Same rule: the caller passes ``getattr(msg, name, None)``
-    rather than a typed default, so a renamed or undeclared field reaches the
-    ``g1_battery`` envelope as ``None`` instead of a plausible ``0.0``.
-    """
-    if value is None:
-        return None
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return None
-
-
-def _to_int_list(value: Any) -> list[int] | None:
-    """Coerce ``value`` (a vector IDL field) to ``list[int]``, or ``None``.
-
-    Vector fields on the ``MainBoardState_`` IDL - ``fan_state`` -- arrive as
-    an iterable whose element type is declared integer on the current
-    firmware.  Copying into a plain ``list`` here (rather than storing the
-    IDL sequence) means the ``_snapshot`` accessor's ``dict(value)`` copy
-    already carries a list a caller can mutate without racing the DDS
-    thread's next write, and it turns a bytes-like or string value (which
-    would otherwise iterate as characters) into ``None``.
-    """
-    if value is None:
-        return None
-    if isinstance(value, (str, bytes, bytearray)):
-        return None
-    try:
-        return [int(item) for item in value]
-    except (TypeError, ValueError):
-        return None
-
-
-def _to_float_list(value: Any) -> list[float] | None:
-    """Coerce ``value`` (a vector IDL field) to ``list[float]``, or ``None``.
-
-    Vector fields on the ``MainBoardState_`` IDL - ``temperature`` -- are a
-    float sequence on the current firmware.  Same copy-into-list rule as
-    :func:`_to_int_list`: the returned list is fresh, so a caller mutating
-    the ``g1_mainboard`` verb's envelope does not race the DDS thread that
-    writes the cache.
-    """
-    if value is None:
-        return None
-    if isinstance(value, (str, bytes, bytearray)):
-        return None
-    try:
-        return [float(item) for item in value]
-    except (TypeError, ValueError):
-        return None
 
 
 def _refuse(reason: str) -> dict[str, Any]:

--- a/strands_robots/drivers/go2.py
+++ b/strands_robots/drivers/go2.py
@@ -73,7 +73,13 @@ import time
 from collections.abc import AsyncGenerator, Callable
 from typing import TYPE_CHECKING, Any, cast
 
-from strands_robots.drivers.base import undeclared_verb_error
+from strands_robots.drivers.base import (
+    telemetry_float,
+    telemetry_float_list,
+    telemetry_int,
+    telemetry_int_list,
+    undeclared_verb_error,
+)
 from strands_robots.mesh.pacing import Ticker
 from strands_robots.tools.g1._dds_engine import DDSPublisher, DDSSubscriberSet
 from strands_robots.tools.g1._g1_common import _DDS_INIT_LOCK
@@ -1254,17 +1260,17 @@ class Go2Driver:
         imu = getattr(msg, "imu_state", None)
         if imu is not None:
             self._imu = {
-                "quaternion": _to_float_list(getattr(imu, "quaternion", None)),
-                "gyroscope": _to_float_list(getattr(imu, "gyroscope", None)),
-                "accelerometer": _to_float_list(getattr(imu, "accelerometer", None)),
-                "rpy": _to_float_list(getattr(imu, "rpy", None)),
+                "quaternion": telemetry_float_list(getattr(imu, "quaternion", None)),
+                "gyroscope": telemetry_float_list(getattr(imu, "gyroscope", None)),
+                "accelerometer": telemetry_float_list(getattr(imu, "accelerometer", None)),
+                "rpy": telemetry_float_list(getattr(imu, "rpy", None)),
             }
         bms = getattr(msg, "bms_state", None)
         if bms is not None:
             self._battery = {
-                "pct": _to_float(getattr(bms, "soc", None)),
-                "current": _to_float(getattr(bms, "current", None)),
-                "cycle": _to_int(getattr(bms, "cycle", None)),
+                "pct": telemetry_float(getattr(bms, "soc", None)),
+                "current": telemetry_float(getattr(bms, "current", None)),
+                "cycle": telemetry_int(getattr(bms, "cycle", None)),
             }
         motors = getattr(msg, "motor_state", None)
         if motors is not None:
@@ -1275,10 +1281,10 @@ class Go2Driver:
                 except (IndexError, KeyError, TypeError):
                     continue
                 joints[name] = {
-                    "q": _to_float(getattr(motor, "q", None)),
-                    "dq": _to_float(getattr(motor, "dq", None)),
-                    "tau_est": _to_float(getattr(motor, "tau_est", None)),
-                    "temperature": _to_int(getattr(motor, "temperature", None)),
+                    "q": telemetry_float(getattr(motor, "q", None)),
+                    "dq": telemetry_float(getattr(motor, "dq", None)),
+                    "tau_est": telemetry_float(getattr(motor, "tau_est", None)),
+                    "temperature": telemetry_int(getattr(motor, "temperature", None)),
                 }
             self._joints = joints
 
@@ -1294,73 +1300,14 @@ class Go2Driver:
             msg: The decoded ``unitree_go`` ``SportModeState_``.
         """
         self._sport = {
-            "mode": _to_int(getattr(msg, "mode", None)),
-            "gait_type": _to_int(getattr(msg, "gait_type", None)),
-            "body_height": _to_float(getattr(msg, "body_height", None)),
-            "position": _to_float_list(getattr(msg, "position", None)),
-            "velocity": _to_float_list(getattr(msg, "velocity", None)),
-            "yaw_speed": _to_float(getattr(msg, "yaw_speed", None)),
-            "foot_force": _to_int_list(getattr(msg, "foot_force", None)),
+            "mode": telemetry_int(getattr(msg, "mode", None)),
+            "gait_type": telemetry_int(getattr(msg, "gait_type", None)),
+            "body_height": telemetry_float(getattr(msg, "body_height", None)),
+            "position": telemetry_float_list(getattr(msg, "position", None)),
+            "velocity": telemetry_float_list(getattr(msg, "velocity", None)),
+            "yaw_speed": telemetry_float(getattr(msg, "yaw_speed", None)),
+            "foot_force": telemetry_int_list(getattr(msg, "foot_force", None)),
         }
-
-
-def _to_float(value: Any) -> float | None:
-    """Coerce an SDK scalar to ``float``, or ``None`` when it is not numeric."""
-    if value is None or isinstance(value, bool):
-        return None
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return None
-
-
-def _to_int(value: Any) -> int | None:
-    """Coerce an SDK scalar to ``int``, or ``None`` when it is not numeric."""
-    if value is None or isinstance(value, bool):
-        return None
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
-
-
-def _to_float_list(value: Any) -> list[float] | None:
-    """Coerce an SDK sequence to ``list[float]``, or ``None`` when unusable.
-
-    Returns ``None`` rather than a partial list when any element fails to
-    convert: half a quaternion is worse than no quaternion, because a consumer
-    cannot tell it is half.
-    """
-    if value is None or isinstance(value, (str, bytes)):
-        return None
-    try:
-        items = list(value)
-    except TypeError:
-        return None
-    out: list[float] = []
-    for item in items:
-        coerced = _to_float(item)
-        if coerced is None:
-            return None
-        out.append(coerced)
-    return out
-
-
-def _to_int_list(value: Any) -> list[int] | None:
-    """Coerce an SDK sequence to ``list[int]``, or ``None`` when unusable."""
-    if value is None or isinstance(value, (str, bytes)):
-        return None
-    try:
-        items = list(value)
-    except TypeError:
-        return None
-    out: list[int] = []
-    for item in items:
-        coerced = _to_int(item)
-        if coerced is None:
-            return None
-        out.append(coerced)
-    return out
 
 
 class _ControlLoop:

--- a/tests/drivers/test_telemetry_coercion_refuses_the_same_non_readings.py
+++ b/tests/drivers/test_telemetry_coercion_refuses_the_same_non_readings.py
@@ -1,0 +1,191 @@
+"""The Unitree drivers agree on which telemetry fields are readings.
+
+``_on_bms``, ``_on_lowstate``, ``_on_mainboard`` and their siblings decode a DDS
+message by reading ``getattr(msg, <field>, None)`` and coercing the result, so
+the coercion is what decides whether a field reaches the mesh as a number or as
+``None``. That rule was written twice - four functions with identical names in
+:mod:`strands_robots.drivers.g1` and :mod:`strands_robots.drivers.go2` - and the
+two copies did not agree:
+
+===========================  =======================  =======================
+value                        ``g1`` (before)          ``go2`` (before)
+===========================  =======================  =======================
+``True`` on a scalar field   ``1.0`` / ``1``          ``None``
+``bytearray(b"\\x01\\x02")``   ``None``                 ``[1.0, 2.0]``
+``memoryview(b"\\x01\\x02")``  ``[1.0, 2.0]``           ``[1.0, 2.0]``
+``[True, 2]``                ``[1.0, 2.0]``           ``None``
+===========================  =======================  =======================
+
+Each copy guarded a class of value the other let through, and the third row is
+the one neither guarded: ``memoryview`` is bytes-like, iterates as integers, and
+so decoded a raw buffer into a two-element "quaternion" on both drivers. Every
+one of those cells publishes a plausible reading where the field carried none,
+which is the exact outcome both decoders' docstrings say the ``None`` default
+exists to prevent - a typed default "looks like a reading", and a number derived
+from a flag or a buffer looks like one just as well.
+
+The refusal branches were uncovered in both modules, which is how two copies of
+one rule came to disagree unnoticed. So the rule now has one owner in
+:mod:`strands_robots.drivers.base`, and this suite grades it three ways: the
+rule itself as a table, the two decoders end to end, and a derivation over the
+driver package that refuses a third private copy.
+"""
+
+from __future__ import annotations
+
+import ast
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from strands_robots.drivers import base, g1, go2
+from strands_robots.drivers.base import (
+    telemetry_float,
+    telemetry_float_list,
+    telemetry_int,
+    telemetry_int_list,
+)
+
+#: ``(value, float, int, float_list, int_list)`` - the whole rule as one table.
+#: The bytes-like rows and the ``bool`` rows are the drift this replaced; the
+#: rest pin that converging on the union of the two copies' guards did not
+#: widen the refusal into values that *are* readings.
+_RULE: list[tuple[Any, float | None, int | None, list[float] | None, list[int] | None]] = [
+    (None, None, None, None, None),
+    (True, None, None, None, None),
+    (False, None, None, None, None),
+    (b"\x01\x02", None, None, None, None),
+    (bytearray(b"\x01\x02"), None, None, None, None),
+    (memoryview(b"\x01\x02"), None, None, None, None),
+    ("12", 12.0, 12, None, None),
+    ("not a number", None, None, None, None),
+    (3.7, 3.7, 3, None, None),
+    (object(), None, None, None, None),
+    ([1, 2], None, None, [1.0, 2.0], [1, 2]),
+    ((1.5, 2.5), None, None, [1.5, 2.5], [1, 2]),
+    ([], None, None, [], []),
+    ([1, None], None, None, None, None),
+    ([True, 2], None, None, None, None),
+    ([1, "x"], None, None, None, None),
+]
+
+
+@pytest.mark.parametrize(("value", "as_float", "as_int", "as_floats", "as_ints"), _RULE, ids=repr)
+def test_one_rule_decides_what_counts_as_a_reading(
+    value: Any,
+    as_float: float | None,
+    as_int: int | None,
+    as_floats: list[float] | None,
+    as_ints: list[int] | None,
+) -> None:
+    """The four coercers answer as the table says, for every class of value."""
+    assert telemetry_float(value) == as_float
+    assert telemetry_int(value) == as_int
+    assert telemetry_float_list(value) == as_floats
+    assert telemetry_int_list(value) == as_ints
+
+
+def test_a_vector_reading_is_a_fresh_list() -> None:
+    """The caller may mutate the envelope without racing the DDS thread's write."""
+    source = [1.0, 2.0]
+    coerced = telemetry_float_list(source)
+    assert coerced == source
+    assert coerced is not source
+
+
+def _cache(driver: Any, attr: str) -> dict[str, Any]:
+    """The record the decoder wrote, refusing the not-yet-decoded ``None``.
+
+    The caches are declared ``dict | None`` because a driver that has received
+    no message on a topic has no record, so reading one without saying that is
+    a type error - and an absent record would otherwise read as a passing
+    refusal cell.
+    """
+    record = getattr(driver, attr)
+    assert record is not None, f"the decoder wrote no {attr}"
+    return record
+
+
+class TestBothDriversReadThroughTheOneOwner:
+    """Identity, not equivalence - a second copy could pass a behaviour table."""
+
+    @pytest.mark.parametrize("driver_module", [g1, go2], ids=["g1", "go2"])
+    @pytest.mark.parametrize(
+        "name",
+        ["telemetry_float", "telemetry_int", "telemetry_float_list", "telemetry_int_list"],
+    )
+    def test_the_driver_resolves_the_shared_function(self, driver_module: types.ModuleType, name: str) -> None:
+        assert getattr(driver_module, name) is getattr(base, name)
+
+    def test_no_driver_keeps_a_private_coercer_of_this_shape(self) -> None:
+        """A third driver cannot land a third copy under the old names.
+
+        Derived over the package rather than listed, so a driver added later is
+        held to the rule without anyone remembering to extend this file.
+        """
+        retired = {"_to_float", "_to_int", "_to_float_list", "_to_int_list"}
+        found: list[str] = []
+        for module_path in sorted(Path(base.__file__).parent.rglob("*.py")):
+            tree = ast.parse(module_path.read_text(encoding="utf-8"))
+            found += [
+                f"{module_path.name}:{node.name}"
+                for node in ast.walk(tree)
+                if isinstance(node, ast.FunctionDef) and node.name in retired
+            ]
+        assert found == [], f"private telemetry coercers still defined: {found}"
+
+
+class TestTheDecodersRefuseANonReading:
+    """The rule through the callback, on the fields each driver publishes."""
+
+    def test_a_flag_on_the_g1_battery_field_is_no_percentage(self) -> None:
+        driver = g1.G1Driver(tool_name="g1", port="1.2.3.4")
+        driver._on_bms(types.SimpleNamespace(soc=True, current=1.5, cycle=False))
+        assert _cache(driver, "_battery")["pct"] is None
+        assert _cache(driver, "_battery")["cycle"] is None
+        assert _cache(driver, "_battery")["current"] == 1.5
+
+    @pytest.mark.parametrize(
+        "buffer",
+        [bytearray(b"\x01\x02"), memoryview(b"\x01\x02")],
+        ids=["bytearray", "memoryview"],
+    )
+    def test_a_buffer_on_the_g1_mainboard_vectors_is_no_vector(self, buffer: Any) -> None:
+        driver = g1.G1Driver(tool_name="g1", port="1.2.3.4")
+        driver._on_mainboard(types.SimpleNamespace(fan_state=buffer, temperature=buffer, value=[1.0], state=[2]))
+        assert _cache(driver, "_mainboard")["fan_state"] is None
+        assert _cache(driver, "_mainboard")["temperature"] is None
+        assert _cache(driver, "_mainboard")["value"] == [1.0]
+
+    @pytest.mark.parametrize(
+        "buffer",
+        [bytearray(b"\x01\x02"), memoryview(b"\x01\x02")],
+        ids=["bytearray", "memoryview"],
+    )
+    def test_a_buffer_on_the_go2_imu_is_no_quaternion(self, buffer: Any) -> None:
+        driver = go2.Go2Driver()
+        imu = types.SimpleNamespace(
+            quaternion=buffer, gyroscope=buffer, accelerometer=[0.0, 0.0, 9.8], rpy=[0.0, 0.0, 0.0]
+        )
+        driver._on_lowstate(types.SimpleNamespace(imu_state=imu, bms_state=None, motor_state=None))
+        assert _cache(driver, "_imu")["quaternion"] is None
+        assert _cache(driver, "_imu")["gyroscope"] is None
+        assert _cache(driver, "_imu")["accelerometer"] == [0.0, 0.0, 9.8]
+
+    def test_a_buffer_on_the_go2_foot_force_is_no_contact_reading(self) -> None:
+        driver = go2.Go2Driver()
+        driver._on_sportmode(
+            types.SimpleNamespace(
+                mode=1,
+                gait_type=2,
+                body_height=0.3,
+                position=[0.0, 0.0, 0.3],
+                velocity=[0.0, 0.0, 0.0],
+                yaw_speed=0.0,
+                foot_force=memoryview(b"\x01\x02\x03\x04"),
+            )
+        )
+        assert _cache(driver, "_sport")["foot_force"] is None
+        assert _cache(driver, "_sport")["body_height"] == 0.3


### PR DESCRIPTION
## The two Unitree drivers disagreed on what counts as a reading

![before/after](https://raw.githubusercontent.com/cagataycali/robots/assets/telemetry-coercion-34402618924/telemetry_coercion.png)

A DDS decoder reads its message as `getattr(msg, <field>, None)` and coerces the result, so the coercion decides whether a field reaches the mesh as a number or as `None`. Both decoders' docstrings say why that matters - a *typed* default "looks like a reading", so a renamed field would publish a plausible constant for as long as the robot runs.

That rule was written **twice**, as four functions with identical names in `drivers/g1.py` and `drivers/go2.py`, and the copies did not agree. Measured through the decoders on `upstream/main` vs this branch:

| field held | `g1` before | `go2` before | after (both) |
| --- | --- | --- | --- |
| `soc=True` (scalar) | `pct=1.0` | `None` | `None` |
| `soc=False` (scalar) | `pct=0.0` | `None` | `None` |
| `bytearray(b"\x01\x02")` (vector) | `None` | `quaternion=[1.0, 2.0]` | `None` |
| `memoryview(b"\x01\x02")` (vector) | `temperature=[1.0, 2.0]` | `quaternion=[1.0, 2.0]` | `None` |
| `[True, 2]` (vector) | `temperature=[1.0, 2.0]` | `None` | `None` |

Each copy guarded a class of value the other let through, and row 4 is the one **neither** guarded: `memoryview` is bytes-like and iterates as integers, so a raw buffer decoded into a two-element "quaternion" - on a field that declares four, from bytes that are not a rotation. `go2`'s bytes-like guard named two of the three buffer types; `g1`'s docstring claimed it "turns a bytes-like or string value into `None`", which was untrue of `memoryview`.

The lower panel is the harm: `soc=True` published `pct=1.0` in the middle of an 88 -> 85 percent discharge. A one-percent pack on the mesh health wire, indistinguishable from a real critical reading, from a field that carried no reading at all.

The refusal branches of all eight functions were uncovered in both modules (`g1.py` 1554-1555/1588/1591-1592/1607/1610-1611, `go2.py` 1310-1361), which is how two copies of one rule came to disagree unnoticed.

## Change

`drivers/base.py` owns the rule: `telemetry_float`, `telemetry_int`, `telemetry_float_list`, `telemetry_int_list`, holding the union of both copies' guards plus `memoryview`, with the two vector readers sharing one all-or-nothing walk ("half a quaternion is worse than no quaternion - a consumer cannot tell that it is half"). Both drivers read through it, so a value one driver refuses cannot be a reading on the other.

| module | statements | lines |
| --- | --- | --- |
| `drivers/base.py` | 56 -> 86 (+30) | +133 |
| `drivers/g1.py` | 588 -> 560 (-28) | -70 |
| `drivers/go2.py` | 564 -> 526 (-38) | -53 |
| **net** | **-36** | +10 |

The +10 raw lines are docstring: both copies' rationale, plus the new rule, now stated once instead of twice.

## Tests

`tests/drivers/test_telemetry_coercion_refuses_the_same_non_readings.py` (32 cells) grades it three ways - the rule as a 16-row table, both decoders end to end, and a derivation over the driver package that refuses a third private copy under the retired names.

Pre-fix measurement: with only the *instrument* (the `base.py` rule) copied into a pristine `upstream/main` worktree and the drivers left untouched, **14 failed / 18 passed** - the 8 identity cells, the package derivation (naming all 8 private copies), and 5 decoder cells asserting `1.0 is None`, `[1.0, 2.0] is None`, `[1, 2, 3, 4] is None`. On this branch, **32 passed**.

Every guard earns its lines:

| mutation to `base.py` | cells failed |
| --- | --- |
| no `bool` guard on `telemetry_float` | 4 |
| no `bool` guard on `telemetry_int` | 4 |
| `memoryview` dropped from the bytes-like set | 4 |
| `bytearray` dropped from the bytes-like set | 3 |
| a partial vector instead of all-or-nothing | 3 |
| the input sequence returned instead of a fresh list | 1 |

Coverage over the three modules: 90% -> 92%, with `base.py` at 100% (89 statements) and 41 fewer statements to cover.

## Gate

`ruff check` / `ruff format --check` clean (1936 files), `mypy` 0 errors (1931 files), full suite **52152 passed / 299 skipped / 0 failed** (29m55s). No existing pin depended on the divergence: the 2538 driver cells on `main` pass unchanged.

Docs: `docs/getting-started/robot-factory.md` gains the driver-author paragraph next to the `halt_failure_detail` rule it parallels.