### PR TITLE
fix(drivers): the Booster T1 snapshot reports an absent IMU field as absent

### DIFF
--- a/changelog.d/3381-booster-imu-sequence-default.md
+++ b/changelog.d/3381-booster-imu-sequence-default.md
@@ -1,0 +1,28 @@
+### Fixed: the Booster T1 snapshot reports an IMU field the robot never sent as absent
+
+`parse_low_state` read the T1's three IMU vectors off a sequence default --
+`[float(v) for v in getattr(imu, "rpy", []) or []]` -- while the function's own
+docstring promised the opposite: "absent fields are omitted rather than
+defaulted: a snapshot that reports a zeroed IMU the robot never sent is worse
+than one that reports none". Three consequences, all on one message:
+
+- A bytes-like value iterates. A `memoryview` or `bytes` field -- what a vendor
+  SDK hands over for a raw buffer -- decoded into a short vector of plausible
+  numbers (`memoryview(b"\x01\x02")` to `[1.0, 2.0]`), so the snapshot reported a
+  two-element attitude as a reading. A consumer then indexes `rpy[2]` for yaw and
+  gets an `IndexError` rather than a decidable absence.
+- One element that is not a number raised `TypeError` out of the comprehension
+  and past `parse_low_state`, discarding the joint, velocity, torque and
+  temperature arrays read off the same message.
+- A field the `LowState` does not declare landed `"rpy": []`, which is still a
+  present key. A caller cannot distinguish "the robot is not reporting attitude"
+  from "the robot reported an empty attitude".
+
+All three vectors now read through `telemetry_float_list` off a `None` default,
+the reader every other driver telemetry decode in the package already shares. A
+well-formed message decodes identically.
+
+The new pin is derived over the whole `strands_robots/drivers/` package rather
+than named per driver: any `getattr(msg, field, <sequence literal>)` is refused,
+so the next vector decode inherits the rule without anyone extending a list of
+module names.

--- a/strands_robots/drivers/booster.py
+++ b/strands_robots/drivers/booster.py
@@ -53,7 +53,7 @@ import threading
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any, cast
 
-from strands_robots.drivers.base import halt_failure_detail, undeclared_verb_error
+from strands_robots.drivers.base import halt_failure_detail, telemetry_float_list, undeclared_verb_error
 from strands_robots.tools.g1._g1_common import _DDS_INIT_LOCK
 from strands_robots.utils import boolean_flag_error, dds_domain_id_error, finite_number_error
 
@@ -326,9 +326,12 @@ def parse_low_state(msg: Any, state_field: str) -> dict[str, Any]:
             :data:`CMD_TYPE_STATE_FIELD`.
 
     Returns:
-        ``{"joints", "velocities", "torques", "temperatures", "imu"}``. Absent
-        fields are omitted rather than defaulted: a snapshot that reports a
-        zeroed IMU the robot never sent is worse than one that reports none.
+        ``{"joints", "velocities", "torques", "temperatures", "imu"}``. Each
+        IMU vector is read through
+        :func:`~strands_robots.drivers.base.telemetry_float_list`, so a field
+        the ``LowState`` does not carry lands ``None`` rather than a reading: a
+        snapshot that reports a zeroed IMU the robot never sent is worse than
+        one that reports none.
     """
     snapshot: dict[str, Any] = {}
     motors = getattr(msg, state_field, None) or []
@@ -339,9 +342,9 @@ def parse_low_state(msg: Any, state_field: str) -> dict[str, Any]:
     imu = getattr(msg, "imu_state", None)
     if imu is not None:
         snapshot["imu"] = {
-            "rpy": [float(v) for v in getattr(imu, "rpy", []) or []],
-            "gyro": [float(v) for v in getattr(imu, "gyro", []) or []],
-            "acc": [float(v) for v in getattr(imu, "acc", []) or []],
+            "rpy": telemetry_float_list(getattr(imu, "rpy", None)),
+            "gyro": telemetry_float_list(getattr(imu, "gyro", None)),
+            "acc": telemetry_float_list(getattr(imu, "acc", None)),
         }
     return snapshot
 

--- a/tests/drivers/test_driver_telemetry_vectors_are_never_read_off_a_sequence_default.py
+++ b/tests/drivers/test_driver_telemetry_vectors_are_never_read_off_a_sequence_default.py
@@ -1,0 +1,122 @@
+"""A driver reads a telemetry vector off ``None``, never off a sequence default.
+
+``getattr(msg, field, <sequence literal>)`` cannot fail, and the literal it
+yields has the exact shape of a reading - so a firmware layout that does not
+declare that name publishes a constant shaped like telemetry for as long as the
+robot runs.  :func:`~strands_robots.drivers.base.telemetry_float_list` and its
+integer sibling are the one owner of that decision: a field the message does not
+carry, or carries as something that is not a vector of numbers, lands ``None``.
+
+This pins the Booster T1's ``LowState`` snapshot - the last read in the package
+still taken off a sequence default - and then derives the rule over the whole
+``drivers/`` package, so the next vector decode cannot reintroduce one.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import types
+from typing import Any
+
+import pytest
+
+import strands_robots.drivers as drivers_package
+from strands_robots.drivers.booster import parse_low_state
+
+#: A humanoid mid-fall.  Every value is distinguishable from an empty vector and
+#: from what a bytes-like field would iterate into.
+_IMU: dict[str, Any] = {
+    "rpy": [0.30, -0.10, 1.57],
+    "gyro": [0.01, 0.02, 0.03],
+    "acc": [0.10, 0.20, 9.81],
+}
+
+#: Values that are not a vector reading, whatever they iterate as.  The
+#: bytes-like members matter most: a raw SDK buffer iterates into small plausible
+#: numbers, so it used to decode into a short vector of the right dtype.
+_NON_READINGS: tuple[Any, ...] = (
+    memoryview(b"\x01\x02"),
+    b"\x01\x02",
+    "0.1,0.2,0.3",
+    [0.30, None, 1.57],
+    4.0,
+)
+
+
+def _snapshot(imu: dict[str, Any]) -> dict[str, Any]:
+    """Read one ``LowState`` whose ``imu_state`` declares exactly ``imu``'s keys.
+
+    Args:
+        imu: The IMU fields the message carries.  A key absent here is a field
+            the firmware never declared.
+
+    Returns:
+        The ``"imu"`` sub-record of the parsed snapshot.
+    """
+    state = types.SimpleNamespace(
+        motor_state_parallel=[types.SimpleNamespace(q=0.0, dq=0.0, tau_est=0.0, temperature=0.0)],
+        imu_state=types.SimpleNamespace(**imu),
+    )
+    record: dict[str, Any] = parse_low_state(state, "motor_state_parallel")["imu"]
+    return record
+
+
+class TestAVectorTheLowStateDoesNotCarryIsAbsentFromTheSnapshot:
+    """The docstring's own promise: it reports none rather than a zeroed IMU."""
+
+    @pytest.mark.parametrize("field", sorted(_IMU))
+    def test_a_dropped_field_is_none(self, field: str) -> None:
+        """Not ``[]``, which is a present key a consumer indexes into."""
+        record = _snapshot({k: v for k, v in _IMU.items() if k != field})
+        assert record[field] is None
+        assert {k: record[k] for k in _IMU if k != field} == {k: v for k, v in _IMU.items() if k != field}
+
+    def test_a_well_formed_message_is_unchanged(self) -> None:
+        """The fix costs the good path nothing."""
+        assert _snapshot(dict(_IMU)) == _IMU
+
+
+class TestAValueThatIsNoReadingIsNotDecodedIntoAPlausibleVector:
+    """Bytes-like and part-numeric values iterate; that does not make them readings."""
+
+    @pytest.mark.parametrize("value", _NON_READINGS, ids=lambda v: type(v).__name__)
+    def test_the_field_reads_as_absent(self, value: Any) -> None:
+        assert _snapshot({**_IMU, "acc": value})["acc"] is None
+
+    @pytest.mark.parametrize("value", _NON_READINGS, ids=lambda v: type(v).__name__)
+    def test_it_costs_only_its_own_field(self, value: Any) -> None:
+        """A raise from inside one comprehension used to cost the whole snapshot.
+
+        ``float(None)`` raised out of ``parse_low_state`` and past its caller, so
+        one malformed element discarded the joint, velocity, torque and
+        temperature arrays read off the same message.
+        """
+        record = _snapshot({**_IMU, "acc": value})
+        assert record["rpy"] == _IMU["rpy"]
+        assert record["gyro"] == _IMU["gyro"]
+
+
+def test_no_driver_reads_a_telemetry_field_from_a_sequence_default() -> None:
+    """Derived over the package rather than named per driver.
+
+    A driver that adds a vector decode inherits the rule without anyone
+    remembering to extend a list of module names.
+    """
+    sequences = (ast.List, ast.Tuple, ast.Dict, ast.Set, ast.ListComp, ast.SetComp, ast.DictComp)
+    root = pathlib.Path(str(drivers_package.__file__)).parent
+    scanned = sorted(root.rglob("*.py"))
+    assert len(scanned) > 10, f"read the installed package, not a stale path: {root}"
+    offenders = [
+        f"{path.relative_to(root)}:{node.lineno}: {ast.unparse(node)}"
+        for path in scanned
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8")))
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "getattr"
+            and len(node.args) == 3
+            and isinstance(node.args[2], sequences)
+        )
+    ]
+    assert offenders == []


### PR DESCRIPTION
A Booster T1 `LowState` field the SDK does not hand over as a float triple was reported as a **reading**: an empty vector, or -- when the field arrives as a raw buffer -- a plausible two-element attitude. `parse_low_state` was the last vector read in `strands_robots/drivers/` still taken off a sequence default.

![the snapshot reports a two-element attitude while the trunk rolls to -1.10 rad](https://raw.githubusercontent.com/cagataycali/robots/assets/booster-imu-34413395480/booster_imu_sequence_default.png)

*MuJoCo (headless, EGL) drops the T1 with a lateral shove at the trunk; the trace is what `parse_low_state` actually returned, replayed at 50 Hz through both trees. From t=1.0s the SDK hands `imu_state.rpy` over as a `memoryview`. Before: **51/51 faulted samples published `[1.0, 2.0]`** while the true roll ran to -1.10 rad. After: 51/51 absent.*

## The read

```python
# before - getattr with a default cannot fail, and a bytes-like value still iterates
"rpy":  [float(v) for v in getattr(imu, "rpy",  []) or []],
"gyro": [float(v) for v in getattr(imu, "gyro", []) or []],
"acc":  [float(v) for v in getattr(imu, "acc",  []) or []],

# after - the shared reader, off None
"rpy":  telemetry_float_list(getattr(imu, "rpy", None)),
...
```

## Measured, the snapshot's `"imu"` record

| `imu_state.acc` carries | before | after |
|---|---|---|
| `[0.1, 0.2, 9.81]` | correct | **unchanged** |
| the field is renamed away | `acc=[]` -- a present key | `acc=None` |
| `memoryview(b"\x01\x02")` (a raw buffer) | `acc=[1.0, 2.0]` | `acc=None` |
| `b"\x01\x02"` | `acc=[1.0, 2.0]` | `acc=None` |
| `"0.1,0.2,0.3"` | `acc=[]`, then `ValueError` per char | `acc=None` |
| `[0.30, None, 1.57]` | **whole snapshot lost** | `acc=None`, `rpy`/`gyro` kept |
| `4.0` | `TypeError` past the function | `acc=None` |

Three distinct failures on one message:

- **A bytes-like value iterates.** `memoryview`/`bytes` -- what a vendor SDK hands over for a raw buffer -- decoded into a short vector of plausible numbers, reported as an attitude. The vector is length 2, so a consumer reading `rpy[2]` for yaw gets an `IndexError` rather than a decidable absence.
- **One bad element cost the whole message.** `float(None)` raised out of the comprehension and past `parse_low_state`, discarding the joint, velocity, torque and temperature arrays read off the same `LowState`.
- **`[]` is a present key.** A caller cannot distinguish "not reporting attitude" from "reported an empty attitude".

## The function's own docstring said so

| where | what it says |
|---|---|
| `parse_low_state`, one line above the read | "absent fields are omitted rather than defaulted: a snapshot that reports a zeroed IMU the robot never sent is worse than one that reports none" |
| `telemetry_float_list` | refuses bytes-like, and is all-or-nothing "because half a quaternion is worse than no quaternion" |
| `Go2Driver._on_lowstate`, `G1Driver._on_lowstate` (#3379) | both read their IMU vectors through the same function |

#3379 quotes the first row as evidence its G1 fix is right. This is the file that sentence was written in.

## Tests

`tests/drivers/test_driver_telemetry_vectors_are_never_read_off_a_sequence_default.py`, 15 cells. On `main` + this file alone: **12 failed, 3 passed**. After: **15 passed**.

The last cell is derived over the whole `strands_robots/drivers/` package rather than named per driver -- any `getattr(msg, field, <sequence literal>)` is refused -- so the next vector decode inherits the rule without anyone extending a list of module names. On `main` it reports exactly `booster.py:342`, `343`, `344`.

Mutations, each run:

| mutation | cells |
|---|---|
| the fix reverted | 12 |
| routed through the reader but the `[]` default kept | 4 |
| only `rpy` routed, `gyro`/`acc` left on defaults | 11 |
| reader result defaulted back (`... or []`) | 8 |

Row 2 is why the pin reads the `getattr` too: `telemetry_float_list([])` is `[]`, so using the shared function is not sufficient if the default stays.

## Gate

`ruff check` + `ruff format --check` clean on `strands_robots tests tests_integ`; `mypy` clean (1937 files). Full suite on this head: **52231 passed, 304 skipped, 0 failed** (28m09s).

LOC: `booster.py` executable statements **358 -> 358**; +3 raw lines, all docstring. No new helper -- the shared reader already exists and is now imported here.

Vector width stays out of scope, as in #3379: no driver validates it, and imposing it on one would re-open the drift #3376 closed.