### PR TITLE
refactor(simulation/predicates): resolve the body name a spec wrote, not a synthesized <name>_main

### DIFF
--- a/changelog.d/3384-predicates-drop-main-body-suffix-fallback.md
+++ b/changelog.d/3384-predicates-drop-main-body-suffix-fallback.md
@@ -1,0 +1,37 @@
+### Removed: the `<name>_main` root-body fallback in the predicate DSL
+
+`_body_position` and `_body_quaternion` looked a body name up twice: the name
+the spec wrote, then `<name>_main`. That second probe existed for the
+procedurally-generated objects of the vendored LIBERO adapter removed in #3056,
+whose MJCF root body carried the suffix while the BDDL goal named the object
+bare. Both lookups now resolve the name the scene declares, and only that name.
+
+The convention was never applied consistently, which is the reason to remove it
+rather than keep it for a scene that might still be shaped that way.
+`_geom_belongs_to_body` - the single owner of the body-to-geom mapping, and the
+gate every contact-aware predicate runs through - matches `<body>_g`, so
+`cube_1_main_g0` is not one of `cube_1`'s geoms. A spec clause naming `cube_1`
+therefore read a *position* off `cube_1_main` while `grasped(cube_1)` and
+`body_on(..., require_contact=True)` reported no contact at all: two predicates
+over one clause disagreeing about which body the clause named, with the
+geometric half silently answering for a body the contact half could not see.
+
+Nothing on `main` emits a `_main` root body. `strands_robots/assets` ships no
+MJCF (0 files match), no `builtin_benchmarks` spec names such a body, and the
+generator that did left with #3056.
+
+A name the scene does not declare now degrades the way every other unresolved
+name does - `_warn_unresolved` logs it once and the term becomes a constant -
+instead of resolving to a different body that happens to share a prefix. The
+`tried` list in that warning drops to the single name asked for, so the log line
+names what the spec wrote. A body genuinely called `plate_1_main` still resolves;
+the suffix was only ever synthesized, never special-cased away.
+
+`tests/simulation/test_benchmark_predicates.py` pins the resolution by the names
+probed rather than by the verdict alone (a recording sim asserts
+`probed == [<the one name>]` on both the position and the orientation path), so a
+reintroduced fallback fails on the extra probe even where it would return the
+same answer. The three tests that pinned the fallback are gone; the two
+vendor-named multi-geom tests are renamed for the `<body>_g<idx>` convention
+they actually cover, which is shared with strands-native `add_object`
+(`<body>_geom`) and stays.

--- a/strands_robots/simulation/predicates.py
+++ b/strands_robots/simulation/predicates.py
@@ -165,16 +165,10 @@ def _body_position(sim: SimEngine, body: str) -> list[float] | None:
     of writing). Future backends can add the same method signature - see
     :meth:`strands_robots.simulation.mujoco.physics.PhysicsMixin.get_body_state`.
 
-    LIBERO body-name convention: BDDL names objects without a suffix
-    (``porcelain_mug_1``), but the MJCF root body is suffixed with
-    ``_main`` (``porcelain_mug_1_main``). Upstream resolves this via
-    ``env.objects_dict[name].root_body`` (see
-    ``libero/libero/envs/bddl_base_domain.py``). We mirror that with a
-    bounded fallback: try the bare name first, then ``<name>_main`` if
-    the bare lookup fails. #176 (sub-task 3d) - without this
-    fallback, BDDL goal predicates like ``(On porcelain_mug_1
-    plate_1)`` resolve to ``None`` (body not found) → predicate
-    silently False even when the mug is physically on the plate.
+    Resolves the name the scene declares, and only that name. A name the
+    scene does not declare is surfaced by :func:`_warn_unresolved` rather
+    than guessed at from a suffix, so a spec typo degrades loudly instead
+    of silently reading some other body that happens to share a prefix.
     """
     get_body_state = getattr(sim, "get_body_state", None)
     if get_body_state is None:
@@ -194,21 +188,10 @@ def _body_position(sim: SimEngine, body: str) -> list[float] | None:
             return [float(c) for c in pos]
         return None
 
-    # 1. Bare name (works for fixtures with explicit body names matching
-    # the BDDL name, e.g. ``living_room_table``).
     pos = _try(body)
     if pos is not None:
         return pos
-    # 2. LIBERO ``<name>_main`` convention (the root body of
-    # procedurally-generated objects). Skip if the name already has
-    # the suffix to avoid double-suffixing on retries.
-    tried = [body]
-    if not body.endswith("_main"):
-        tried.append(f"{body}_main")
-        pos = _try(f"{body}_main")
-        if pos is not None:
-            return pos
-    _warn_unresolved("body", body, tuple(tried))
+    _warn_unresolved("body", body)
     return None
 
 
@@ -226,9 +209,8 @@ def _joint_position(sim: SimEngine, joint: str) -> float | None:
     negation* both answer ``False``, so no success criterion over that joint
     can ever hold.
 
-    So resolve over the scene, mirroring the bounded ladder
-    :func:`_body_position` already uses for the LIBERO body-name convention:
-    the unscoped observation first (single-robot scenes, and the controlled
+    So resolve over the scene with a bounded ladder over the entities the
+    world reports: the unscoped observation first (single-robot scenes, and the controlled
     robot's own joints, keep their existing fast path), then each robot the
     world reports by name via the same ``robot_name`` route the ``base_*``
     helpers use. Only once every entity has been asked is the name genuinely
@@ -325,20 +307,12 @@ def _body_quaternion(sim: SimEngine, body: str) -> list[float] | None:
             return [float(c) for c in quat]
         return None
 
-    # Mirror _body_position's resolution: bare BDDL name first, then the LIBERO
-    # ``<name>_main`` root-body convention (#176). Without the fallback,
-    # body_upright(<bddl_name>) resolved to None -> silently False for every
-    # procedurally-generated LIBERO object, whose MJCF root body is _main-suffixed.
+    # Same exact-name resolution as :func:`_body_position`, so the position
+    # and the orientation of one body are never read off two different bodies.
     quat = _try(body)
     if quat is not None:
         return quat
-    tried = [body]
-    if not body.endswith("_main"):
-        tried.append(f"{body}_main")
-        quat = _try(f"{body}_main")
-        if quat is not None:
-            return quat
-    _warn_unresolved("body", body, tuple(tried))
+    _warn_unresolved("body", body)
     return None
 
 
@@ -673,7 +647,7 @@ def _geom_belongs_to_body(geom: str, body: str) -> bool:
 
     - exact ``body`` (single-geom scenes whose geom is named after the body),
     - ``<body>_geom`` (strands :meth:`add_object`),
-    - ``<body>_g<idx>`` (LIBERO / robosuite multi-geom objects), and
+    - ``<body>_g<idx>`` (multi-geom objects that number their geoms), and
     - ``<body>/geom_<id>`` - the name ``get_contacts`` **synthesizes** for a
       geom the asset left unnamed, which is the dominant case in real MJCF
       (a Panda scene has 81 unnamed geoms out of 82).
@@ -703,14 +677,11 @@ def _body_contact(sim: SimEngine, body_a: str, body_b: str) -> bool | None:
     geometric-only checks) or hard-fail.
 
     Body-geom matching is delegated to :func:`_geom_belongs_to_body`, which
-    owns every supported geom-naming convention. This mirrors how upstream
-    LIBERO's ``ObjectState.check_contact`` walks the per-object geom list, but
-    avoids hard-coding the body→geom map by using the naming conventions.
+    owns every supported geom-naming convention, so the body→geom map is
+    derived from the names the scene reports rather than hard-coded.
 
-    Used by the contact-aware branch of :func:`_body_on` (LIBERO's
-    ``On(A, B)`` predicate semantics requires
-    ``arg2.check_contact(arg1)`` per
-    ``libero/libero/envs/predicates/base_predicates.py``).
+    Used by the contact-aware branch of :func:`_body_on`, where "A is on B"
+    means B carries A's weight and so must be touching it.
     """
     get_contacts = getattr(sim, "get_contacts", None)
     if get_contacts is None:
@@ -756,21 +727,20 @@ def _body_on(
 
     True when ``A.z > B.z + z_offset`` AND horizontal distance ``|A.xy - B.xy|
     < xy_tol``. When ``require_contact=True``, ALSO requires physics
-    contact between A and B via ``sim.get_contacts()`` - matches
-    upstream LIBERO's ``ObjectState.check_ontop`` which combines a
-    geometric check with ``check_contact``. The z-offset parameter
+    contact between A and B via ``sim.get_contacts()``, so a body hovering
+    above B is not scored as resting on it. The z-offset parameter
     accounts for B's half-height + a small buffer; tune per scene.
-    Intended for sparse-success benchmarks (LIBERO, etc.) where exact
-    geometric containment isn't required.
+    Intended for sparse-success benchmarks where exact geometric
+    containment isn't required.
 
     Contact-check graceful degradation: when
     ``require_contact=True`` but the sim engine doesn't expose
     ``get_contacts`` (e.g. test stubs, custom engines), the contact
     check is skipped and only the geometric check fires. This
     preserves backwards compatibility - engines without contact
-    support get the geometric-only verdict. LIBERO benchmarks running on
-    ``MuJoCoSimEngine`` (which implements ``get_contacts``) get the
-    strict upstream-matching semantics.
+    support get the geometric-only verdict. A benchmark running on
+    ``MuJoCoSimEngine`` (which implements ``get_contacts``) gets the
+    strict contact-confirmed semantics.
 
     For full fidelity (MJCF geom size lookup + narrow-phase collision), write
     a scene-specific predicate and register it via :func:`register_predicate`.
@@ -842,8 +812,8 @@ def _body_inside(body: str, container: str, xy_tol: float = 0.15, z_tol: float =
     """Approximate ``(in A B)`` predicate - A contained within B's volume.
 
     True when A's position is within an axis-aligned box centered on B with
-    half-extents (``xy_tol``, ``xy_tol``, ``z_tol``). LIBERO-typical use is
-    "object inside basket / drawer / compartment" where exact bbox is
+    half-extents (``xy_tol``, ``xy_tol``, ``z_tol``). The typical use is
+    "object inside basket / drawer / compartment" where the exact bbox is
     benchmark-specific; the defaults are tuned for table-top manipulation.
 
     When richer geometry is available, override by registering a
@@ -990,11 +960,11 @@ def _grasped(body: str, gripper_prefix: str) -> BoolPredicate:
     gripper geom is in contact with any geom belonging to ``body``.
 
     Body-geom matching is delegated to :func:`_geom_belongs_to_body`, the
-    shared owner of that mapping, so ``grasped`` fires on real LIBERO/robosuite
-    scenes (where a BDDL object ``cube_1`` owns collision geoms
-    ``cube_1_g0`` / ``cube_1_g1`` ...), on strands-native ``add_object`` scenes
-    (``<body>_geom``), on single-geom scenes whose geom is named exactly after
-    the body, and on assets whose geoms are unnamed.
+    shared owner of that mapping, so ``grasped`` fires on multi-geom objects
+    that number their geoms (``cube_1_g0`` / ``cube_1_g1`` ...), on
+    strands-native ``add_object`` scenes (``<body>_geom``), on single-geom
+    scenes whose geom is named exactly after the body, and on assets whose
+    geoms are unnamed.
 
     Backends must implement ``get_contacts()`` returning the MuJoCo
     ``{"contacts": [{"geom1", "geom2", ...}]}`` shape. Other backends are
@@ -1021,9 +991,9 @@ def _grasped(body: str, gripper_prefix: str) -> BoolPredicate:
             g2 = c.get("geom2") or ""
             # One side must be a geom of the grasped body; the other must
             # start with the gripper prefix. ``_geom_belongs_to_body`` owns
-            # every geom-naming convention, so a LIBERO ``(grasped cube_1)``
-            # goal fires on ``cube_1_g0`` and a scene with unnamed geoms
-            # fires on the synthesized ``cube_1/geom_<id>`` name.
+            # every geom-naming convention, so a ``grasped(cube_1)`` goal
+            # fires on ``cube_1_g0`` and a scene with unnamed geoms fires on
+            # the synthesized ``cube_1/geom_<id>`` name.
             body_match = _geom_belongs_to_body(g1, body) or _geom_belongs_to_body(g2, body)
             gripper_match = any(isinstance(g, str) and g.startswith(gripper_prefix) for g in (g1, g2))
             if body_match and gripper_match:
@@ -2226,11 +2196,10 @@ def can_resolve_body(sim: SimEngine, body: str) -> bool:
     """Whether *body* resolves in *sim* right now, via the predicate DSL's own lookup.
 
     Uses the exact resolution path the body-referencing predicates use at
-    evaluation time (:func:`_body_position`), including the LIBERO
-    ``<name>_main`` fallback - so a ``True`` here means the predicate will
-    genuinely be evaluable against the live scene, and a ``False`` means it
-    would degrade to a constant ``False`` forever (a typo'd name, or a
-    backend without body lookups).
+    evaluation time (:func:`_body_position`) - so a ``True`` here means the
+    predicate will genuinely be evaluable against the live scene, and a
+    ``False`` means it would degrade to a constant ``False`` forever (a
+    typo'd name, or a backend without body lookups).
 
     Args:
         sim: The engine to probe.

--- a/tests/simulation/test_benchmark_predicates.py
+++ b/tests/simulation/test_benchmark_predicates.py
@@ -54,6 +54,18 @@ class _BodyStateSim:
         return {}
 
 
+class _RecordingBodyStateSim(_BodyStateSim):
+    """``_BodyStateSim`` that records every body name it was asked for."""
+
+    def __init__(self, positions: dict[str, list[float]]):
+        super().__init__(positions)
+        self.probed: list[str] = []
+
+    def get_body_state(self, body_name: str) -> dict[str, Any]:
+        self.probed.append(body_name)
+        return super().get_body_state(body_name)
+
+
 class _ScopedJointObsSim:
     """Sim whose ``get_observation`` is robot-scoped, like the real backends.
 
@@ -226,57 +238,36 @@ class TestBodyPositionPredicates:
         pred = make_predicate("body_above_z", body="cube", z=0)
         assert pred(sim) is False
 
-    def test_body_position_libero_main_suffix_fallback(self):
-        """Round 46 (#176 sub-task 3d) - LIBERO objects' BDDL names
-        (``porcelain_mug_1``) map to MJCF root bodies suffixed with
-        ``_main`` (``porcelain_mug_1_main``). The predicate evaluator
-        must transparently retry with the suffix when the bare name
-        misses, mirroring upstream LIBERO's
-        ``env.objects_dict[name].root_body`` resolution. Without this,
-        BDDL goal predicates like ``(On porcelain_mug_1 plate_1)``
-        silently resolve to ``False`` even when physics has the mug
-        on the plate.
-
-        Pin: a sim that only exposes ``porcelain_mug_1_main`` (NOT
-        ``porcelain_mug_1``) must still resolve via the predicate as
-        if the bare name worked.
-        """
-        # Sim only knows the suffixed name (mimics MJCF body naming).
-        sim = _BodyStateSim({"porcelain_mug_1_main": [0.0, 0.0, 0.5]})
-        pred = make_predicate("body_above_z", body="porcelain_mug_1", z=0.4)
-        assert pred(sim) is True, (
-            "body_above_z with bare BDDL name should fall back to ``<name>_main`` "
-            "for LIBERO scenes; round-46 fix may have regressed."
-        )
-
-    def test_body_position_main_suffix_no_double_suffix(self):
-        """Already-suffixed names must not double-suffix on retry.
-        Round 46 (#176 sub-task 3d).
-        """
-        # Sim only knows the suffixed name; caller passes already-suffixed.
-        sim = _BodyStateSim({"plate_1_main": [0.0, 0.0, 0.4]})
-        pred = make_predicate("body_above_z", body="plate_1_main", z=0.3)
-        assert pred(sim) is True
-
-    def test_body_position_bare_name_wins_over_suffix(self):
-        """When BOTH ``<name>`` and ``<name>_main`` exist, prefer the
-        bare lookup. This preserves the contract for fixtures /
-        explicit-named bodies (e.g. ``living_room_table``) which don't
-        use the LIBERO suffix.
-
-        Round 46 (#176 sub-task 3d).
-        """
-        sim = _BodyStateSim(
-            {
-                "living_room_table": [0.0, 0.0, 0.46],
-                "living_room_table_main": [99.0, 99.0, 99.0],  # decoy
-            }
-        )
+    def test_a_declared_body_resolves_in_a_single_probe(self):
+        """The name the spec wrote is the only name asked for."""
+        sim = _RecordingBodyStateSim({"living_room_table": [0.0, 0.0, 0.46]})
         pred = make_predicate("body_above_z", body="living_room_table", z=0.4)
         assert pred(sim) is True
-        # Decoy at 99.0 should not be reached if bare lookup wins.
-        pred2 = make_predicate("body_above_z", body="living_room_table", z=98.0)
-        assert pred2(sim) is False, "bare name should win over _main suffix; double-resolve detected"
+        assert sim.probed == ["living_room_table"]
+
+    def test_a_body_the_scene_does_not_declare_is_not_reached_through_a_suffix(self):
+        """No suffix is synthesized for a name the scene does not declare.
+
+        A ``<name>_main`` root-body fallback used to resolve here, for the
+        procedurally-generated objects of a vendored benchmark adapter that
+        no longer ships. The contact predicates never honoured the same
+        convention (:func:`_geom_belongs_to_body` matches ``<body>_g``, so
+        ``cube_1_main_g0`` is not one of ``cube_1``'s geoms), so a spec
+        naming ``cube_1`` got a position from ``cube_1_main`` while
+        ``grasped(cube_1)`` reported no contact - two predicates over one
+        clause disagreeing about which body it named.
+        """
+        sim = _RecordingBodyStateSim({"porcelain_mug_1_main": [0.0, 0.0, 0.5]})
+        pred = make_predicate("body_above_z", body="porcelain_mug_1", z=0.4)
+        assert pred(sim) is False
+        assert sim.probed == ["porcelain_mug_1"]
+
+    def test_a_suffixed_name_the_scene_declares_still_resolves(self):
+        """``_main`` is not special-cased away either - it is just a name."""
+        sim = _RecordingBodyStateSim({"plate_1_main": [0.0, 0.0, 0.4]})
+        pred = make_predicate("body_above_z", body="plate_1_main", z=0.3)
+        assert pred(sim) is True
+        assert sim.probed == ["plate_1_main"]
 
 
 # Joint predicates
@@ -442,7 +433,7 @@ class TestRewardTerms:
         assert term(None) == pytest.approx(-0.01)
 
 
-# LIBERO / #110 predicates
+# Contact-aware manipulation predicates (#110)
 
 
 class _BodyStateWithQuatSim:
@@ -566,13 +557,12 @@ class TestGrasped:
         pred = make_predicate("grasped", body="cube", gripper_prefix="robot0_gripper")
         assert pred(sim) is False
 
-    def test_detects_libero_multi_geom_object(self):
-        # LIBERO / robosuite name a BDDL object ``cube_1``'s collision
-        # geoms ``cube_1_g0`` / ``cube_1_g1`` ... (the same ``<body>_g<idx>``
-        # convention _body_contact matches). ``(grasped cube_1)`` must fire
-        # when a gripper geom touches such a geom - previously it silently
-        # returned False because only exact ``cube_1`` / ``cube_1_geom``
-        # names were matched.
+    def test_detects_a_numbered_multi_geom_object(self):
+        # A multi-geom object numbers its collision geoms ``cube_1_g0`` /
+        # ``cube_1_g1`` ... (the ``<body>_g<idx>`` convention _body_contact
+        # matches). ``grasped(cube_1)`` must fire when a gripper geom touches
+        # such a geom - previously it silently returned False because only
+        # exact ``cube_1`` / ``cube_1_geom`` names were matched.
         sim = _ContactSim(
             [
                 {"geom1": "robot0_gripper_finger_l", "geom2": "cube_1_g0"},
@@ -581,7 +571,7 @@ class TestGrasped:
         pred = make_predicate("grasped", body="cube_1", gripper_prefix="robot0_gripper")
         assert pred(sim) is True
 
-    def test_detects_libero_multi_geom_object_higher_index(self):
+    def test_detects_a_numbered_multi_geom_object_at_a_higher_index(self):
         sim = _ContactSim(
             [
                 {"geom1": "cube_1_g3", "geom2": "robot0_gripper_finger_r"},
@@ -745,7 +735,7 @@ class TestDegradationContract:
 
 class _GeomContactSim:
     """Sim exposing both body positions and geom-prefix contacts, for the
-    ``body_on(require_contact=True)`` LIBERO-style combined check."""
+    ``body_on(require_contact=True)`` combined geometric+contact check."""
 
     def __init__(self, positions: dict[str, list[float]], contacts: list[dict[str, Any]], status: str = "success"):
         self._pos = positions
@@ -941,33 +931,42 @@ class TestExtractJsonHelperGuard:
 
 # Name-resolution surfacing (#176 follow-up): a spec that references a body /
 # joint the backend supports looking up but cannot resolve (a typo) must not be
-# silent. It still degrades to a constant, but the name is logged once, and the
-# LIBERO ``<name>_main`` root-body fallback now also covers the quaternion path.
+# silent. It still degrades to a constant, but the name is logged once.
 
 _PRED_LOGGER = "strands_robots.simulation.predicates"
 
 
-class TestBodyUprightLiberoMainFallback:
-    """body_upright must resolve the LIBERO ``<name>_main`` root body.
+class _RecordingQuatSim(_BodyStateWithQuatSim):
+    """``_BodyStateWithQuatSim`` that records every body name it was asked for."""
 
-    BDDL ``(upright X)`` compiles to ``body_upright(body=X)`` with the bare
-    object name, but the MJCF root body of a procedurally-generated LIBERO
-    object is ``X_main``. Before the fix, ``_body_quaternion`` tried only the
-    bare name (unlike ``_body_position``, which has the fallback), so an upright
-    mug silently scored as not-upright and the goal was never satisfiable.
+    def __init__(self, bodies: dict[str, dict[str, Any]]):
+        super().__init__(bodies)
+        self.probed: list[str] = []
+
+    def get_body_state(self, body_name: str) -> dict[str, Any]:
+        self.probed.append(body_name)
+        return super().get_body_state(body_name)
+
+
+class TestOrientationResolvesTheSameNamesAsPosition:
+    """The orientation lookup asks for exactly the names the position lookup does.
+
+    ``_body_quaternion`` mirrors ``_body_position``'s resolution so a single
+    clause's position and orientation can never be read off two different
+    bodies - which is what a suffix fallback on only one of the two would do.
     """
 
-    def test_upright_resolves_via_main_suffix(self):
-        # Only the _main root body exists (the bare BDDL name does not).
-        sim = _BodyStateWithQuatSim({"mug_main": {"quaternion": [1, 0, 0, 0]}})
+    def test_orientation_of_an_undeclared_body_is_not_reached_through_a_suffix(self):
+        sim = _RecordingQuatSim({"mug_main": {"quaternion": [1, 0, 0, 0]}})
         pred = make_predicate("body_upright", body="mug")
-        assert pred(sim) is True  # FAILS pre-fix: no _main fallback -> False
-
-    def test_upright_tilted_via_main_suffix_is_false(self):
-        # Resolves via _main but genuinely tipped over -> correctly False.
-        sim = _BodyStateWithQuatSim({"mug_main": {"quaternion": [0.707, 0.707, 0.0, 0.0]}})
-        pred = make_predicate("body_upright", body="mug", tol=0.1)
         assert pred(sim) is False
+        assert sim.probed == ["mug"]
+
+    def test_orientation_of_a_declared_body_resolves_in_a_single_probe(self):
+        sim = _RecordingQuatSim({"mug": {"quaternion": [0.707, 0.707, 0.0, 0.0]}})
+        pred = make_predicate("body_upright", body="mug", tol=0.1)
+        assert pred(sim) is False  # declared, resolved, and genuinely tipped over
+        assert sim.probed == ["mug"]
 
 
 class TestUnresolvedNameSurfacing:

--- a/tests/simulation/test_contact_geom_name_resolution.py
+++ b/tests/simulation/test_contact_geom_name_resolution.py
@@ -3,7 +3,7 @@
 ``get_contacts`` reports a contact as a pair of geom NAMES, and for a geom the
 asset left unnamed it synthesizes ``"<body>/geom_<id>"``. Two body-level
 predicates consume those names -- ``grasped`` and
-``body_on(require_contact=True)``, the gate every LIBERO ``(on A B)`` goal runs
+``body_on(require_contact=True)``, the gate every ``on(A, B)`` goal runs
 through -- and they used two different matchers:
 
 * ``_body_contact`` matched only the ``<body>_g`` prefix inline, so a geom named
@@ -41,8 +41,8 @@ from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
 _MATCHING = [
     ("mug", "a single-geom scene whose geom is named after the body"),
     ("mug_geom", "the strands add_object convention"),
-    ("mug_g0", "the LIBERO / robosuite <body>_g<idx> convention"),
-    ("mug_g11", "a double-digit LIBERO geom index"),
+    ("mug_g0", "the numbered <body>_g<idx> multi-geom convention"),
+    ("mug_g11", "a double-digit geom index"),
     ("mug/geom_2", "the name get_contacts synthesizes for an unnamed geom"),
     ("mug/geom_81", "a double-digit synthesized id"),
 ]
@@ -198,7 +198,7 @@ class TestRestingContactIsDetected:
 
     @pytest.mark.parametrize("fixture_name", ["unnamed_geoms", "geoms_named_after_bodies"])
     def test_body_on_require_contact_succeeds(self, fixture_name: str, request) -> None:
-        """The gate every LIBERO ``(on A B)`` goal is compiled with."""
+        """The gate every ``on(A, B)`` goal is compiled with."""
         sim = request.getfixturevalue(fixture_name)
         # Premise: the scene really is in contact, so a False verdict below
         # would be a false negative rather than an honest miss.


### PR DESCRIPTION
![predicate body-name resolution, before and after](https://raw.githubusercontent.com/cagataycali/robots/assets/predicates-main-fallback-34424095337/predicate_disagreement.png)

The predicate DSL looked every body name up **twice**: the name the spec wrote, then `<name>_main`. That second probe served the procedurally-generated objects of the vendored LIBERO adapter removed in #3056, whose MJCF root body carried the suffix while the goal named the object bare. Both lookups now resolve the name the scene declares, and only that name.

## Why remove it rather than keep it for a scene still shaped that way

The convention was only ever **half** honoured. `_geom_belongs_to_body` - the single owner of the body-to-geom mapping, and the gate every contact-aware predicate runs through - matches `<body>_g`, so `cube_1_main_g0` is not one of `cube_1`'s geoms. One clause naming `cube_1` therefore read a *position* off `cube_1_main` while the contact half saw nothing at all.

Measured on the real MuJoCo scene above (mug resting on a table, root body `mug_main`, geoms `mug_main_g0/g1`, 4 contacts, 60 samples at 50 Hz over settled physics):

| clause naming `mug` | before | after |
| --- | --- | --- |
| `body_above_z(mug, z=0.41)` (geometric half) | **True 60/60** - via `mug_main` | False 60/60 |
| `body_on(mug, table, require_contact=True)` (contact half) | False 60/60 | False 60/60 |
| **the two halves disagree** | **60/60 samples** | **0/60** |
| `body_above_z(mug_main)` - the declared name (control) | True 60/60 | True 60/60 |

The geometric half silently answered for a body the contact half could not see. A spec author reading `body_above_z` as satisfied and `grasped` as unsatisfied had no way to tell the two predicates were talking about different bodies.

A name the scene does not declare now degrades the way every other unresolved name does - `_warn_unresolved` logs it once and the term becomes a constant - instead of resolving to a different body that shares a prefix. The `tried` list drops to the single name asked for, so the warning names what the spec wrote. A body genuinely called `plate_1_main` still resolves; the suffix was only ever *synthesized*, never special-cased away.

## Nothing on `main` emits a `_main` root body

```
$ grep -rl '_main' strands_robots/assets | wc -l
0                                    # ships no MJCF at all
$ grep -c '_main' strands_robots/simulation/builtin_benchmarks.py
0
$ find . -iname '*libero*' -not -path './.git/*'
./changelog.d/2459-isaac-libero-object-meshes.md
./changelog.d/3056-remove-vendored-libero-benchmark.md      # the generator is gone
```

## Tests pin the names probed, not just the verdict

A recording sim asserts `probed == [<the one name>]` on both the position and the orientation path, so a reintroduced fallback fails on the *extra probe* even where it would return the same answer. Mutations over the two predicate test files (153 cells):

| mutation | F | P | cells fired |
| --- | --- | --- | --- |
| the `<name>_main` fallback restored on both lookups | 2 | 151 | both `..._not_reached_through_a_suffix` |
| restored on the position lookup only | 1 | 152 | `test_a_body_the_scene_does_not_declare_is_not_reached_through_a_suffix` |
| restored on the orientation lookup only | 1 | 152 | `test_orientation_of_an_undeclared_body_is_not_reached_through_a_suffix` |
| suffix probed **before** the declared name - *identical verdicts* | 2 | 151 | + `test_a_declared_body_resolves_in_a_single_probe` |
| (restored, my tree) | 0 | 153 | - |

The last row is why the probe assertion earns its line: that mutant returns the same answer for every body and is caught only by the probe count.

Pre-fix: these two test files against pristine `predicates.py` give **2 failed / 151 passed**; after, **153 passed**.

## Scope

The `<body>_g<idx>` branch **stays** - one `startswith(f"{body}_g")` serves both it and strands-native `add_object`'s `<body>_geom`, so it is live. Its docstring, and the two tests named for the departed vendor, are retargeted at the convention they actually cover. `body_on`, `check_ontop`, `grasped` and `_body_contact` are unchanged in behaviour; only prose that explained them by reference to a removed adapter moved.

## Numbers

| | before | after |
| --- | --- | --- |
| `predicates.py` executable statements | 694 | **682** (-12) |
| `libero\|bddl\|robosuite` refs, the 3 files | 43 | **0** |
| tests in the two predicate files | 153 | 153 |

Net diff excluding the changelog fragment: **+113 / -145**.

## Gate

- `ruff check` + `ruff format --check` on `strands_robots tests tests_integ`: clean, 1991 files
- `mypy` (pinned 1.20.2, the `<2.0.0` cap): `Success: no issues found in 1937 source files`
- `MUJOCO_GL=egl pytest tests/`: **52,237 passed / 304 skipped / 1 failed** in 29m33s

The one failure is `tests/simulation/mujoco/test_state_mutation_blocked_during_policy.py::test_state_mutation_guard_is_global_scope`, which asserts a mutation is refused *while* a policy is running. It references nothing this PR touches (0 hits for `predicate`/`_body_position`/`_body_quaternion`/`_main`) and passes standalone (4/4); the run had three other full suites on the same host, so the policy thread had finished before the mutation attempt.

Artifact rendered headless (`MUJOCO_GL=egl`); both trees measured in separate subprocesses with a provenance assert on `strands_robots.__file__` and on whether the fallback is present in the loaded source.