### PR TITLE
fix(drivers): a G1 IMU field the message does not carry is not a level reading

### DIFF
--- a/changelog.d/3379-g1-imu-absent-field-is-not-a-level-reading.md
+++ b/changelog.d/3379-g1-imu-absent-field-is-not-a-level-reading.md
@@ -1,0 +1,35 @@
+### Fixed: a G1 IMU field the message does not carry is `None`, not a level reading
+
+`G1Driver._on_lowstate` read its four `IMUState_` vectors with typed
+defaults - `[0.0, 0.0, 0.0]` for `rpy`, `gyroscope` and `accelerometer`,
+`[1.0, 0.0, 0.0, 0.0]` for `quaternion`. A `getattr` carrying a default
+cannot fail, and every one of those constants is a well-formed reading of a
+robot that is fine: zero rpy is perfectly level, the identity quaternion is
+upright, and a zero accelerometer is free fall, which a standing robot never
+reports because gravity always lands on one axis. A firmware that renamed or
+dropped a field therefore published a constant shaped exactly like telemetry
+- and kept publishing it, to `strands/{peer_id}/imu` via
+`SensorLoopsMixin._read_imu`, for as long as the robot ran. A fleet reading
+attitude off the wire was told a falling humanoid was level.
+
+The four reads now go through `telemetry_float_list`, which is what the twin
+driver already did: `Go2Driver._on_lowstate` reads the same four names that
+way, so after the shared-coercer work this was the one Unitree telemetry read
+still carrying typed defaults. The same rule is kept one method down in the
+same class (`_on_bms` reads through `getattr(msg, name, None)` so a renamed
+field lands `None` rather than a plausible zero), stated outright by the
+sibling humanoid in `strands_robots.drivers.booster.parse_low_state` ("a
+snapshot that reports a zeroed IMU the robot never sent is worse than one that
+reports none"), and documented by the consuming `g1_imu` verb, which described
+every field as "or `None`" and promised it "does not fabricate a reading the
+driver does not have" while the writer made the per-field `None` unreachable
+for any driver that had received a frame.
+
+Because the fields are now coerced one at a time, a single unreadable vector
+reports itself as `None` instead of raising inside its comprehension, being
+swallowed by the callback's `except`, and abandoning the whole assignment -
+which previously discarded the three good readings that arrived in the same
+frame and left the last record in place as though nothing had been received.
+
+No new coercion helper: the shared function was already imported in the
+module, so this removes a hand-rolled read rather than adding a rule.

--- a/strands_robots/drivers/g1.py
+++ b/strands_robots/drivers/g1.py
@@ -1357,15 +1357,39 @@ class G1Driver:
         motion-switcher API and arrives on a different topic.  Writing this
         field to :attr:`_mode_machine` (rather than :attr:`_fsm_id`) keeps the
         two ranges separate: ``[0, 255]`` for the echo, arbitrary for the gate.
+
+        Each ``IMUState_`` vector is read through ``getattr(imu, name, None)``
+        and coerced by
+        :func:`~strands_robots.drivers.base.telemetry_float_list`, so a field
+        the message does not carry lands ``None`` rather than a typed default.
+        The twin driver
+        :meth:`~strands_robots.drivers.go2.Go2Driver._on_lowstate`
+        reads the same four names the same way, and it is the stricter half of
+        the rule here: a default-carrying read cannot fail, and every default
+        this IMU could take is a well-formed
+        reading of a robot that is fine -- ``[0.0, 0.0, 0.0]`` rpy is perfectly
+        level, ``[1.0, 0.0, 0.0, 0.0]`` is upright, and a zero accelerometer is
+        free fall, which a standing robot never reports because gravity is
+        always on one axis.  Those constants are published to
+        ``strands/{peer_id}/imu`` by
+        :class:`~strands_robots.mesh.sensors.SensorLoopsMixin` for as long as
+        the robot runs, so a fleet reading attitude off the wire would be told
+        a falling humanoid is level.  ``None`` says the field was not read,
+        which is what the ``g1_imu`` verb documents for every one of them.
+
+        Because each field is coerced on its own, one unreadable vector reports
+        itself as ``None`` and leaves the other three intact, rather than
+        raising past the dict and abandoning a frame that carried three good
+        readings.
         """
         try:
             imu = getattr(msg, "imu_state", None)
             if imu is not None:
                 self._imu = {
-                    "rpy": [float(x) for x in getattr(imu, "rpy", [0.0, 0.0, 0.0])[:3]],
-                    "gyroscope": [float(x) for x in getattr(imu, "gyroscope", [0.0, 0.0, 0.0])[:3]],
-                    "accelerometer": [float(x) for x in getattr(imu, "accelerometer", [0.0, 0.0, 0.0])[:3]],
-                    "quaternion": [float(x) for x in getattr(imu, "quaternion", [1.0, 0.0, 0.0, 0.0])[:4]],
+                    "rpy": telemetry_float_list(getattr(imu, "rpy", None)),
+                    "gyroscope": telemetry_float_list(getattr(imu, "gyroscope", None)),
+                    "accelerometer": telemetry_float_list(getattr(imu, "accelerometer", None)),
+                    "quaternion": telemetry_float_list(getattr(imu, "quaternion", None)),
                     "t": time.time(),
                 }
             mode_machine = getattr(msg, "mode_machine", None)

--- a/strands_robots/tools/g1/g1_imu.py
+++ b/strands_robots/tools/g1/g1_imu.py
@@ -75,6 +75,12 @@ def g1_imu(driver: Any) -> dict[str, Any]:
     ``present=False`` and every field ``None``; the verb does not
     fabricate a reading the driver does not have.
 
+    ``present=True`` with an individual field ``None`` is the same rule one
+    level down: the ``LowState`` arrived, but that vector was not in it (or
+    not at its declared width), so ``_on_lowstate`` cached ``None`` for it
+    rather than a typed default.  A caller must therefore check each field it
+    reads, not just ``present``.
+
     Args:
         driver: An object with a ``_snapshot(attr: str)`` method
             returning the cached sensor dict (in practice a

--- a/tests/drivers/test_g1_imu_absent_field_is_not_a_level_reading.py
+++ b/tests/drivers/test_g1_imu_absent_field_is_not_a_level_reading.py
@@ -1,0 +1,168 @@
+"""An ``IMUState_`` vector the message does not carry caches ``None``, not level.
+
+:meth:`~strands_robots.drivers.g1.G1Driver._on_lowstate` read its four IMU
+vectors with typed defaults -- ``[0.0, 0.0, 0.0]`` for ``rpy``, ``gyroscope``
+and ``accelerometer``, ``[1.0, 0.0, 0.0, 0.0]`` for ``quaternion``.  A
+``getattr`` carrying a default cannot fail, and every one of those constants is
+a well-formed reading of a robot that is upright and still: zero rpy is
+perfectly level, the identity quaternion is upright, and a zero accelerometer is
+free fall, which a standing robot never reports because gravity always lands on
+one axis.  A firmware that renames or drops a field therefore published a
+constant shaped exactly like telemetry, to ``strands/{peer_id}/imu`` via
+:class:`~strands_robots.mesh.sensors.SensorLoopsMixin`, for as long as the robot
+ran.
+
+The rule these tests pin was already kept everywhere else. The twin driver
+reads the same four names through the shared coercer
+(:meth:`~strands_robots.drivers.go2.Go2Driver._on_lowstate`), the same class
+reads its battery pack that way one method down (:meth:`G1Driver._on_bms`, so a
+renamed field lands ``None`` rather than a plausible zero), the sibling humanoid
+states it outright in
+:func:`~strands_robots.drivers.booster.parse_low_state` ("a snapshot that
+reports a zeroed IMU the robot never sent is worse than one that reports none"),
+and the consuming verb ``g1_imu`` documented ``None`` for every field while the
+writer made that outcome unreachable.
+"""
+
+from __future__ import annotations
+
+import inspect
+import types
+from typing import Any
+
+import pytest
+
+from strands_robots.drivers import g1, go2
+from strands_robots.drivers.g1 import G1Driver
+from strands_robots.tools.g1.g1_imu import g1_imu
+
+# The four IMU vectors both Unitree drivers cache, read off their own writers.
+IMU_FIELDS = ("rpy", "gyroscope", "accelerometer", "quaternion")
+
+
+def _class_name(module: Any) -> str:
+    """The driver class a Unitree module defines, so the pin names neither twice."""
+    return "G1Driver" if module.__name__.endswith("g1") else "Go2Driver"
+
+
+# One well-formed frame: the robot is rolled and yawed, gravity is on Z. Every
+# case below starts from this and removes or corrupts exactly one field, so a
+# fabricated value is visible against three real neighbours.
+WIRED = {
+    "rpy": [0.05, -0.02, 1.3],
+    "gyroscope": [0.01, 0.02, 0.03],
+    "accelerometer": [0.1, 0.0, 9.79],
+    "quaternion": [0.79, 0.0, 0.0, 0.61],
+}
+
+
+def _driver() -> G1Driver:
+    return G1Driver(tool_name="g1", port="192.168.1.172")
+
+
+def _decode(**fields: Any) -> dict[str, Any]:
+    """Run one ``rt/lowstate`` frame through the driver and return ``_imu``.
+
+    Args:
+        **fields: The ``imu_state`` attributes to publish. A name that is
+            absent from this mapping is absent from the message, which is what
+            a renamed or dropped IDL field looks like on the wire.
+
+    Returns:
+        The cached record, ``t`` removed so cases compare by value.
+    """
+    driver = _driver()
+    driver._on_lowstate(types.SimpleNamespace(imu_state=types.SimpleNamespace(**fields), mode_machine=4))
+    assert driver._imu is not None, "a LowState carrying imu_state must cache a record"
+    record = dict(driver._imu)
+    record.pop("t")
+    return record
+
+
+def test_a_fully_populated_frame_is_cached_verbatim() -> None:
+    """The good path is untouched: every declared vector round-trips by value."""
+    assert _decode(**WIRED) == WIRED
+
+
+@pytest.mark.parametrize("missing", sorted(IMU_FIELDS))
+def test_an_absent_vector_caches_none_and_leaves_its_siblings_alone(missing: str) -> None:
+    """A field the message does not carry is ``None``, not a level reading.
+
+    The three fields that *were* on the wire keep their values, so the record
+    reports precisely what arrived rather than being discarded wholesale.
+    """
+    record = _decode(**{k: v for k, v in WIRED.items() if k != missing})
+    assert record[missing] is None
+    assert {k: v for k, v in record.items() if k != missing} == {k: v for k, v in WIRED.items() if k != missing}
+
+
+def test_an_imu_state_carrying_no_vectors_reports_no_readings() -> None:
+    """An ``imu_state`` with none of the four fields fabricates nothing.
+
+    Pre-fix this was the worst cell: a complete, plausible record of a robot
+    standing perfectly level and upright while in free fall.
+    """
+    assert _decode() == dict.fromkeys(IMU_FIELDS)
+
+
+@pytest.mark.parametrize("value", ["0.05", b"\x01\x02\x03", 0.05, None], ids=["str", "bytes", "scalar", "none"])
+def test_a_non_vector_field_costs_only_itself(value: Any) -> None:
+    """One unreadable vector reports ``None``; the other three survive.
+
+    Pre-fix a string ``rpy`` raised inside the comprehension, the driver's
+    ``except`` swallowed it, and the whole assignment was abandoned -- the
+    three good readings in the same frame were lost with it.
+    """
+    record = _decode(**{**WIRED, "rpy": value})
+    assert record["rpy"] is None
+    assert {k: record[k] for k in ("gyroscope", "accelerometer", "quaternion")} == {
+        k: WIRED[k] for k in ("gyroscope", "accelerometer", "quaternion")
+    }
+
+
+def test_the_imu_verb_reports_the_unread_field_as_none() -> None:
+    """``g1_imu`` renders the ``None`` its own docstring documents.
+
+    The verb documented every field as "or ``None``" while the writer made
+    that outcome unreachable for a driver that had received a frame.
+    """
+    driver = _driver()
+    driver._on_lowstate(
+        types.SimpleNamespace(
+            imu_state=types.SimpleNamespace(**{k: v for k, v in WIRED.items() if k != "rpy"}),
+            mode_machine=4,
+        )
+    )
+    envelope = g1_imu(driver)
+    assert envelope["present"] is True
+    assert envelope["rpy"] is None
+    assert envelope["accelerometer"] == WIRED["accelerometer"]
+
+
+def test_both_unitree_drivers_read_their_imu_through_the_same_rule() -> None:
+    """The G1 and the Go2 coerce the same four names with the same function.
+
+    :meth:`Go2Driver._on_lowstate` already read its IMU through
+    :func:`~strands_robots.drivers.base.telemetry_float_list`; the G1 was the
+    one Unitree telemetry read still carrying typed defaults. Deriving the call
+    from both sources means a future driver that hand-rolls the coercion again
+    fails here rather than drifting quietly.
+    """
+    for module in (g1, go2):
+        body = inspect.getsource(module.__dict__[_class_name(module)]._on_lowstate)
+        for field in IMU_FIELDS:
+            assert f'telemetry_float_list(getattr(imu, "{field}", None))' in body, (
+                f"{module.__name__}._on_lowstate must read {field} through the shared coercer"
+            )
+
+
+def test_no_imu_read_carries_a_typed_default() -> None:
+    """A default reintroduced on any of the four reads fails here.
+
+    The values are the defect's own constants, so this cell is a derivation
+    over the writer rather than a restatement of it.
+    """
+    source = inspect.getsource(G1Driver._on_lowstate)
+    body = source.split('"""', 2)[2]  # skip the docstring, which quotes them
+    for default in ("[0.0, 0.0, 0.0]", "[1.0, 0.0, 0.0, 0.0]"):
+        assert default not in body, f"{default} is a reading of a robot that is fine"


### PR DESCRIPTION
A G1 `IMUState_` field the message does not carry was cached as a **level, upright, free-falling** robot. `Go2Driver._on_lowstate` already read the same four names correctly; the G1 was the one Unitree telemetry read left on typed defaults.

![the driver reports level while the pelvis rolls 60 degrees](https://raw.githubusercontent.com/cagataycali/robots/assets/g1-imu-34408248573/g1_imu_level.png)

*MuJoCo (headless, EGL) renders the true pelvis attitude; the trace is what `_on_lowstate` actually cached, replayed at 20 Hz through both trees. The firmware stops carrying `imu_state.rpy` at t=2s. Peak fabricated attitude error: **1.05 rad (60.2 deg)**.*

## The read

```python
# before - a getattr default cannot fail, and every default here is a valid reading
"rpy":           [float(x) for x in getattr(imu, "rpy",           [0.0, 0.0, 0.0])[:3]],
"gyroscope":     [float(x) for x in getattr(imu, "gyroscope",     [0.0, 0.0, 0.0])[:3]],
"accelerometer": [float(x) for x in getattr(imu, "accelerometer", [0.0, 0.0, 0.0])[:3]],
"quaternion":    [float(x) for x in getattr(imu, "quaternion",    [1.0, 0.0, 0.0, 0.0])[:4]],

# after - the shared coercer, already imported in this module
"rpy":           telemetry_float_list(getattr(imu, "rpy", None)),
...
```

`[0.0, 0.0, 0.0]` rpy is perfectly level, `[1.0, 0.0, 0.0, 0.0]` is upright, and a zero accelerometer is free fall - which a standing robot never reports, because gravity is always on one axis. `SensorLoopsMixin._read_imu` publishes `_imu` to `strands/{peer_id}/imu`, so those constants went on the wire for as long as the robot ran.

## Measured, `_on_lowstate` cache (`t` elided)

| `imu_state` carries | before | after |
|---|---|---|
| all four fields | correct | **unchanged** |
| `rpy` renamed away | `rpy=[0.0, 0.0, 0.0]`, siblings real | `rpy=None`, siblings real |
| none of the four | `rpy/gyro/accel=[0,0,0]`, `quat=[1,0,0,0]` | all four `None` |
| `rpy` is a `str` | **whole record dropped** (3 good readings lost) | `rpy=None`, other three kept |

The last row is the `except` swallowing a raise from inside the comprehension: one malformed field discarded the frame and left the previous record in place as though nothing had arrived. Coercing per field fixes it.

## Four in-tree witnesses said so already

| where | what it says |
|---|---|
| `Go2Driver._on_lowstate` | reads the same four names via `telemetry_float_list` |
| `G1Driver._on_bms` (one method down) | "a default-carrying read ... publishes a constant shaped exactly like telemetry" |
| `booster.parse_low_state` | "a snapshot that reports a zeroed IMU the robot never sent is worse than one that reports none" |
| the `g1_imu` verb | documents every field "or `None`", promises it "does not fabricate a reading the driver does not have" |

That last one was unreachable: `_on_lowstate` always populated all four keys, so a per-field `None` could never be rendered for a driver that had received a frame. This PR makes the verb's documented contract true and adds the sentence spelling out that `present=True` does not imply every field is a reading.

## Tests

`tests/drivers/test_g1_imu_absent_field_is_not_a_level_reading.py`, 13 cells. On pristine `main` + this file: **12 failed, 1 passed** (the pass is the untouched good path). After: **13 passed**.

Mutations, each run:

| mutation | cells |
|---|---|
| the fix reverted | 12 |
| routed through the coercer but the `getattr` default kept | 8 |
| only `rpy` fixed, other three left on defaults | 6 |
| coercer result defaulted back (`... or [0.0, 0.0, 0.0]`) | 11 |

The second row is why the pin reads the `getattr` too: using the shared function is not sufficient if the default stays.

## Gate

`ruff check` + `ruff format --check` clean on `strands_robots tests tests_integ`; `mypy` clean (1934 files). Full suite `52194 passed, 299 skipped, 0 failed` (28m41s); collected `52480 -> 52493`, exactly the 13 new cells.

LOC: `g1.py` executable statements **558 -> 558**. No new helper - the shared coercer was already imported - so the diff swaps four hand-rolled reads and the rest is docstring.

Width is deliberately out of scope: neither Unitree driver validates vector width, and imposing it on one twin would re-open the drift #3376 closed.