### PR TITLE
fix(drivers/g1): a lidar field the message does not carry is None, not a fault code or a zero-point cloud

### DIFF
--- a/changelog.d/3382-g1-lidar-fields-are-readings.md
+++ b/changelog.d/3382-g1-lidar-fields-are-readings.md
@@ -1,0 +1,42 @@
+### Fixed: a G1 lidar field the message does not carry is `None`, not a fault code or a zero-point cloud
+
+`G1Driver._on_lidar_state` and `G1Driver._on_lidar_cloud` were the last two
+Unitree telemetry decoders still reading their fields with typed `getattr`
+defaults and a bare `int()` / `float()`, after `_on_lowstate` moved its IMU
+vectors and layout id onto the shared coercers in `strands_robots.drivers.base`.
+A typed default is a well-formed value, and every one of these was shaped like a
+reading. Measured through the decoders:
+
+| the message carries | before | after |
+| --- | --- | --- |
+| no `error_state` | `code=-1`, `code_text="-1 (unknown)"` | `None`, `None` |
+| `error_state=False` | `code=0`, `code_text="False (OK)"` | `None`, `None` |
+| `error_state="3"` | `code=3`, `code_text="'3'"` | `3`, `"3 (unknown)"` |
+| `error_state=b"\x03"` | raises; the whole frame is dropped | `None`, rates kept |
+| no `cloud_frequency` | `freq=0.0` | `None` |
+| no `width` | `count=0`, `width=0` | `None`, `None` |
+| no header at all | a zero-point cloud | every field `None` |
+| `width="n/a"` | raises; the whole frame is dropped | `width=None`, `height` kept |
+
+`-1` renders as a fault code, `0.0` on `cloud_frequency` is a unit that has
+stopped scanning, and `int(False)` is `0`, the one code `ERR_CODES` renders as
+`OK` - a healthy lidar fabricated from a flag. A `width` of `0` is a zero-point
+cloud, which the summary's own docstring names as the shape of the fault `count`
+exists to show. Both consuming verbs, `g1_lidar_state` and `g1_lidar_summary`,
+already documented every field as "or `None`"; the writers made that unreachable
+for any driver that had received a message.
+
+`code_text` now renders the coerced `code` rather than the raw field, so the two
+describe one reading; a code that is no reading has no text. `count` needs both
+dimensions and is `None` when either is. An unreadable field costs that field
+and not the frame, matching what `_on_lowstate` does for its vectors.
+
+`tests/drivers/test_g1_lidar_fields_are_readings_too.py` pins the rows above,
+that neither decoder needs its `except` for a frame of non-readings, and widens
+the structural scan from `_on_lowstate` alone to every `_on_*` decoder on both
+Unitree drivers - no typed `getattr` default, no bare `int()` / `float()` - so
+the six already on the rule are passing controls and a decoder added later is
+held to it.
+
+Pure routing: `g1.py` loses one executable statement (a local the record now
+computes inline).

--- a/strands_robots/drivers/g1.py
+++ b/strands_robots/drivers/g1.py
@@ -1452,22 +1452,31 @@ class G1Driver:
 
         The names read here are the ones ``LidarState_`` declares: the MID-360
         reports its fault code as ``error_state`` and its scan rate as
-        ``cloud_frequency``. Reading a name the IDL does not define is
-        indistinguishable from a healthy reading in this record, because
-        ``getattr``'s default is what lands in it - so a unit whose lidar had
-        faulted would publish ``code=-1`` and ``freq=0.0`` for as long as it
-        ran, and the fleet card would read that as "no reading yet".
+        ``cloud_frequency``. Each is read as ``getattr(msg, name, None)`` and
+        coerced by :func:`~strands_robots.drivers.base.telemetry_int` /
+        :func:`~strands_robots.drivers.base.telemetry_float`, the rule every
+        other decoder in this class follows, so a name the message does not
+        carry lands ``None`` for that key rather than a constant shaped like a
+        reading. The typed defaults this read used to carry were all such
+        constants: ``-1`` renders as a fault code, ``0.0`` on ``cloud_frequency``
+        is a unit that has stopped scanning, and ``int(False)`` on
+        ``error_state`` is ``0``, which :func:`decode_code` renders as ``OK`` - a
+        healthy lidar fabricated from a flag. ``g1_lidar_state`` documents every
+        field as "or ``None``", and this is what makes that reachable once a
+        message has arrived.
 
-        ``error_state`` is read once and used for both the numeric code and its
-        rendered text so the two cannot come to describe different fields.
+        ``code_text`` renders the coerced ``code``, not the raw field, so the
+        two describe one reading: a numeric string on the field used to publish
+        ``code=3`` beside ``code_text="'3'"``. A code that is no reading has no
+        text.
         """
         try:
-            error_state = getattr(msg, "error_state", -1)
+            code = telemetry_int(getattr(msg, "error_state", None))
             self._lidar_state = {
-                "code": int(error_state),
-                "code_text": decode_code(error_state),
-                "freq": float(getattr(msg, "cloud_frequency", 0.0)),
-                "sys_rotation_speed": float(getattr(msg, "sys_rotation_speed", 0.0)),
+                "code": code,
+                "code_text": None if code is None else decode_code(code),
+                "freq": telemetry_float(getattr(msg, "cloud_frequency", None)),
+                "sys_rotation_speed": telemetry_float(getattr(msg, "sys_rotation_speed", None)),
                 "t": time.time(),
             }
         except Exception as exc:  # noqa: BLE001
@@ -1488,17 +1497,25 @@ class G1Driver:
         for a cap to apply to. ``count`` is therefore the cloud's true size: a
         MID-360 that drops from 24000 points to 3000 is reporting a fault, and
         clamping the number would hide exactly that.
+
+        For the same reason a header field the message does not carry is
+        ``None``, not ``0``. Each is read as ``getattr(msg, name, None)`` and
+        coerced by :func:`~strands_robots.drivers.base.telemetry_int`, so a
+        renamed ``width`` reports no reading rather than a zero-point cloud -
+        which is precisely the shape of the fault ``count`` exists to show.
+        ``count`` needs both dimensions, so it is ``None`` when either is; a
+        field that is unreadable costs that field, not the frame, so the header
+        fields that did parse still reach the record.
         """
         try:
-            width = int(getattr(msg, "width", 0))
-            height = int(getattr(msg, "height", 0))
-            count = width * height
+            width = telemetry_int(getattr(msg, "width", None))
+            height = telemetry_int(getattr(msg, "height", None))
             self._lidar_summary = {
-                "count": count,
+                "count": None if width is None or height is None else width * height,
                 "width": width,
                 "height": height,
-                "point_step": int(getattr(msg, "point_step", 0)),
-                "row_step": int(getattr(msg, "row_step", 0)),
+                "point_step": telemetry_int(getattr(msg, "point_step", None)),
+                "row_step": telemetry_int(getattr(msg, "row_step", None)),
                 "t": time.time(),
             }
         except Exception as exc:  # noqa: BLE001

--- a/tests/drivers/test_g1_lidar_fields_are_readings_too.py
+++ b/tests/drivers/test_g1_lidar_fields_are_readings_too.py
@@ -1,0 +1,252 @@
+"""The two G1 lidar decoders read their fields as readings, like every other decoder.
+
+``strands_robots.drivers.base`` owns the rule for what a telemetry field is:
+read it as ``getattr(msg, name, None)`` and coerce it through ``telemetry_int``
+/ ``telemetry_float``, so a name the message does not carry lands ``None``
+rather than a constant shaped like a reading. After the IMU vectors and the
+layout id in ``_on_lowstate`` moved onto that rule, the two lidar decoders were
+the only Unitree telemetry reads left on typed defaults and a bare ``int()`` /
+``float()``:
+
+* ``_on_lidar_state`` defaulted ``error_state`` to ``-1`` - which renders as a
+  fault code - and both rates to ``0.0``, a unit that has stopped scanning. And
+  ``int(False)`` is ``0``, which :data:`ERR_CODES` renders as ``OK``, so a flag
+  on the field published a healthy lidar. The rendered text was built from the
+  *raw* field, so a numeric string published ``code=3`` beside
+  ``code_text="'3'"``.
+* ``_on_lidar_cloud`` defaulted every header field to ``0``. A renamed
+  ``width`` therefore reported a zero-point cloud, which is precisely the shape
+  of the fault the summary's own docstring says ``count`` exists to show. And
+  a single unreadable header field raised inside the bare ``int()``, was
+  swallowed by the callback's ``except``, and dropped the frame's other fields.
+
+Both consuming verbs (``g1_lidar_state``, ``g1_lidar_summary``) already
+documented every field as "or ``None``"; the writers made that unreachable for
+any driver that had received a message.
+
+The structural cell widens the scan the layout-id fix introduced from
+``_on_lowstate`` alone to every ``_on_*`` decoder on both Unitree drivers, so
+the six that were already on the rule are passing controls and a decoder added
+later is held to it without anyone remembering to add a case.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import logging
+import textwrap
+import types
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from strands_robots.drivers import g1, go2
+from strands_robots.drivers.g1 import G1Driver
+from strands_robots.mesh.core import Mesh
+
+#: Every ``_on_*`` DDS decoder on both Unitree drivers, whose own source the
+#: structural cells read. Derived rather than listed so a new decoder enrols.
+_DECODERS: list[Callable[..., None]] = sorted(
+    (
+        member
+        for cls in (g1.G1Driver, go2.Go2Driver)
+        for name, member in vars(cls).items()
+        if name.startswith("_on_") and callable(member)
+    ),
+    key=lambda fn: fn.__qualname__,
+)
+
+#: Values that are not a reading of an integer field. The two ``bool``
+#: spellings are the rows that matter: ``int(False)`` is ``0`` and ``0`` is
+#: the one lidar code the response table renders as ``OK``.
+_NON_READINGS: list[tuple[str, Any]] = [
+    ("bool-false", False),
+    ("bool-true", True),
+    ("bytes", b"\x03"),
+    ("word", "n/a"),
+    ("none", None),
+]
+
+
+def _driver() -> G1Driver:
+    return G1Driver(tool_name="g1", port="1.2.3.4")
+
+
+def _state(**fields: Any) -> dict[str, Any]:
+    """Decode one ``LidarState_`` stand-in carrying only *fields* and return the record."""
+    driver = _driver()
+    driver._on_lidar_state(types.SimpleNamespace(**fields))
+    assert driver._lidar_state is not None, "the decoder wrote no record"
+    return driver._lidar_state
+
+
+def _summary(**fields: Any) -> dict[str, Any]:
+    """Decode one ``PointCloud2_`` header stand-in carrying only *fields* and return the record."""
+    driver = _driver()
+    driver._on_lidar_cloud(types.SimpleNamespace(**fields))
+    assert driver._lidar_summary is not None, "the decoder wrote no record"
+    return driver._lidar_summary
+
+
+_HEALTHY_RATES = {"cloud_frequency": 10.0, "sys_rotation_speed": 3600.0}
+_FULL_HEADER = {"width": 24000, "height": 1, "point_step": 16, "row_step": 24000 * 16}
+
+
+class TestTheLidarStateFieldsAreReadings:
+    """``error_state`` and the two rates land ``None`` when they are no reading."""
+
+    def test_an_absent_fault_code_is_not_a_fault(self) -> None:
+        """Pre-fix: ``code=-1``, rendered ``"-1 (unknown)"``, from a field that was not there."""
+        record = _state(**_HEALTHY_RATES)
+        assert record["code"] is None
+        assert record["code_text"] is None
+
+    @pytest.mark.parametrize(("label", "value"), _NON_READINGS, ids=[label for label, _ in _NON_READINGS])
+    def test_a_fault_code_that_is_no_reading_is_none(self, label: str, value: Any) -> None:
+        """``False`` used to publish ``code=0`` beside ``"False (OK)"`` - a healthy lidar from a flag."""
+        record = _state(error_state=value, **_HEALTHY_RATES)
+        assert record["code"] is None
+        assert record["code_text"] is None
+
+    def test_an_unreadable_code_costs_that_field_not_the_frame(self) -> None:
+        """The rates that arrived in the same message still reach the record."""
+        record = _state(error_state=b"\x03", **_HEALTHY_RATES)
+        assert record["freq"] == pytest.approx(10.0)
+        assert record["sys_rotation_speed"] == pytest.approx(3600.0)
+
+    def test_the_rendered_text_describes_the_coerced_code(self) -> None:
+        """A numeric string used to publish ``code=3`` beside ``code_text="'3'"``."""
+        record = _state(error_state="3", **_HEALTHY_RATES)
+        assert record["code"] == 3
+        assert record["code_text"].startswith("3 ")
+
+    def test_a_real_fault_and_a_real_ok_still_read_as_such(self) -> None:
+        assert _state(error_state=3, **_HEALTHY_RATES)["code_text"].startswith("3 ")
+        assert "OK" in _state(error_state=0, **_HEALTHY_RATES)["code_text"]
+
+    @pytest.mark.parametrize("field", ["cloud_frequency", "sys_rotation_speed"])
+    def test_an_absent_rate_is_not_a_stopped_unit(self, field: str) -> None:
+        """Pre-fix an absent rate published ``0.0``: a lidar that has stopped scanning."""
+        rates = {name: value for name, value in _HEALTHY_RATES.items() if name != field}
+        record = _state(error_state=0, **rates)
+        key = "freq" if field == "cloud_frequency" else field
+        assert record[key] is None
+
+    @pytest.mark.parametrize("field", ["cloud_frequency", "sys_rotation_speed"])
+    def test_a_flag_on_a_rate_is_not_a_one_hertz_reading(self, field: str) -> None:
+        """``float(True)`` is ``1.0``; a flag on a rate field is not a rate."""
+        record = _state(error_state=0, **{**_HEALTHY_RATES, field: True})
+        key = "freq" if field == "cloud_frequency" else field
+        assert record[key] is None
+
+    def test_a_reading_that_is_no_reading_reaches_the_mesh_as_none(self) -> None:
+        """The record is published; the wire has to say "no reading" too."""
+        driver = _driver()
+        driver._on_lidar_state(types.SimpleNamespace(**_HEALTHY_RATES))
+        published = Mesh(driver, peer_id="neon")._read_lidar_state()
+        assert published is not None
+        assert published["code"] is None
+        assert published["freq"] == pytest.approx(10.0)
+
+
+class TestTheLidarHeaderFieldsAreReadings:
+    """Every ``PointCloud2_`` header field lands ``None`` when it is no reading."""
+
+    @pytest.mark.parametrize("field", sorted(_FULL_HEADER))
+    def test_an_absent_header_field_is_none_not_zero(self, field: str) -> None:
+        header = {name: value for name, value in _FULL_HEADER.items() if name != field}
+        assert _summary(**header)[field] is None
+
+    def test_an_absent_width_is_not_a_zero_point_cloud(self) -> None:
+        """Pre-fix: ``count=0``, the exact shape of the fault ``count`` exists to show."""
+        header = {name: value for name, value in _FULL_HEADER.items() if name != "width"}
+        assert _summary(**header)["count"] is None
+
+    def test_a_message_carrying_none_of_the_header_is_all_none(self) -> None:
+        record = _summary()
+        assert {key: record[key] for key in ("count", *_FULL_HEADER)} == dict.fromkeys(("count", *_FULL_HEADER))
+
+    @pytest.mark.parametrize(("label", "value"), _NON_READINGS, ids=[label for label, _ in _NON_READINGS])
+    def test_a_width_that_is_no_reading_is_none_and_so_is_the_count(self, label: str, value: Any) -> None:
+        """``int(True)`` is ``1``: a flag on ``width`` used to publish a one-point cloud."""
+        record = _summary(**{**_FULL_HEADER, "width": value})
+        assert record["width"] is None
+        assert record["count"] is None
+
+    def test_an_unreadable_field_costs_that_field_not_the_frame(self) -> None:
+        """Pre-fix the bare ``int()`` raised and the callback dropped the whole frame."""
+        record = _summary(**{**_FULL_HEADER, "width": "n/a"})
+        assert record["height"] == 1
+        assert record["point_step"] == 16
+        assert record["row_step"] == 24000 * 16
+
+    def test_a_full_frame_still_counts_width_times_height(self) -> None:
+        record = _summary(**{**_FULL_HEADER, "width": 640, "height": 480})
+        assert record["count"] == 640 * 480
+
+    def test_a_float_dimension_is_still_truncated(self) -> None:
+        """``telemetry_int(2.7) == 2`` is the owner's pinned answer; grading it here would be drift."""
+        assert _summary(**{**_FULL_HEADER, "width": 2.7})["width"] == 2
+
+
+class TestNeitherDecoderRaisesOutOfTheCallback:
+    """The DDS thread must survive any frame, and nothing should need the ``except`` to."""
+
+    @pytest.mark.parametrize("decoder", ["_on_lidar_state", "_on_lidar_cloud"])
+    def test_a_frame_of_non_readings_is_decoded_without_a_swallowed_error(
+        self, decoder: str, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        driver = _driver()
+        frame = types.SimpleNamespace(
+            error_state=b"\x03",
+            cloud_frequency="n/a",
+            sys_rotation_speed=True,
+            width=None,
+            height="n/a",
+            point_step=b"\x10",
+            row_step=False,
+        )
+        with caplog.at_level(logging.DEBUG, logger=g1.logger.name):
+            getattr(driver, decoder)(frame)
+        assert not [
+            r for r in caplog.records if "decode failed" in r.getMessage() or "summary failed" in r.getMessage()
+        ]
+
+
+class TestEveryUnitreeDecoderReadsItsFieldsAsReadings:
+    """The house rule, derived over both drivers rather than stated per decoder."""
+
+    def test_the_derivation_found_the_decoders(self) -> None:
+        names = {fn.__qualname__ for fn in _DECODERS}
+        assert {"G1Driver._on_lidar_state", "G1Driver._on_lidar_cloud", "G1Driver._on_lowstate"} <= names
+        assert any(name.startswith("Go2Driver.") for name in names), "the Go2 control is missing"
+
+    @pytest.mark.parametrize("decoder", _DECODERS, ids=[fn.__qualname__ for fn in _DECODERS])
+    def test_every_field_read_defaults_to_none(self, decoder: Callable[..., None]) -> None:
+        """A typed default is a well-formed value, so it lands looking like a reading."""
+        tree = ast.parse(textwrap.dedent(inspect.getsource(decoder)))
+        reads = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "getattr"
+        ]
+        assert reads, f"{decoder.__qualname__} reads no field with getattr, so the scan grades nothing"
+        typed = [
+            ast.unparse(node)
+            for node in reads
+            if len(node.args) >= 3 and not (isinstance(node.args[2], ast.Constant) and node.args[2].value is None)
+        ]
+        assert typed == [], f"{decoder.__qualname__} reads a field with a typed default: {typed}"
+
+    @pytest.mark.parametrize("decoder", _DECODERS, ids=[fn.__qualname__ for fn in _DECODERS])
+    def test_no_field_is_coerced_with_a_bare_builtin(self, decoder: Callable[..., None]) -> None:
+        """``int()`` / ``float()`` accept a ``bool``; the shared coercers are the owner of the rule."""
+        tree = ast.parse(textwrap.dedent(inspect.getsource(decoder)))
+        bare = [
+            ast.unparse(node)
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id in {"int", "float"}
+        ]
+        assert bare == [], f"{decoder.__qualname__} coerces a field with a bare builtin: {bare}"

--- a/tests/drivers/test_g1_lidar_summary_describes_the_cloud.py
+++ b/tests/drivers/test_g1_lidar_summary_describes_the_cloud.py
@@ -207,7 +207,17 @@ class TestTheRestOfTheDriverIsUnchanged:
         assert driver._lidar_state["freq"] == pytest.approx(10.0)
 
     def test_a_malformed_cloud_message_is_still_swallowed(self) -> None:
-        """The DDS thread must survive a bad frame rather than tear down."""
+        """The DDS thread must survive a bad frame rather than tear down.
+
+        The unreadable field costs that field, not the frame: ``width`` lands
+        ``None`` and so does the ``count`` that needs it, while the ``height``
+        that did parse still reaches the record. Before the header fields read
+        through the shared coercer the bare ``int()`` raised here and the whole
+        frame was dropped, so this asserted that no record was written.
+        """
         driver = G1Driver(tool_name="g1", port="1.2.3.4")
         driver._on_lidar_cloud(types.SimpleNamespace(width="not a number", height=1))
-        assert driver._lidar_summary is None
+        assert driver._lidar_summary is not None
+        assert driver._lidar_summary["width"] is None
+        assert driver._lidar_summary["count"] is None
+        assert driver._lidar_summary["height"] == 1


### PR DESCRIPTION
Follow-up to #3376 / #3379 / #3380, which moved the Unitree telemetry reads onto the shared coercers in `strands_robots.drivers.base`. Two decoders in the same class were left behind: `G1Driver._on_lidar_state` and `G1Driver._on_lidar_cloud` still read every field with a typed `getattr` default and coerce it with a bare `int()` / `float()`. Derived over both drivers rather than asserted: of the 8 `_on_*` decoders on `G1Driver` and `Go2Driver`, these two carry all 7 typed defaults and all 7 bare builtin coercions in the set; the other 6 carry 0 of each.

Every one of those defaults is a well-formed value shaped like a reading, and `_on_lidar_state`'s own docstring already argued that this is the failure mode ("`getattr`'s default is what lands in it") -- it fixed the *names* read and left the defaults in place. Both consuming verbs, `g1_lidar_state` and `g1_lidar_summary`, document every field as "or `None`"; the writers made that unreachable once a message had arrived.

## What changes

Measured through the decoders on both trees (`t` elided):

| the message carries | before | after |
| --- | --- | --- |
| no `error_state` | `code=-1`, `code_text="-1 (unknown)"` | `None`, `None` |
| `error_state=False` | `code=0`, `code_text="False (OK)"` | `None`, `None` |
| `error_state=True` | `code=1`, `code_text="True (unknown)"` | `None`, `None` |
| `error_state="3"` | `code=3`, `code_text="'3'"` | `3`, `"3 (unknown)"` |
| `error_state=b"\x03"` | raises; **whole frame dropped**, rates lost | `None`, `None`; rates kept |
| no `cloud_frequency` | `freq=0.0` | `freq=None` |
| `cloud_frequency=True` | `freq=1.0` | `freq=None` |
| no `width` | `count=0`, `width=0` | `None`, `None`; `height` kept |
| no header at all | `count=0, width=0, height=0, point_step=0, row_step=0` | every field `None` |
| `width=True, height=True` | `count=1` (a one-point cloud) | `None`, `None` |
| `width="n/a"` | raises; **whole frame dropped** | `width=None`, `count=None`; `height` kept |
| `width=2.7` | `2` | `2` |

Three distinct failures, each with a row above:

- **A typed default is a reading.** `-1` renders as a fault code. `0.0` on `cloud_frequency` is a lidar that has stopped scanning. `count=0` is a zero-point cloud, which `_on_lidar_cloud`'s docstring names as precisely the shape of the fault `count` exists to show ("a MID-360 that drops from 24000 points to 3000 is reporting a fault").
- **`int(False)` is `0`, and `0` is `OK`.** `ERR_CODES[0] == "OK"` and `isinstance(False, int)` holds, so a flag on `error_state` published `code=0` beside `"False (OK)"`: a healthy lidar fabricated from a value that was no reading. `telemetry_int` refuses `bool`.
- **`code_text` described a different value than `code`.** The docstring said one read feeds both "so the two cannot come to describe different fields" -- but `code` went through `int()` and `code_text` through `decode_code(raw)`, so a numeric string gave `3` beside `"'3'"`. `code_text` now renders the *coerced* code; a code that is no reading has no text.

A fourth is structural rather than a value: the bare builtin raised on anything non-numeric, the callback's `except` swallowed it, and the frame's other fields were lost with the last record left standing -- the same shape #3379 removed from the IMU read.

**A float is deliberately still truncated** (`width=2.7 -> 2`). That is `telemetry_int`'s own pinned answer and the Go2 accepts it; refusing it on the lidar alone would be the drift #3376 removed. Pinned as the accepted boundary.

## Evidence

Four corners, `tests/drivers/`, base = `8303a4c` (#3380's squash), `[dev]` env:

| | `main`'s decoders | this change |
| --- | --- | --- |
| existing tests | 2448 passed | 2448 passed |
| + the new file | **31 failed**, 16 passed | 2495 passed |

2448 + 47 = 2495, and the two right-hand cells agree, so no existing cell changed verdict except the one described under *Size*. The 16 that pass on `main` are the controls: the 12 structural cells on the six decoders already on the rule, the derivation cell, the real-fault/real-OK cell, the full-frame count and the float boundary. 47 failures in both columns are this env's standing `lerobot`/`mujoco`-absent cells, byte-identical node ids on both trees.

Mutation table against the new file (47 cells, `collected` stable on every row):

| mutation | fires |
| --- | --- |
| control | 0 |
| `error_state` back to `int(getattr(..., -1))` | 11 |
| `freq` back to `float(getattr(..., 0.0))` | 5 |
| `count` zero-fills a missing dimension (`(width or 0) * (height or 0)`) | 7 |
| `code_text` rendered from the raw field again | 7 |
| an unreadable `width` drops the frame (`if width is None: return`) | 9 |
| a typed default on one **Go2** read | **1** (the structural cell alone) |
| a bare `int()` on one `_on_pressure` read | **1** (the structural cell alone) |

The last two rows are why the structural scan is widened: #3380's scan covers `_on_lowstate` only, and the defect here lived two methods down from it. The new scan derives every `_on_*` decoder from both driver classes, so a decoder added later enrols without a list being extended.

## Size

`g1.py` +36/-19, of which the executable statement count goes **558 -> 557** by AST (the `count` local is computed inline). Everything else in that file's diff is the two docstrings, which now state the rule instead of arguing around it. No docs change: `docs/getting-started/robot-factory.md:166-175` already states the convention this brings the last two decoders under, and nothing in `docs/` described the lidar defaults.

One existing cell moved, in `test_g1_lidar_summary_describes_the_cloud.py`: `test_a_malformed_cloud_message_is_still_swallowed` asserted `_lidar_summary is None` after `width="not a number"`, which was the *observable consequence* of the raise it was written to survive rather than its intent (the docstring: "the DDS thread must survive a bad frame"). It still asserts the frame is swallowed, and now also that the unreadable field costs that field (`width`, `count` are `None`) and not the frame (`height == 1`).

Gate: `ruff check` / `ruff format --check` clean over 1992 files; `mypy` clean on the three touched Python files; the 119-grader whole-tree roster minus the two `lerobot`-import graders has a failure set byte-identical to the pristine base (all `mujoco`/`lerobot`/`torch`-absent); docstring xref, changelog, unicode-dash and ASCII-log graders 671 passed.