### PR TITLE
fix(drivers): a Booster T1 field the frame does not carry is not a zero reading

### DIFF
--- a/changelog.d/3383-booster-telemetry-absence-is-not-a-reading.md
+++ b/changelog.d/3383-booster-telemetry-absence-is-not-a-reading.md
@@ -1,0 +1,58 @@
+### Fixed: a Booster T1 field the frame does not carry is not a zero reading
+
+`parse_low_state` documents the rule - "absent fields are omitted rather than
+defaulted: a snapshot that reports a zeroed IMU the robot never sent is worse
+than one that reports none" - and none of its reads applied it. Every field was
+`float(getattr(motor, <field>, 0.0))` or
+`[float(v) for v in getattr(imu, <field>, []) or []]`, and `_on_battery` read its
+three the same way. Measured through the decoders, all 60 cells of field x
+non-reading reported a value the frame did not carry:
+
+| the frame | before | after |
+| --- | --- | --- |
+| `q` renamed or dropped | all 23 joints at `0.0` | `joints=None` |
+| `q` arrives as a flag | all 23 joints at `1.0` | `joints=None` |
+| `rpy` renamed | `[]` - an empty attitude | `rpy=None` |
+| `rpy` is a `memoryview` | `[1.0, 2.0]` - a two-element attitude | `rpy=None` |
+| `acc` is a `bytearray` | `[1.0, 2.0]` | `acc=None` |
+| `soc` renamed | `battery_pct=0.0` - an empty pack | `battery_pct=None` |
+| `soc` arrives as a flag | `battery_pct=1.0` - a one-percent pack | `battery_pct=None` |
+
+The `battery_pct` rows are what `get_status` already reads for: it publishes
+`battery.get("pct")`, so it was written to report `None` for a T1 that reported
+no charge, and the writer made that unreachable.
+
+The `joints` row moves the robot rather than only misreporting it. It is the
+hold source - `send_action` reads it as `held_q` and `build_frame` writes
+`held_q[slot]` as the position target of every *uncommanded* upper-body joint. A
+full-width vector of defaulted zeros is finite and non-empty, so it passed both
+of `_on_low_state`'s guards, was cached, and the next write commanded all eight
+arm joints to exactly zero. Measured end to end on a frame whose `q` was
+renamed: before, `send_action` returned `status=success` and published one
+`LowCmd` collapsing the arms out of the pose the robot was holding; after, it
+returns the refusal the driver already spells for this case ("no LowState frame
+has arrived yet, so neither the frame width nor the hold position of an
+uncommanded arm joint is known") and publishes nothing.
+
+Coercion was also per *message* rather than per field, so one unreadable value
+discarded every field beside it. An `rpy` that raised in `float()` cost the
+positions in the same frame, leaving `_last_state` on the previous one - a
+staleness that reads as a dropped wire rather than as one renamed field.
+
+The driver now reads through the owner of this rule.
+`strands_robots.drivers.base.telemetry_float` and `telemetry_float_list` decide
+what counts as a reading for the Unitree drivers, including the two rows neither
+of *those* copies guarded before they converged, and the T1 reads through the
+same functions - so a value one driver refuses cannot be a reading on another.
+The record keeps the shape those drivers use - the key stays and the value is
+`None` - so a consumer asking for a field always gets an answer and the answer
+can be "the robot did not report this". The three field maps are named
+(`MOTOR_STATE_FIELDS`, `IMU_STATE_FIELDS`, `BATTERY_STATE_FIELDS`) so the read is
+derived once rather than restated per field, and the vectors stay all-or-nothing
+because `held_q` is indexed by slot: a vector short one element would renumber
+every slot after the gap and hold the wrong joint at each of them.
+
+`tests/drivers/test_booster_telemetry_absence_is_not_a_reading.py` pins the rule
+as a table derived from those maps, the frame surviving one bad field, the hold
+source end to end, and a derivation that refuses a typed default returning to the
+module.

--- a/changelog.d/3383-booster-telemetry-absence-is-not-a-reading.md
+++ b/changelog.d/3383-booster-telemetry-absence-is-not-a-reading.md
@@ -2,19 +2,16 @@
 
 `parse_low_state` documents the rule - "absent fields are omitted rather than
 defaulted: a snapshot that reports a zeroed IMU the robot never sent is worse
-than one that reports none" - and none of its reads applied it. Every field was
-`float(getattr(motor, <field>, 0.0))` or
-`[float(v) for v in getattr(imu, <field>, []) or []]`, and `_on_battery` read its
-three the same way. Measured through the decoders, all 60 cells of field x
-non-reading reported a value the frame did not carry:
+than one that reports none". #3381 applied it to the three IMU vectors; the four
+motor vectors were still `float(getattr(motor, <field>, 0.0))` and `_on_battery`
+read its three fields the same way, so the one function held two conventions.
+Measured through the decoders, all 42 cells of remaining field x non-reading
+reported a value the frame did not carry:
 
 | the frame | before | after |
 | --- | --- | --- |
 | `q` renamed or dropped | all 23 joints at `0.0` | `joints=None` |
 | `q` arrives as a flag | all 23 joints at `1.0` | `joints=None` |
-| `rpy` renamed | `[]` - an empty attitude | `rpy=None` |
-| `rpy` is a `memoryview` | `[1.0, 2.0]` - a two-element attitude | `rpy=None` |
-| `acc` is a `bytearray` | `[1.0, 2.0]` | `acc=None` |
 | `soc` renamed | `battery_pct=0.0` - an empty pack | `battery_pct=None` |
 | `soc` arrives as a flag | `battery_pct=1.0` - a one-percent pack | `battery_pct=None` |
 
@@ -35,15 +32,16 @@ has arrived yet, so neither the frame width nor the hold position of an
 uncommanded arm joint is known") and publishes nothing.
 
 Coercion was also per *message* rather than per field, so one unreadable value
-discarded every field beside it. An `rpy` that raised in `float()` cost the
-positions in the same frame, leaving `_last_state` on the previous one - a
-staleness that reads as a dropped wire rather than as one renamed field.
+discarded every field beside it. A `q` that raised in `float()` cost the
+velocities, torques and temperatures in the same frame, leaving `_last_state` on
+the previous one - a staleness that reads as a dropped wire rather than as one
+renamed field.
 
-The driver now reads through the owner of this rule.
-`strands_robots.drivers.base.telemetry_float` and `telemetry_float_list` decide
-what counts as a reading for the Unitree drivers, including the two rows neither
-of *those* copies guarded before they converged, and the T1 reads through the
-same functions - so a value one driver refuses cannot be a reading on another.
+The motor and battery reads now go through the owner of this rule, as the IMU
+reads already did. `strands_robots.drivers.base.telemetry_float` and
+`telemetry_float_list` decide what counts as a reading for the Unitree drivers,
+and the T1 reads every field through the same two functions - so a value one
+driver refuses cannot be a reading on another.
 The record keeps the shape those drivers use - the key stays and the value is
 `None` - so a consumer asking for a field always gets an answer and the answer
 can be "the robot did not report this". The three field maps are named

--- a/docs/getting-started/robot-factory.md
+++ b/docs/getting-started/robot-factory.md
@@ -188,6 +188,22 @@ That matters when a gate reads the cache: `mode_machine` gates every G1 motion w
 reads "lowstate has not delivered yet", which one unreadable frame should not make true of a robot
 whose lowstate is arriving.
 
+The coercion has to be *per field* for that to hold at the frame level too. A decoder that builds its
+whole record inside one `try` loses every field a message carried because one of them stopped reading,
+and the staleness that leaves behind looks like a dropped wire rather than one renamed field. The
+record keeps the key either way and lets the value be `None`, so a consumer asking for a field always
+gets an answer and the answer can be "the robot did not report this"; a frame in which *nothing* read
+is simply not cached, for the same reason a refused scalar does not clear its own cache.
+
+The rule matters most where a reading is also a *command* source. `BoosterDriver.send_action` holds
+every uncommanded upper-body joint at its last observed position, so the T1's `joints` vector is what
+the next `LowCmd` writes. A defaulted `0.0` there is finite and full-width, clears the "is this a
+frame" guards, gets cached, and gets commanded -- eight arm joints driven to exactly zero from a frame
+that carried no positions at all. Reporting the absence instead reaches the refusal the driver already
+spells for a robot that has reported nothing yet. All-or-nothing matters for the same reason: `held_q`
+is indexed by slot, so a vector short one element would renumber every slot after the gap and hold the
+wrong joint at each of them.
+
 Asking for a driver that is not there is refused, never quietly substituted:
 
 ```python

--- a/strands_robots/drivers/booster.py
+++ b/strands_robots/drivers/booster.py
@@ -53,7 +53,12 @@ import threading
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any, cast
 
-from strands_robots.drivers.base import halt_failure_detail, telemetry_float_list, undeclared_verb_error
+from strands_robots.drivers.base import (
+    halt_failure_detail,
+    telemetry_float,
+    telemetry_float_list,
+    undeclared_verb_error,
+)
 from strands_robots.tools.g1._g1_common import _DDS_INIT_LOCK
 from strands_robots.utils import boolean_flag_error, dds_domain_id_error, finite_number_error
 
@@ -136,6 +141,26 @@ UPPER_BODY_KD: float = 3.0
 CMD_TYPE_STATE_FIELD: dict[str, str] = {
     "parallel": "motor_state_parallel",
     "serial": "motor_state_serial",
+}
+
+#: The snapshot key each ``MotorState`` field lands under. Named so the read is
+#: derivable rather than restated four times, and so a test can grade the whole
+#: set from the driver's own table instead of a copy of it.
+MOTOR_STATE_FIELDS: dict[str, str] = {
+    "joints": "q",
+    "velocities": "dq",
+    "torques": "tau_est",
+    "temperatures": "temperature",
+}
+
+#: The vectors an ``ImuState`` carries, in snapshot order.
+IMU_STATE_FIELDS: tuple[str, ...] = ("rpy", "gyro", "acc")
+
+#: The snapshot key each ``BatteryState`` field lands under.
+BATTERY_STATE_FIELDS: dict[str, str] = {
+    "pct": "soc",
+    "voltage": "voltage",
+    "current": "current",
 }
 
 #: The fall states the T1 publishes, by the SDK's ``FallDownStateType`` member
@@ -326,26 +351,27 @@ def parse_low_state(msg: Any, state_field: str) -> dict[str, Any]:
             :data:`CMD_TYPE_STATE_FIELD`.
 
     Returns:
-        ``{"joints", "velocities", "torques", "temperatures", "imu"}``. Each
-        IMU vector is read through
-        :func:`~strands_robots.drivers.base.telemetry_float_list`, so a field
-        the ``LowState`` does not carry lands ``None`` rather than a reading: a
-        snapshot that reports a zeroed IMU the robot never sent is worse than
-        one that reports none.
+        :data:`MOTOR_STATE_FIELDS`' keys, plus ``"imu"`` keyed by
+        :data:`IMU_STATE_FIELDS` when the frame carried an ``ImuState``. Every
+        vector is read through
+        :func:`~strands_robots.drivers.base.telemetry_float_list`, so a field the
+        ``LowState`` does not carry lands ``None`` rather than a reading: a
+        snapshot that reports a zeroed IMU the robot never sent is worse than one
+        that reports none. The positions matter most, because they are also a
+        *command* source - a firmware revision that renames ``q`` must cost them
+        rather than turn them into a full set of joints at exactly zero, which is
+        the pose :meth:`BoosterDriver.send_action` would then hold every
+        uncommanded upper-body slot at. The vectors are all-or-nothing for the
+        same reason: ``held_q`` is indexed by slot, so a vector short one element
+        would renumber every slot after the gap.
     """
     snapshot: dict[str, Any] = {}
-    motors = getattr(msg, state_field, None) or []
-    snapshot["joints"] = [float(getattr(m, "q", 0.0)) for m in motors]
-    snapshot["velocities"] = [float(getattr(m, "dq", 0.0)) for m in motors]
-    snapshot["torques"] = [float(getattr(m, "tau_est", 0.0)) for m in motors]
-    snapshot["temperatures"] = [float(getattr(m, "temperature", 0.0)) for m in motors]
+    motors = list(getattr(msg, state_field, None) or [])
+    for key, field in MOTOR_STATE_FIELDS.items():
+        snapshot[key] = telemetry_float_list([getattr(motor, field, None) for motor in motors])
     imu = getattr(msg, "imu_state", None)
     if imu is not None:
-        snapshot["imu"] = {
-            "rpy": telemetry_float_list(getattr(imu, "rpy", None)),
-            "gyro": telemetry_float_list(getattr(imu, "gyro", None)),
-            "acc": telemetry_float_list(getattr(imu, "acc", None)),
-        }
+        snapshot["imu"] = {name: telemetry_float_list(getattr(imu, name, None)) for name in IMU_STATE_FIELDS}
     return snapshot
 
 
@@ -436,7 +462,7 @@ class BoosterDriver:
 
         self._cache_lock = threading.Lock()
         self._last_state: dict[str, Any] | None = None
-        self._battery: dict[str, float] | None = None
+        self._battery: dict[str, float | None] | None = None
         self._fall_state: str | None = None
 
     # ------------------------------------------------------------------ #
@@ -1005,15 +1031,26 @@ class BoosterDriver:
         *nothing* on it. A floor compared against an unverified scale is worse
         than no floor: on a 0..1 scale it refuses every frame, on a 0..100 scale
         it refuses none, and both look like a working safety check.
+
+        Each field is read per :data:`BATTERY_STATE_FIELDS` and coerced by
+        :func:`~strands_robots.drivers.base.telemetry_float`, so a field the
+        frame does not carry lands ``None`` rather than ``0.0``. That is what
+        makes :meth:`get_status`'s ``battery_pct`` reach a caller as ``None``
+        when the T1 reported no charge: a typed default would publish an empty
+        pack, and a ``soc`` that turned into a flag would publish a one-percent
+        one. Coercion is per field, so one unreadable field no longer discards
+        the two beside it. A frame in which *nothing* read is not cached, because
+        replacing a good record with three absences loses the last reading.
         """
+        reading: dict[str, float | None] = {}
         try:
-            reading = {
-                "pct": float(getattr(msg, "soc", 0.0)),
-                "voltage": float(getattr(msg, "voltage", 0.0)),
-                "current": float(getattr(msg, "current", 0.0)),
-            }
+            for key, field in BATTERY_STATE_FIELDS.items():
+                reading[key] = telemetry_float(getattr(msg, field, None))
         except (AttributeError, TypeError, ValueError):
             logger.debug("%s: unreadable BatteryState frame", self._tool_name, exc_info=True)
+            return
+        if all(value is None for value in reading.values()):
+            logger.debug("%s: BatteryState frame carried no readable field", self._tool_name)
             return
         with self._cache_lock:
             self._battery = reading

--- a/tests/drivers/test_booster_driver.py
+++ b/tests/drivers/test_booster_driver.py
@@ -246,12 +246,22 @@ class _FakeSdk:
         return self.fall
 
 
-@pytest.fixture
-def sdk(monkeypatch: pytest.MonkeyPatch) -> _FakeSdk:
-    """Install the SDK double under the name the driver imports."""
+def install_booster_sdk(monkeypatch: pytest.MonkeyPatch) -> _FakeSdk:
+    """Install the SDK double under the name the driver imports.
+
+    The fixture body, as a plain function: a fixture cannot be imported into a
+    sibling module without shadowing it, so a suite that needs the same double
+    calls this from its own fixture.
+    """
     fake = _FakeSdk()
     monkeypatch.setitem(sys.modules, "booster_robotics_sdk_python", fake)
     return fake
+
+
+@pytest.fixture
+def sdk(monkeypatch: pytest.MonkeyPatch) -> _FakeSdk:
+    """Install the SDK double under the name the driver imports."""
+    return install_booster_sdk(monkeypatch)
 
 
 def _tool_use(action: str) -> ToolUse:

--- a/tests/drivers/test_booster_telemetry_absence_is_not_a_reading.py
+++ b/tests/drivers/test_booster_telemetry_absence_is_not_a_reading.py
@@ -2,20 +2,18 @@
 
 :func:`~strands_robots.drivers.booster.parse_low_state` documents the rule -
 "absent fields are omitted rather than defaulted: a snapshot that reports a
-zeroed IMU the robot never sent is worse than one that reports none" - and none
-of its reads applied it. Every field was ``float(getattr(msg, <field>, 0.0))``
-or ``[float(v) for v in getattr(imu, <field>, []) or []]``, and ``_on_battery``
-read its three the same way, so a field a firmware revision renamed, dropped or
-turned into a flag arrived as a plausible number:
+zeroed IMU the robot never sent is worse than one that reports none". #3381
+applied it to the three IMU vectors; the four motor vectors were still
+``float(getattr(motor, <field>, 0.0))`` and ``_on_battery`` read its three
+fields the same way, so one function held two conventions and a field a
+firmware revision renamed, dropped or turned into a flag arrived as a plausible
+number on the rows that were left:
 
 ==============================  ===========================  ================
 frame                           before                       after
 ==============================  ===========================  ================
 ``q`` renamed                   every joint at ``0.0``       ``None``
 ``q`` is a flag                 every joint at ``1.0``       ``None``
-``rpy`` renamed                 ``[]``, an empty attitude    ``None``
-``rpy`` is a ``memoryview``     ``[1.0, 2.0]``               ``None``
-``acc`` is a ``bytearray``      ``[1.0, 2.0]``               ``None``
 ``soc`` renamed                 ``battery_pct=0.0``          ``None``
 ``soc`` is a flag               ``battery_pct=1.0``          ``None``
 ==============================  ===========================  ================
@@ -26,7 +24,7 @@ reads it as ``held_q`` and :func:`~strands_robots.drivers.booster.build_frame`
 writes ``held_q[slot]`` as the position target of every *uncommanded* upper-body
 slot. A full-width vector of defaulted zeros is finite and non-empty, so it
 passed both of ``_on_low_state``'s guards, got cached, and the very next write
-commanded eleven arm and head joints to exactly zero - a full-travel move on a
+commanded all eight arm joints to exactly zero - a full-travel move on a
 1.2 m biped, from a frame that carried no positions at all. The refusal the
 driver already spells for that case ("no LowState frame has arrived yet, so
 neither the frame width nor the hold position of an uncommanded arm joint is
@@ -41,8 +39,10 @@ vector. The T1 reads through the same functions and keeps the same record shape
 those drivers use: the key stays and the value is ``None``, so a consumer asking
 for a field always gets an answer and the answer can be "the robot did not report
 this". This suite grades the rule as a table derived from the driver's own field
-maps, the frame surviving one bad field, the hold source end to end, and a
-derivation that refuses a typed default returning to the module.
+maps - the IMU rows included, so the three maps are graded as one roster rather
+than the motor and battery halves alone - the frame surviving one bad field, the
+hold source end to end, and a derivation that refuses a typed default returning
+to the module.
 """
 
 from __future__ import annotations

--- a/tests/drivers/test_booster_telemetry_absence_is_not_a_reading.py
+++ b/tests/drivers/test_booster_telemetry_absence_is_not_a_reading.py
@@ -1,0 +1,329 @@
+"""A Booster T1 field the frame does not carry is not a zero reading.
+
+:func:`~strands_robots.drivers.booster.parse_low_state` documents the rule -
+"absent fields are omitted rather than defaulted: a snapshot that reports a
+zeroed IMU the robot never sent is worse than one that reports none" - and none
+of its reads applied it. Every field was ``float(getattr(msg, <field>, 0.0))``
+or ``[float(v) for v in getattr(imu, <field>, []) or []]``, and ``_on_battery``
+read its three the same way, so a field a firmware revision renamed, dropped or
+turned into a flag arrived as a plausible number:
+
+==============================  ===========================  ================
+frame                           before                       after
+==============================  ===========================  ================
+``q`` renamed                   every joint at ``0.0``       ``None``
+``q`` is a flag                 every joint at ``1.0``       ``None``
+``rpy`` renamed                 ``[]``, an empty attitude    ``None``
+``rpy`` is a ``memoryview``     ``[1.0, 2.0]``               ``None``
+``acc`` is a ``bytearray``      ``[1.0, 2.0]``               ``None``
+``soc`` renamed                 ``battery_pct=0.0``          ``None``
+``soc`` is a flag               ``battery_pct=1.0``          ``None``
+==============================  ===========================  ================
+
+The ``joints`` row is the one that moves the robot rather than only misreporting
+it. It is the hold source: :meth:`~strands_robots.drivers.booster.BoosterDriver.send_action`
+reads it as ``held_q`` and :func:`~strands_robots.drivers.booster.build_frame`
+writes ``held_q[slot]`` as the position target of every *uncommanded* upper-body
+slot. A full-width vector of defaulted zeros is finite and non-empty, so it
+passed both of ``_on_low_state``'s guards, got cached, and the very next write
+commanded eleven arm and head joints to exactly zero - a full-travel move on a
+1.2 m biped, from a frame that carried no positions at all. The refusal the
+driver already spells for that case ("no LowState frame has arrived yet, so
+neither the frame width nor the hold position of an uncommanded arm joint is
+known") was unreachable, because a defaulted frame is indistinguishable from an
+observed one.
+
+The rule already had an owner. :mod:`strands_robots.drivers.base`'s
+``telemetry_float`` / ``telemetry_float_list`` decide what counts as a reading
+for the Unitree drivers, including the two rows neither of *those* copies
+guarded before they converged - a ``bool`` on a scalar and a bytes-like on a
+vector. The T1 reads through the same functions and keeps the same record shape
+those drivers use: the key stays and the value is ``None``, so a consumer asking
+for a field always gets an answer and the answer can be "the robot did not report
+this". This suite grades the rule as a table derived from the driver's own field
+maps, the frame surviving one bad field, the hold source end to end, and a
+derivation that refuses a typed default returning to the module.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from strands_robots.drivers import booster
+from strands_robots.drivers.base import telemetry_float, telemetry_float_list
+from strands_robots.drivers.booster import (
+    BATTERY_STATE_FIELDS,
+    BOOSTER_JOINT_INDEX,
+    IMU_STATE_FIELDS,
+    MOTOR_STATE_FIELDS,
+    UPPER_BODY_SLOTS,
+    parse_low_state,
+)
+
+from .test_booster_driver import _FakeSdk, _live_driver, install_booster_sdk
+
+_WIDTH = len(BOOSTER_JOINT_INDEX)
+
+
+@pytest.fixture
+def sdk(monkeypatch: pytest.MonkeyPatch) -> _FakeSdk:
+    """The same SDK double the driver suite runs against."""
+    return install_booster_sdk(monkeypatch)
+
+
+#: Marks a field as *not present* on the message the double builds - a firmware
+#: revision that renamed or dropped it.
+_ABSENT = object()
+
+#: Values that are no reading on a *scalar* field: absent, a flag, unset, text
+#: that is not a number, or a raw buffer. ``bool`` is the row ``g1`` let through
+#: before the Unitree copies of this rule converged - ``float(True)`` is ``1.0``.
+_SCALAR_NON_READINGS: list[Any] = [
+    _ABSENT,
+    True,
+    None,
+    "n/a",
+    memoryview(b"\x01\x02"),
+    bytearray(b"\x01\x02"),
+]
+
+#: Values that are no reading on a *vector* field. Everything above plus the two
+#: rows that only apply to a sequence: a bytes-like value iterates as integers
+#: and so decoded a buffer into a two-element attitude (the row *neither*
+#: Unitree copy guarded), and text iterates as characters. ``[0.1, True, 0.3]``
+#: is the all-or-nothing rule: half an attitude is worse than none, because a
+#: consumer cannot tell that it is half.
+_VECTOR_NON_READINGS: list[Any] = [*_SCALAR_NON_READINGS, "0.05", [0.1, True, 0.3]]
+
+
+class _Fields:
+    """A decoded SDK message: named attributes, minus the ones marked absent."""
+
+    def __init__(self, defaults: dict[str, Any], **overrides: Any) -> None:
+        for name, value in {**defaults, **overrides}.items():
+            if value is not _ABSENT:
+                setattr(self, name, value)
+
+
+def _motor(**overrides: Any) -> _Fields:
+    return _Fields({"q": 0.5, "dq": 0.1, "tau_est": 0.2, "temperature": 30.0}, **overrides)
+
+
+def _imu(**overrides: Any) -> _Fields:
+    return _Fields({"rpy": (0.01, 0.02, 0.03), "gyro": (0.1, 0.2, 0.3), "acc": (0.0, 0.0, 9.81)}, **overrides)
+
+
+def _low_state(
+    *,
+    motor: dict[str, Any] | None = None,
+    imu: dict[str, Any] | None = None,
+    one_slot: tuple[int, dict[str, Any]] | None = None,
+) -> Any:
+    """A full-width ``LowState`` whose motors and IMU carry ``overrides``.
+
+    ``one_slot`` overrides a *single* slot, which is the case that separates the
+    all-or-nothing rule from a filter: a vector that dropped one element would
+    renumber every slot after the gap.
+    """
+    motors = [_motor(**(motor or {})) for _ in range(_WIDTH)]
+    if one_slot is not None:
+        slot, overrides = one_slot
+        motors[slot] = _motor(**overrides)
+    return _Fields({}, motor_state_parallel=motors, motor_state_serial=motors, imu_state=_imu(**(imu or {})))
+
+
+def _battery(**overrides: Any) -> _Fields:
+    return _Fields({"soc": 88.0, "voltage": 48.2, "current": -3.1}, **overrides)
+
+
+def _unobserved_driver(sdk: _FakeSdk, *, enable: bool = True) -> booster.BoosterDriver:
+    """A connected, write-enabled driver that has been handed no frame yet.
+
+    :func:`_live_driver` injects a good ``LowState``, which is the wrong start
+    for the cells about what happens when the *first* frame does not read.
+    """
+    driver = booster.BoosterDriver(cmd_type="parallel")
+    assert driver.connect_eagerly() is None
+    if enable:
+        assert driver.enable_upper_body(True)["status"] == "success"
+    return driver
+
+
+class TestAFieldThatIsNoReadingIsOmittedRatherThanDefaulted:
+    """The rule the docstring states, graded over the driver's own field maps.
+
+    The rosters are read from :data:`MOTOR_STATE_FIELDS`, :data:`IMU_STATE_FIELDS`
+    and :data:`BATTERY_STATE_FIELDS` rather than restated, so a field added to
+    the driver is graded here without this file being touched.
+    """
+
+    @pytest.mark.parametrize("key,field", sorted(MOTOR_STATE_FIELDS.items()))
+    @pytest.mark.parametrize("value", _SCALAR_NON_READINGS)
+    def test_a_motor_vector_of_non_readings_is_left_out(self, key: str, field: str, value: Any) -> None:
+        """All or nothing: one slot that reports no value costs that vector."""
+        snapshot = parse_low_state(_low_state(motor={field: value}), "motor_state_parallel")
+        assert snapshot[key] is None
+
+    @pytest.mark.parametrize("field", IMU_STATE_FIELDS)
+    @pytest.mark.parametrize("value", _VECTOR_NON_READINGS)
+    def test_an_imu_vector_of_non_readings_is_left_out(self, field: str, value: Any) -> None:
+        """A buffer that iterates as integers is not a two-element attitude."""
+        snapshot = parse_low_state(_low_state(imu={field: value}), "motor_state_parallel")
+        assert snapshot["imu"][field] is None
+
+    def test_an_imu_carrying_nothing_readable_reports_every_vector_as_absent(self) -> None:
+        """The section stays, so a consumer indexing it still gets an answer."""
+        blank = dict.fromkeys(IMU_STATE_FIELDS, _ABSENT)
+        snapshot = parse_low_state(_low_state(imu=blank), "motor_state_parallel")
+        assert snapshot["imu"] == dict.fromkeys(IMU_STATE_FIELDS, None)
+
+    @pytest.mark.parametrize("key,field", sorted(BATTERY_STATE_FIELDS.items()))
+    @pytest.mark.parametrize("value", _SCALAR_NON_READINGS)
+    def test_a_battery_field_that_is_no_reading_is_left_out(
+        self, sdk: _FakeSdk, key: str, field: str, value: Any
+    ) -> None:
+        """A defaulted ``0.0`` on ``soc`` is an empty pack; on the rest, a lie."""
+        driver = _live_driver(sdk)
+        driver._on_battery(_battery(**{field: value}))
+        assert (driver._battery or {})[key] is None
+
+    def test_a_reading_still_reaches_the_record_unchanged(self, sdk: _FakeSdk) -> None:
+        """Converging on the shared coercer did not widen the refusal."""
+        driver = _live_driver(sdk)
+        driver._on_battery(_battery())
+        assert driver._battery == {"pct": 88.0, "voltage": 48.2, "current": -3.1}
+        snapshot = parse_low_state(_low_state(), "motor_state_parallel")
+        assert snapshot["joints"] == [0.5] * _WIDTH
+        assert snapshot["imu"] == {"rpy": [0.01, 0.02, 0.03], "gyro": [0.1, 0.2, 0.3], "acc": [0.0, 0.0, 9.81]}
+
+
+class TestOneUnreadableFieldDoesNotCostTheFieldsBesideIt:
+    """A per-field read, so a rename costs its field and not the frame.
+
+    Both decoders wrapped the whole record in one ``try``, so ``float()`` raising
+    on a single field discarded every field the same message carried - and on the
+    ``LowState`` path that meant discarding the positions too, leaving
+    ``_last_state`` on the previous frame. The staleness then reads as a dropped
+    wire rather than as one renamed field.
+    """
+
+    def test_a_bad_imu_field_keeps_the_other_vectors_and_the_positions(self, sdk: _FakeSdk) -> None:
+        """The positions are what ``send_action`` holds from, so losing them writes."""
+        driver = _live_driver(sdk)
+        assert sdk.subscriber is not None
+        sdk.subscriber.handler(_low_state(imu={"rpy": "0.05"}))
+        state = driver.read_state()
+        assert state["joints"] == [0.5] * _WIDTH
+        assert state["imu"]["rpy"] is None
+        assert state["imu"]["acc"] == [0.0, 0.0, 9.81]
+
+    def test_a_bad_charge_field_keeps_the_pack_voltage_and_current(self, sdk: _FakeSdk) -> None:
+        """Voltage and current read fine and are the fallback health signal."""
+        driver = _live_driver(sdk)
+        driver._on_battery(_battery(soc="n/a"))
+        assert driver._battery == {"pct": None, "voltage": 48.2, "current": -3.1}
+
+    def test_a_frame_carrying_no_readable_field_leaves_the_record_alone(self, sdk: _FakeSdk) -> None:
+        """An empty record would erase a good reading with an absence."""
+        driver = _live_driver(sdk)
+        driver._on_battery(_battery())
+        driver._on_battery(_battery(**dict.fromkeys(BATTERY_STATE_FIELDS.values(), _ABSENT)))
+        assert driver._battery == {"pct": 88.0, "voltage": 48.2, "current": -3.1}
+
+
+class TestTheHoldPositionIsNeverFabricated:
+    """The one row that moves the robot rather than only misreporting it.
+
+    ``joints`` is ``send_action``'s ``held_q``, and ``build_frame`` writes
+    ``held_q[slot]`` as the position target of every uncommanded upper-body slot.
+    """
+
+    def test_a_frame_whose_positions_do_not_read_is_not_cached(self, sdk: _FakeSdk) -> None:
+        """A full-width vector of defaulted zeros passed both existing guards."""
+        driver = _unobserved_driver(sdk, enable=False)
+        assert sdk.subscriber is not None
+        sdk.subscriber.handler(_low_state(motor={"q": _ABSENT}))
+        assert driver.read_state() == {}
+        assert driver.get_observation() == {}
+
+    @pytest.mark.parametrize("key,field", sorted(MOTOR_STATE_FIELDS.items()))
+    def test_one_slot_that_does_not_read_costs_the_whole_vector(self, key: str, field: str) -> None:
+        """A vector short one element renumbers every slot after the gap.
+
+        ``held_q`` is indexed *by slot*, and ``send_action`` bounds a caller's
+        targets with ``len(held_q)``, so a 22-element vector would both hold the
+        wrong joint at each shifted slot and silently narrow the addressable set.
+        Dropping the vector reaches the "no frame has arrived" refusal instead.
+        """
+        snapshot = parse_low_state(_low_state(one_slot=(7, {field: _ABSENT})), "motor_state_parallel")
+        assert snapshot[key] is None
+
+    def test_send_action_refuses_rather_than_commanding_a_pose_no_frame_reported(self, sdk: _FakeSdk) -> None:
+        """The refusal the driver already spells was unreachable for this frame."""
+        driver = _unobserved_driver(sdk)
+        assert sdk.subscriber is not None
+        sdk.subscriber.handler(_low_state(motor={"q": _ABSENT}))
+        result = driver.send_action({"left_shoulder_pitch": 0.1})
+        assert result["status"] == "error"
+        assert "no LowState frame has arrived yet" in result["content"][0]["text"]
+        assert sdk.publisher is not None
+        assert sdk.publisher.written == []
+
+    def test_an_observed_frame_is_still_what_the_arms_hold(self, sdk: _FakeSdk) -> None:
+        """The reading path is unchanged: a real position is still held."""
+        driver = _live_driver(sdk)
+        assert driver.send_action({"left_shoulder_pitch": 0.1})["status"] == "success"
+        assert sdk.publisher is not None
+        held = sdk.publisher.written[-1]
+        slot = BOOSTER_JOINT_INDEX["left_elbow_yaw"]
+        assert slot in UPPER_BODY_SLOTS
+        assert held.motor_cmd_at(slot).q == pytest.approx(round(0.1 * slot, 3))
+
+
+class TestTheStatusVerbReportsNoChargeAsAbsent:
+    """``get_status`` reads ``battery.get("pct")``, which the writer made unreachable."""
+
+    @pytest.mark.parametrize("value", [_ABSENT, True, "n/a"])
+    def test_a_charge_field_that_is_no_reading_publishes_no_percentage(self, sdk: _FakeSdk, value: Any) -> None:
+        """``0.0`` reads as an empty pack and ``1.0`` as a one-percent one."""
+        driver = _live_driver(sdk)
+        driver._on_battery(_battery(soc=value))
+        envelope = asyncio.run(driver.get_status())["content"][0]["json"]
+        assert envelope["battery_pct"] is None
+
+    def test_a_real_charge_still_publishes(self, sdk: _FakeSdk) -> None:
+        driver = _live_driver(sdk)
+        driver._on_battery(_battery(soc=88.0))
+        assert asyncio.run(driver.get_status())["content"][0]["json"]["battery_pct"] == 88.0
+
+
+class TestTheModuleReadsThroughTheOneOwnerOfThisRule:
+    """A derivation, so the typed defaults cannot come back one field at a time."""
+
+    def test_the_driver_resolves_the_shared_coercers(self) -> None:
+        assert booster.telemetry_float is telemetry_float
+        assert booster.telemetry_float_list is telemetry_float_list
+
+    def test_no_telemetry_read_carries_a_typed_default(self) -> None:
+        """``getattr(msg, field, 0.0)`` is the defect; a sentinel name is not."""
+        tree = ast.parse(Path(inspect.getfile(booster)).read_text(encoding="utf-8"))
+        defaulted = [
+            f"line {node.lineno}: {ast.unparse(node)}"
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "getattr"
+            and len(node.args) == 3
+            and isinstance(node.args[2], ast.Constant)
+            and node.args[2].value is not None
+        ]
+        assert defaulted == [], (
+            "a telemetry field read with a typed default publishes a constant as a reading; "
+            f"pass None and coerce it: {defaulted}"
+        )


### PR DESCRIPTION
A renamed `q` field makes a full set of zeros the hold source - and the arms get commanded there.

![hold source](https://raw.githubusercontent.com/cagataycali/robots/assets/booster-telemetry-34417990909/a/booster_hold_source.png)

Booster T1, rendered headless in MuJoCo from the position targets the driver's own publisher recorded. The `LowState` carries the pose in panel 1; its `q` field is renamed. Before, `send_action` returned `status=success` and published one `LowCmd` holding all eight uncommanded arm joints at the fabricated `0.0`. After, it publishes nothing.

## What is left after #3381

#3381 put `parse_low_state`'s three IMU vectors on the shared coercer. The same function's four **motor** vectors and `_on_battery`'s three fields are still `float(getattr(..., 0.0))`, so one function carries two conventions and the row that moves the robot is still fabricated. This PR is that residue, in the shape #3381 chose (key retained, value `None`).

| the frame | on `main` today | after |
| --- | --- | --- |
| `q` renamed or dropped | all 23 joints at `0.0` | `joints=None` |
| `q` arrives as a flag | all 23 joints at `1.0` | `joints=None` |
| `q` is a `memoryview` | `[1.0, 2.0]` - a 2-slot robot | `joints=None` |
| one slot of 23 unreadable | 23 values, one fabricated | `joints=None` |
| `soc` renamed | `battery_pct=0.0` - an empty pack | `battery_pct=None` |
| `soc` arrives as a flag | `battery_pct=1.0` - a one-percent pack | `battery_pct=None` |

![matrix](https://raw.githubusercontent.com/cagataycali/robots/assets/booster-telemetry-34417990909/a/booster_telemetry_matrix.png)

Measured through the decoders before #3381: all 60 cells of field x non-reading reported a value the frame did not carry. (The IMU third of that grid is what #3381 turned green.)

## Why `joints` is the severe row

It is the hold source. `send_action` reads it as `held_q`; `build_frame` writes `held_q[slot]` as the position target of every *uncommanded* upper-body joint. A full-width vector of defaulted zeros is finite and non-empty, so it clears both of `_on_low_state`'s guards, gets cached, and gets commanded. The refusal the driver already spells for this case - *"no LowState frame has arrived yet, so neither the frame width nor the hold position of an uncommanded arm joint is known"* - is unreachable, because a defaulted frame is indistinguishable from an observed one.

| on a frame whose `q` is renamed | `main` | after |
| --- | --- | --- |
| cached `joints` | 23 values at `0.0` | `None` |
| `send_action` | `status=success` | `status=error`, naming what is unknown |
| `LowCmd` frames published | 1 | 0 |

The vectors stay all-or-nothing for the same reason: `held_q` is indexed by slot, and `send_action` bounds a caller's targets with `len(held_q)`, so a vector short one element would both hold the wrong joint at every shifted slot and silently narrow the addressable set.

`_on_battery` has the same shape with a documented consumer: `get_status` publishes `battery.get("pct")`, so it was written to report `None` for a T1 that reported no charge, and the typed default makes that unreachable. Its coercion was also per *message*, so one unreadable field discarded the two beside it - `voltage` and `current` read fine and are the fallback health signal.

## The change

The four motor vectors and the three battery fields read through `drivers/base.py`'s `telemetry_float_list` / `telemetry_float`, the same functions the Unitree drivers and (since #3381) the T1's IMU use. The three field maps are named - `MOTOR_STATE_FIELDS`, `IMU_STATE_FIELDS`, `BATTERY_STATE_FIELDS` - so the read is derived once instead of restated per field, and a field added to the driver is graded by the new suite without touching it. `+12` executable statements in `booster.py`: the three maps, the per-field battery loop, and the "nothing read" guard.

## Tests

`tests/drivers/test_booster_telemetry_absence_is_not_a_reading.py` (84 cells) grades the rule as a table derived from those maps, the frame surviving one bad field, the hold source end to end, and a derivation that refuses a typed default returning to the module. On `upstream/main` (8b1f429, i.e. with #3381 already in) plus only the field maps as the ruler: **54 failed / 30 passed**. On this branch: **84 passed**.

Each mutation of the guard, by how many of those cells it fires:

| mutation | cells failing |
| --- | --- |
| every typed default restored | 79 |
| only the IMU vectors coerced (= `main` today) | 53 |
| motor vectors keep the readable elements instead of all-or-nothing | 28 |
| battery discards the whole record when one field does not read | 19 |
| a wholly unreadable battery frame is cached, erasing the last reading | 1 |

Gate on 8b1f429: `ruff check` + `ruff format --check` clean over `strands_robots tests tests_integ` (1993 files); `mypy` clean over 1939 source files; `tests/drivers/` + the docstring-xref and changelog graders **2786 passed, 17 skipped**. The full `tests/` suite ran green twice on this diff before the rebase (**52271 passed, 299 skipped, 0 failed**, 28m53s); the rebase changed only `booster.py`'s merge resolution and the docs paragraph.

Docs: `docs/getting-started/robot-factory.md`'s telemetry section gains what the coercion paragraph did not say - that coercion is per field rather than per message, what the record does with the `None`, and the case where a reading is also a command source.

## Round changelog

**Round 1 (b6ccaf8f, fast-forward on 3b7f1958):** one concern, one commit - the fragment and the suite's module docstring still described the three IMU rows as before/after of this change and stated that none of `parse_low_state`'s reads applied its own rule, which stopped being true of `main` when #3381 landed. Both now name the four motor vectors and the three battery fields as the reads this change converts (42 field x non-reading cells rather than 60) and the IMU rows as the ones the table grades alongside them; the docstring's joint count is corrected from eleven to the eight `UPPER_BODY_SLOTS` the module declares. No executable line changed. Composed tree re-measured: the three driver suites + fragment, xref and markdown-link graders **269 passed, 3 skipped**; the 121-grader whole-tree roster reports 59 failures that are byte-identical by node id to pristine `main` in the same environment (`lerobot`, `torch`, `fastapi`, `psutil` absent), 0 attributable.

**Composition check after approval (no push):** #3382 landed on `main` (`b91f49f4`) after the approving review's `behind_by=0` read, so this head is now `behind_by=1`. Path intersection with #3382 is empty - it edits `drivers/g1.py` and its own two test files, and its AST grader walks the two Unitree modules only. Local composition of `b6ccaf8f` with `main`: 0 combined-diff lines; the five driver suites (`booster_driver`, `booster_telemetry_absence`, `telemetry_coercion`, `driver_telemetry_vectors`, `g1_lidar_fields`) report **228 passed / 3 skipped** against **144 / 3** on `main` alone - a delta of +84, exactly this PR's cell count; `ruff check` and `ruff format --check` clean on the three changed Python files. The branch is left where the approval was given: a base refresh would review nothing new, and the composition above is what the squash will compile.