### PR TITLE
fix(drivers/g1): the lowstate layout id is a reading, not an int() cast

### DIFF
--- a/changelog.d/3380-lowstate-layout-id-is-a-reading.md
+++ b/changelog.d/3380-lowstate-layout-id-is-a-reading.md
@@ -1,0 +1,41 @@
+### Fixed: the G1 lowstate layout id is a reading, not an `int()` cast
+
+`mode_machine` arrives on `rt/lowstate` beside the IMU and is echoed on every
+`LowCmd_` the G1 driver builds. The firmware drops a frame whose layout id does
+not match the one it announced, so an id built from something other than a
+number is a write the robot silently ignores - the same failure a typed default
+has elsewhere in this decoder, on the one field that leaves the process again.
+
+The four IMU vectors in that method read through
+`strands_robots.drivers.base.telemetry_int` / `telemetry_float_list`; the layout
+id beside them was still coerced with a bare `int()`. Measured through
+`_on_lowstate`:
+
+| `LowState_.mode_machine` holds | before | after |
+| --- | --- | --- |
+| `9` | `9` | `9` |
+| `True` | **`1`** | `None`, previous kept |
+| `False` | **`0`** | `None`, previous kept |
+| `b"\x09"` | raises into the shared `except` | `None`, previous kept |
+| `"n/a"` | raises into the shared `except` | `None`, previous kept |
+| `2.7` | `2` | `2` |
+| `"9"` | `9` | `9` |
+
+`1` and `0` are valid uint8 layout ids, so a flag on the field was
+indistinguishable from a reading. `telemetry_int` refuses both. A float is still
+truncated: `telemetry_int(2.7) == 2` is the owner's own pinned answer and the Go2
+accepts it too, so refusing it here would be the drift those functions exist to
+prevent.
+
+A refused reading leaves `_mode_machine` at the last value that parsed rather
+than clearing it, matching `_refresh_fsm_id` two ranges over. Today the raise
+position produced that too; stating it keeps it true once a field is decoded
+after this one, which is what went wrong on the IMU side.
+
+`tests/drivers/test_g1_layout_id_is_a_reading_too.py` pins the refusals, the
+accepted boundary including the float rows, and an AST scan for any non-`None`
+`getattr` default across the whole method on both Unitree drivers - a derivation
+rather than a search for this defect's own constants, since the constants a
+future field would default to are not knowable.
+
+Pure routing: `g1.py`'s executable statement count is unchanged at 558.

--- a/docs/getting-started/robot-factory.md
+++ b/docs/getting-started/robot-factory.md
@@ -174,6 +174,20 @@ which driver asked. Each returns `None` for anything that is not a reading, incl
 vector of the wrong length). The vector readers are all-or-nothing and return a fresh list, so a
 caller mutating the envelope does not race the callback thread's next write.
 
+The rule covers the scalars a decoder sends back out, not only the ones it publishes. The Unitree
+`mode_machine` is read from `rt/lowstate` and echoed on every `LowCmd_`, and the firmware drops a
+frame whose layout id does not match the one it announced -- so an id that came from something other
+than a number is a write the robot silently ignores. A bare `int()` is the wrong coercion for that:
+`int(True)` is `1` and `int(False)` is `0`, both valid uint8 ids, so a flag on the field would be
+indistinguishable from a reading. `telemetry_int` refuses both. A float is still truncated, because
+that is the shared answer and a decoder stricter than its sibling on a value both accept is the
+drift these functions exist to prevent.
+
+A refused scalar leaves the cached value at the last reading that parsed, rather than clearing it.
+That matters when a gate reads the cache: `mode_machine` gates every G1 motion write and its refusal
+reads "lowstate has not delivered yet", which one unreadable frame should not make true of a robot
+whose lowstate is arriving.
+
 Asking for a driver that is not there is refused, never quietly substituted:
 
 ```python

--- a/strands_robots/drivers/g1.py
+++ b/strands_robots/drivers/g1.py
@@ -1381,6 +1381,24 @@ class G1Driver:
         itself as ``None`` and leaves the other three intact, rather than
         raising past the dict and abandoning a frame that carried three good
         readings.
+
+        ``mode_machine`` is read the same way, through
+        :func:`~strands_robots.drivers.base.telemetry_int`.  It is a reading
+        like any other and it is the one this method sends back out: the
+        firmware drops a ``LowCmd_`` whose layout id does not match, so an id
+        built from something that was not a number is a write the robot
+        silently ignores.  ``int()`` read a ``bool`` as ``1``/``0``, both valid
+        uint8 layout ids, so a flag on the field was indistinguishable from a
+        reading; it also raised on a buffer or a word, which the shared
+        ``except`` then logged as a failure of the whole lowstate rather than of
+        one field.  A float is still truncated, because that is the owner's own
+        answer and the Go2 accepts it too.
+
+        A refused reading leaves :attr:`_mode_machine` at its previous value,
+        matching :meth:`_refresh_fsm_id` two ranges over: the layout id does
+        not change while the robot is powered, so the last reading that parsed
+        is a better answer than ``None`` - which the gate reads as "lowstate
+        has not delivered yet".
         """
         try:
             imu = getattr(msg, "imu_state", None)
@@ -1392,9 +1410,9 @@ class G1Driver:
                     "quaternion": telemetry_float_list(getattr(imu, "quaternion", None)),
                     "t": time.time(),
                 }
-            mode_machine = getattr(msg, "mode_machine", None)
+            mode_machine = telemetry_int(getattr(msg, "mode_machine", None))
             if mode_machine is not None:
-                self._mode_machine = int(mode_machine)
+                self._mode_machine = mode_machine
         except Exception as exc:  # noqa: BLE001 - IDL message can be anything
             logger.debug("%s: lowstate decode failed: %s", self._tool_name, exc)
 

--- a/tests/drivers/test_g1_layout_id_is_a_reading_too.py
+++ b/tests/drivers/test_g1_layout_id_is_a_reading_too.py
@@ -1,0 +1,154 @@
+"""``mode_machine`` is a reading, and it is the one ``_on_lowstate`` sends back.
+
+The four IMU vectors in ``rt/lowstate`` are read through the shared telemetry
+coercers, so a field the message does not carry lands ``None`` rather than a
+typed default. ``mode_machine`` is decoded in the same method and was still
+coerced with a bare ``int()``, which differs from that rule in both directions a
+uint8 can go wrong:
+
+* ``int(True)`` is ``1``, and ``1`` is a valid hardware-layout id. A flag on the
+  field therefore produced a layout id no message declared, indistinguishable
+  from a real one.
+* ``int(2.7)`` is ``2``, so a float was truncated into a *different* valid id
+  rather than refused.
+
+That value is not only cached, it is echoed on every ``LowCmd_`` this driver
+builds (``_build_lowcmd_from_action``, ``_build_zero_torque_lowcmd``), and the
+firmware drops a frame whose layout id does not match the one it announced. So
+an id built from something that was not a number is a write the robot silently
+ignores - the failure mode a typed default has everywhere else in this decoder,
+on the one field that leaves the process again.
+
+``telemetry_int`` already refuses both, and a refused reading now leaves
+:attr:`~strands_robots.drivers.g1.G1Driver._mode_machine` at its previous value.
+That matches :meth:`~strands_robots.drivers.g1.G1Driver._refresh_fsm_id` two
+ranges over: the layout id does not change while the robot is powered, so the
+last reading that parsed is a better answer than ``None`` - which the motion
+gate reads as "lowstate has not delivered yet".
+
+The structural cell here is an AST scan rather than a search for the defect's
+own constants, because the constants a *future* field would default to are not
+knowable. It covers the whole method and both Unitree drivers, so the Go2 is a
+passing control: this is the house rule, not a G1 rule.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+import types
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from strands_robots.drivers import g1, go2
+
+#: Both Unitree ``_on_lowstate`` decoders, whose own source the scan reads.
+_DECODERS: list[Callable[..., None]] = [g1.G1Driver._on_lowstate, go2.Go2Driver._on_lowstate]
+
+#: A healthy ``imu_state``, so these cells vary only ``mode_machine``.
+_IMU = types.SimpleNamespace(
+    rpy=[0.1, -0.2, 0.3],
+    gyroscope=[1.0, 2.0, 3.0],
+    accelerometer=[0.0, 0.0, 9.81],
+    quaternion=[0.99, 0.01, 0.02, 0.03],
+)
+
+#: Values that are not a uint8 layout id. The two ``bool`` spellings are the
+#: reason this matters: ``int(True)`` is ``1`` and ``int(False)`` is ``0``, both
+#: valid layout ids, so a flag on the field was indistinguishable from a reading.
+_NOT_AN_ID: list[tuple[str, Any]] = [
+    ("a flag that is true", True),
+    ("a flag that is false", False),
+    ("a raw buffer", b"\x09"),
+    ("not a number", "n/a"),
+    ("absent", None),
+]
+
+#: Values the shared owner reads as an id, so this change must not refuse them.
+#: A float is truncated rather than refused - ``telemetry_int(2.7) == 2`` is the
+#: owner's own documented answer, pinned in its rule table, and a decoder that
+#: graded it where its sibling does not is the drift #3376 removed.
+_STILL_AN_ID: list[tuple[Any, int]] = [(0, 0), (9, 9), (255, 255), ("9", 9), (2.7, 2), (2.0, 2)]
+
+
+def _driver() -> Any:
+    return g1.G1Driver(tool_name="g1", port="1.2.3.4")
+
+
+def _deliver(driver: Any, mode_machine: Any) -> None:
+    driver._on_lowstate(types.SimpleNamespace(imu_state=_IMU, mode_machine=mode_machine))
+
+
+class TestTheLayoutIdIsARead:
+    """A value that is not a number does not become an id the wire carries."""
+
+    @pytest.mark.parametrize(("label", "value"), _NOT_AN_ID, ids=[label for label, _ in _NOT_AN_ID])
+    def test_an_unreadable_id_keeps_the_last_one_that_parsed(self, label: str, value: Any) -> None:
+        driver = _driver()
+        _deliver(driver, 9)
+        _deliver(driver, value)
+        assert driver._mode_machine == 9, label
+
+    @pytest.mark.parametrize(("label", "value"), _NOT_AN_ID, ids=[label for label, _ in _NOT_AN_ID])
+    def test_an_unreadable_id_is_never_learned_in_the_first_place(self, label: str, value: Any) -> None:
+        """With no previous reading the gate's refusal stays honest."""
+        driver = _driver()
+        _deliver(driver, value)
+        assert driver._mode_machine is None, label
+
+    @pytest.mark.parametrize(("value", "expected"), _STILL_AN_ID, ids=[repr(v) for v, _ in _STILL_AN_ID])
+    def test_an_id_that_parses_is_still_taken(self, value: Any, expected: int) -> None:
+        """The control: the coercion did not stop reading real layout ids.
+
+        The float rows are the accepted boundary. ``int()`` truncated them and
+        so does the owner, deliberately - refusing them here would make this
+        decoder stricter than the Go2 on a value both used to accept.
+        """
+        driver = _driver()
+        _deliver(driver, value)
+        assert driver._mode_machine == expected
+
+    def test_a_later_reading_replaces_an_earlier_one(self) -> None:
+        """The control for keeping the previous value: it is not a latch."""
+        driver = _driver()
+        _deliver(driver, 9)
+        _deliver(driver, 10)
+        assert driver._mode_machine == 10
+
+    def test_the_imu_is_unaffected_either_way(self) -> None:
+        """The IMU is decoded independently, which this must not change."""
+        driver = _driver()
+        _deliver(driver, True)
+        assert driver._imu is not None
+        assert driver._imu["rpy"] == [0.1, -0.2, 0.3]
+        assert driver._imu["quaternion"] == [0.99, 0.01, 0.02, 0.03]
+
+
+class TestNoLowstateReadCarriesATypedDefault:
+    """Derived over the method, so a field added later joins the rule."""
+
+    @pytest.mark.parametrize("decoder", _DECODERS, ids=["g1", "go2"])
+    def test_every_field_read_defaults_to_none(self, decoder: Callable[..., None]) -> None:
+        defaulted = [
+            ast.unparse(node)
+            for node in ast.walk(ast.parse(textwrap.dedent(inspect.getsource(decoder))))
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "getattr"
+            and len(node.args) == 3
+            and not (isinstance(node.args[2], ast.Constant) and node.args[2].value is None)
+        ]
+        assert defaulted == [], f"a typed default makes an absent field look like a reading: {defaulted}"
+
+    @pytest.mark.parametrize("decoder", _DECODERS, ids=["g1", "go2"])
+    def test_the_scan_reaches_the_reads(self, decoder: Callable[..., None]) -> None:
+        """Non-vacuity: "no typed defaults" must not mean "no reads found"."""
+        reads = [
+            node
+            for node in ast.walk(ast.parse(textwrap.dedent(inspect.getsource(decoder))))
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "getattr"
+        ]
+        assert len(reads) >= 5, f"only {len(reads)} field reads found - the scan is looking in the wrong place"


### PR DESCRIPTION
Follow-up to #3379, which routed the four IMU vectors in `G1Driver._on_lowstate` through the shared telemetry coercers. The scalar decoded beside them in the same method was left on a bare `int()`.

`mode_machine` is the uint8 hardware-layout id, and it is the one value this method sends back out: `_build_lowcmd_from_action` and `_build_zero_torque_lowcmd` echo it on every frame, and the firmware drops a `LowCmd_` whose layout id does not match the one it announced. So an id built from something other than a number is a write the robot silently ignores.

## What changes

Measured through `_on_lowstate` on both trees:

| `LowState_.mode_machine` holds | before | after |
| --- | --- | --- |
| `9` | `9` | `9` |
| `"9"` | `9` | `9` |
| `2.7` | `2` | `2` |
| `True` | **`1`** | `None`, previous kept |
| `False` | **`0`** | `None`, previous kept |
| `b"\x09"` | raises into the shared `except` | `None`, previous kept |
| `"n/a"` | raises into the shared `except` | `None`, previous kept |

`1` and `0` are valid uint8 layout ids, so a flag on the field was indistinguishable from a reading. `telemetry_int` refuses both.

**A float is deliberately still truncated.** `telemetry_int(2.7) == 2` is the owner's own pinned answer - `(3.7, 3.7, 3, None, None)` in its rule table - and the Go2 accepts it too. Refusing it on the G1 alone would be exactly the drift #3376 removed, so it is pinned here as the accepted boundary rather than fixed.

A refused reading leaves `_mode_machine` at the last value that parsed, matching `_refresh_fsm_id` two ranges over: the layout id does not change while the robot is powered. Today the raise position produced that too, since `mode_machine` happens to be the last statement in the block - stating it keeps it true once a field is decoded after this one, which is what went wrong on the IMU side.

## Why the structural cell is an AST scan

#3379's `test_no_imu_read_carries_a_typed_default` searches the method text for `[0.0, 0.0, 0.0]` and `[1.0, 0.0, 0.0, 0.0]` after splitting off the docstring, which is a neat way to avoid the docstring quoting them. It cannot cover a field it does not know the constants for. Measured: rewriting the surviving read as `getattr(msg, "mode_machine", 0)` leaves that file's suite at **13 passed, 0 fires**. The AST scan here reports it by name, over the whole method and both Unitree drivers - so the Go2 is a passing control and this reads as the house rule rather than a G1 rule.

## Evidence

Four corners, `tests/drivers/` (base = 7c2ddc653):

| | main's `_on_lowstate` | this change |
| --- | --- | --- |
| existing tests | 2549 passed | 2549 passed |
| + the new file | **4 failed**, 18 passed | 2571 passed |

2549 + 22 = 2571, and the two right-hand cells agree, so no existing cell changed behaviour. The 4 failures are exactly the two `bool` spellings across the two refusal cells; the 18 that pass on main are the accepted boundary and the buffer/word rows, whose cached value is the same either way.

Mutation table against the new file (22 cells, `collected` stable on every row):

| mutation | fires |
| --- | --- |
| control | 0 |
| `mode_machine` back to a bare `int()` | 4 |
| a refused id clobbers the last good one | 5 |
| over-reach: every id refused | 12 |
| a typed default on the surviving read | **1** (the AST cell alone) |
| a typed default on the Go2 read | **1** (the AST cell alone) |

The over-reach row firing the accepted-boundary controls is what shows this refuses non-readings rather than narrowing what counts as an id. The last two rows firing one cell each are why the structural cell earns its lines.

## Size

`g1.py` +20/-2, of which **17 lines are docstring**: the executable statement count is unchanged at 558 by AST, so this is pure routing. Docs +14 in `docs/getting-started/robot-factory.md`, which #3379 did not touch - the section there covered the vectors a decoder publishes and now also covers the scalars it sends back out.

Gate: `ruff check` / `ruff format --check` clean over 1991 files, `mypy strands_robots tests tests_integ` 0 errors with no suppressions, `tests/drivers/` + the CodeQL-filter and docstring-xref graders 2623 passed, every `tests/test_docs*.py` plus the markdown-link grader 245 passed, changelog graders 91 passed.