### PR TITLE
fix(drivers/robotiq): a halt that never reached the gripper is reported

### DIFF
--- a/changelog.d/3390-robotiq-stop-reports-the-halt-it-could-not-reach.md
+++ b/changelog.d/3390-robotiq-stop-reports-the-halt-it-could-not-reach.md
@@ -1,0 +1,22 @@
+### Fixed: a Robotiq halt that never reached the gripper is reported
+
+`RobotiqDriver.stop` wrote its own `rGTO`-clearing frame and, when the wire
+refused it, called `logger.debug`. The root logger sits at `WARNING` until
+something lowers it, so on a default configuration that call emitted nothing and
+named no gripper - and `stop` is annotated `-> None`, so no envelope, flag or log
+anywhere recorded that the fingers had not stopped. A 2F-85 whose halt does not
+land keeps travelling to the last commanded aperture, closing on whatever is
+between the fingers or opening and releasing it.
+
+`stop` now delegates to `stop_task`, which already decided a verdict for the
+identical write, and logs a non-success through `halt_failure_detail` at `error`
+naming the gripper and what the wire said - the shape `BoosterDriver`,
+`EarthRoverDriver` and `CrazyflieDriver` already use, and the one
+`HardwareDriver.stop` documents. Behaviour on a disconnected gripper is
+unchanged: `stop_task` answers `success` there, so nothing is logged.
+
+`tests/drivers/test_stop_hook_logs_the_halt_it_could_not_complete.py` graded only
+the hooks that delegate to an envelope verb, which is why a hook holding its own
+wire was invisible to it. It now carries a second derived relation: a `stop` that
+catches its own wire failure must report it at a level a default configuration
+emits, naming the robot.

--- a/strands_robots/drivers/robotiq/driver.py
+++ b/strands_robots/drivers/robotiq/driver.py
@@ -43,7 +43,7 @@ import time
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any, cast
 
-from strands_robots.drivers.base import undeclared_verb_error
+from strands_robots.drivers.base import halt_failure_detail, undeclared_verb_error
 from strands_robots.drivers.robotiq.protocol import (
     DEFAULT_TCP_PORT,
     DEFAULT_UNIT_ID,
@@ -479,14 +479,23 @@ class RobotiqDriver:
         Clearing ``rGTO`` stops motion without dropping the activation, so the
         next :meth:`send_action` moves immediately rather than paying for
         another calibration stroke. A stop on a disconnected gripper is a no-op
-        rather than an error - there is nothing moving to halt.
+        rather than an error - there is nothing moving to halt, which is the
+        ``success`` :meth:`stop_task` answers there.
+
+        Annotated ``-> None`` by the driver protocol, so it carries no verdict:
+        this delegates to :meth:`stop_task` rather than repeating its write, and
+        logs what that envelope decided. A halt that did not reach the gripper
+        leaves the fingers travelling to their last commanded aperture - closing
+        on whatever is between them, or opening and releasing it - so the log is
+        the only surface left that can say the gripper did not stop.
         """
-        if not self.is_connected:
-            return
-        try:
-            self._write_command(activate=True, go_to=False)
-        except (OSError, ProtocolError) as exc:
-            logger.debug("stop could not reach the gripper: %s", exc)
+        if (detail := halt_failure_detail(self.stop_task())) is not None:
+            logger.error(
+                "%s.stop(): the halt did not reach the gripper, whose fingers may still be "
+                "travelling to the last commanded aperture: %s",
+                self._tool_name,
+                detail,
+            )
 
     def cleanup(self) -> None:
         """Close the socket. Leaves the gripper activated and holding position."""

--- a/tests/drivers/robotiq/conftest.py
+++ b/tests/drivers/robotiq/conftest.py
@@ -39,6 +39,10 @@ class FakeGripper:
         commanded: Every ``rPR`` the gripper was told to go to, in order, for a
             test to assert what actually reached the wire.
         writes: Every decoded output payload, for asserting the flag bits.
+        exception_code: While set, every request is answered with a Modbus
+            exception carrying this code. Writable after construction so a test
+            can make a connected controller *start* refusing, which is how the
+            wire fails in the field - a driver reaches it once and then does not.
     """
 
     def __init__(
@@ -72,7 +76,7 @@ class FakeGripper:
         self._object_status = object_status
         self._fault = fault
         self._current = current
-        self._exception_code = exception_code
+        self.exception_code = exception_code
         self._never_activates = never_activates
 
         self.activated = starts_activated
@@ -156,8 +160,8 @@ class FakeGripper:
 
     def _answer(self, transaction: int, unit: int, body: bytes) -> bytes:
         function = body[0]
-        if self._exception_code is not None:
-            return _frame(transaction, unit, struct.pack(">BB", function | 0x80, self._exception_code))
+        if self.exception_code is not None:
+            return _frame(transaction, unit, struct.pack(">BB", function | 0x80, self.exception_code))
         if function == WRITE_MULTIPLE_REGISTERS:
             address, count, _byte_count = struct.unpack(">HHB", body[1:6])
             self._apply(body[6 : 6 + count * 2])

--- a/tests/drivers/robotiq/test_robotiq_gripper_moves_over_modbus_tcp.py
+++ b/tests/drivers/robotiq/test_robotiq_gripper_moves_over_modbus_tcp.py
@@ -10,6 +10,8 @@ assertions read what reached the wire.
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, cast
 
@@ -229,6 +231,33 @@ def test_stopping_halts_the_fingers_without_dropping_activation(connected: Conne
     assert fake.writes[-1]["go_to"] == 0, "rGTO must be cleared to halt"
     assert fake.writes[-1]["activate"] == 1, "rACT must stay set to keep the gripper activated"
     assert fake.activation == 3
+
+
+def test_a_halt_that_could_not_reach_the_gripper_is_reported_not_swallowed(
+    connected: Connected, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The verdict-free ``stop`` hook has only the log to record an unreached halt.
+
+    ``stop_task`` decides a verdict for the same write and can say the gripper
+    refused it; ``stop`` is annotated ``-> None`` and cannot. So a halt that did
+    not land has to be reported at a level a default logging configuration emits,
+    naming the gripper - the fingers are still travelling to the last commanded
+    aperture, and nothing else anywhere records that the gripper did not stop.
+    """
+    driver, fake = connected()
+    fake.exception_code = 0x02  # a connected controller that starts refusing.
+
+    # The information the hook needs exists: the same write, read as an envelope.
+    assert driver.stop_task()["status"] == "error"
+
+    with caplog.at_level(logging.WARNING, logger="strands_robots.drivers.robotiq.driver"):
+        asyncio.run(driver.stop())
+
+    reported = [record for record in caplog.records if record.levelno >= logging.WARNING]
+    assert reported, "an unreached halt was reported nowhere a default configuration emits"
+    message = reported[0].getMessage()
+    assert "robotiq_2f85" in message, f"the report must name the gripper: {message!r}"
+    assert "0x02" in message, f"the report must carry what the wire said: {message!r}"
 
 
 @pytest.mark.parametrize("verb", ["start_task", "run_policy"])

--- a/tests/drivers/test_stop_hook_logs_the_halt_it_could_not_complete.py
+++ b/tests/drivers/test_stop_hook_logs_the_halt_it_could_not_complete.py
@@ -40,6 +40,21 @@ rather than listed: *a ``stop`` that calls one of its own envelope-returning
 verbs must read what that verb answered.* Nine of the twelve shipped drivers
 already satisfied it - seven log the failure directly at the wire and two read a
 delegated envelope first - so this pins the shape they already have.
+
+That relation only reaches the hooks that *delegate*. Three reached the wire
+themselves and guarded it with ``except``, and one of the three - ``RobotiqDriver``
+- reported the failure with ``logger.debug`` and did not name the gripper, while
+its own ``stop_task`` decided a real verdict for the identical write. The root
+logger sits at ``WARNING`` until something lowers it, so that call emitted
+nothing at all: the "seven log the failure directly at the wire" above counted a
+report no operator receives. A 2F-85 whose halt did not land leaves the fingers
+travelling to the last commanded aperture - closing on whatever is between them,
+or opening and releasing it - and ``stop`` returns ``None``, so there was no
+surface anywhere saying the gripper had not stopped. Hence the second relation,
+derived the same way: *a ``stop`` that catches its own wire failure must report it
+at a level a default configuration emits, naming the robot.* ``RobotiqDriver.stop``
+now delegates to ``stop_task`` like the three above, which leaves that population
+the two hooks that really do hold the wire themselves.
 """
 
 from __future__ import annotations
@@ -205,6 +220,127 @@ class TestTheRelationIsNotVacuous:
         # call to it is not the shape this relation is about.
         node = ast.parse("async def stop(self) -> None:\n    self._halt_repeater()\n").body[0]
         assert _discarded_envelopes(node, {"stop_task", "land"}) == []
+
+
+# --------------------------------------------------------------------------- #
+# The same asymmetry, for the hooks that reach the wire themselves.            #
+# --------------------------------------------------------------------------- #
+
+#: Logging levels a default configuration actually emits. The root logger sits at
+#: ``WARNING`` until something lowers it, so a call below that is not a report at
+#: all: it runs, formats nothing, and the failure reaches no operator. That makes
+#: ``logger.debug`` indistinguishable from dropping the exception on the floor.
+_EMITTED_LEVELS = frozenset({"warning", "error", "exception", "critical"})
+
+
+def _logger_calls(node: ast.AST) -> list[tuple[str, ast.Call]]:
+    """Every ``logger.<level>(...)`` call in this body, paired with its level."""
+    return [
+        (call.func.attr, call)
+        for call in ast.walk(node)
+        if isinstance(call, ast.Call)
+        and isinstance(call.func, ast.Attribute)
+        and isinstance(call.func.value, ast.Name)
+        and call.func.value.id == "logger"
+    ]
+
+
+def _unreported_wire_failures(node: ast.AST) -> list[str]:
+    """Handlers in this hook that catch a wire failure and report it to nobody.
+
+    :func:`_discarded_envelopes` grades the hooks that delegate to a verb which
+    decides a verdict. A hook that instead guards its own wire call with
+    ``except`` is invisible to it, and owes exactly the same thing: ``stop``
+    returns ``None``, so the handler is the last place the failure can be
+    recorded. Two ways to fail that are the same absence - reporting below the
+    level a default configuration emits, and not naming which robot did not stop,
+    which in a fleet teardown leaves an operator with a message they cannot act
+    on.
+    """
+    unreported = []
+    for handler in (h for h in ast.walk(node) if isinstance(h, ast.ExceptHandler)):
+        caught = ast.unparse(handler.type) if handler.type else "<bare except>"
+        calls = _logger_calls(handler)
+        emitted = [call for level, call in calls if level in _EMITTED_LEVELS]
+        if not emitted:
+            levels = sorted({level for level, _ in calls})
+            unreported.append(f"except {caught}: reports at {levels or ['nothing at all']}")
+        elif not any("_tool_name" in ast.dump(call) for call in emitted):
+            unreported.append(f"except {caught}: the report does not name the robot")
+    return unreported
+
+
+class TestEveryStopHookReportsTheWireFailureItCaught:
+    """The relation for the hooks that hold the wire themselves."""
+
+    def test_the_population_is_the_hooks_that_guard_their_own_wire_call(self) -> None:
+        guarding = sorted(
+            name
+            for name, cls in _driver_classes().items()
+            if any(isinstance(node, ast.ExceptHandler) for node in ast.walk(_method_ast(cls, "stop")))
+        )
+        # Named so the relation cannot quietly empty out into a vacuous pass.
+        assert guarding == ["MicroduckDriver", "URDriver"], guarding
+
+    def test_no_caught_wire_failure_goes_unreported(self) -> None:
+        offenders = {
+            name: unreported
+            for name, cls in sorted(_driver_classes().items())
+            if (unreported := _unreported_wire_failures(_method_ast(cls, "stop")))
+        }
+        assert offenders == {}, (
+            "these stop hooks catch a failure to halt the robot and report it nowhere an "
+            "operator will see. stop() returns None, so nothing else records that the robot "
+            f"did not stop: {offenders}"
+        )
+
+
+class TestTheWireRelationIsNotVacuous:
+    """Graded on constructed sources, so a clean tree is not the only evidence."""
+
+    _COMPLIANT = """
+        async def stop(self) -> None:
+            try:
+                self._write(0)
+            except OSError as exc:
+                logger.error("%s.stop(): it did not stop: %s", self._tool_name, exc)
+    """
+    _BELOW_THE_THRESHOLD = """
+        async def stop(self) -> None:
+            try:
+                self._write(0)
+            except OSError as exc:
+                logger.debug("could not reach it: %s", exc)
+    """
+    _UNNAMED_ROBOT = """
+        async def stop(self) -> None:
+            try:
+                self._write(0)
+            except OSError as exc:
+                logger.error("the halt did not land: %s", exc)
+    """
+    _SILENT = """
+        async def stop(self) -> None:
+            try:
+                self._write(0)
+            except OSError:
+                pass
+    """
+
+    def test_a_named_report_at_an_emitted_level_is_accepted(self) -> None:
+        node = ast.parse(textwrap.dedent(self._COMPLIANT)).body[0]
+        assert _unreported_wire_failures(node) == []
+
+    @pytest.mark.parametrize("source", ["_BELOW_THE_THRESHOLD", "_UNNAMED_ROBOT", "_SILENT"])
+    def test_a_failure_an_operator_cannot_see_is_refused(self, source: str) -> None:
+        node = ast.parse(textwrap.dedent(getattr(self, source))).body[0]
+        assert len(_unreported_wire_failures(node)) == 1
+
+    def test_debug_is_reported_as_the_non_report_it_is(self) -> None:
+        # The wording matters: "reports at ['debug']" is what tells a reader the
+        # call is there and still emits nothing under a default configuration.
+        node = ast.parse(textwrap.dedent(self._BELOW_THE_THRESHOLD)).body[0]
+        assert _unreported_wire_failures(node) == ["except OSError: reports at ['debug']"]
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
![robotiq stop halt report](https://raw.githubusercontent.com/cagataycali/robots/assets/robotiq-stop-report-34424124486/robotiq-stop-report.png)

`RobotiqDriver.stop` reported a halt the wire refused with `logger.debug`. The root logger sits at `WARNING` until something lowers it, so that call emitted nothing, and it named no gripper. `stop` is annotated `-> None`, so there was no envelope, flag or log anywhere saying the fingers had not stopped.

Measured against a scripted Modbus TCP 2F-85 (`tests/drivers/robotiq/conftest.py`), closing on a part when the controller starts answering Modbus exception `0x02`:

| surface | before | after |
|---|---|---|
| `stop_task()` envelope | `error` (verdict exists) | `error` (unchanged) |
| gripper `rGTO` after the halt | `1` - still commanded to close | `1` (unchanged) |
| gripper `rPR` after the halt | `255` - fully closed | `255` (unchanged) |
| halt frames that landed | `0` | `0` (unchanged) |
| **operator sees, at the default level** | **nothing** | `ERROR`, naming the gripper and the Modbus exception |

Nothing about the wire changes: the halt never lands either way. What changes is that the failure is now reported. A 2F-85 whose halt does not land keeps travelling to the last commanded aperture - closing on whatever is between the fingers, or opening and releasing it.

## The fleet already agreed on this

Of the eleven shipped drivers whose `stop` reports a halt failure, ten report at `error`/`warning` and name the robot. Robotiq was the only one below `WARNING`, and the only one that named no robot:

| | report level | names the robot |
|---|---|---|
| booster, crazyflie, earthrover, feetech, g1, go2 | `error` | yes |
| franka, microduck, reachy, ur | `warning` | yes |
| **robotiq** | **`debug`** | **no** |

`HardwareDriver.stop`'s own docstring already required it: "an implementation that delegates to a halt verb must read that verb's envelope and log a non-success ... `halt_failure_detail` reads the reason out of such an envelope."

## The change

`stop` now delegates to `stop_task`, which already decided a verdict for the byte-identical write (`_write_command(activate=True, go_to=False)` under the same `except`), and reports it through `halt_failure_detail` - the shape `BoosterDriver`, `EarthRoverDriver` and `CrazyflieDriver` already use. Disconnected behaviour is unchanged: `stop_task` answers `success` there, so nothing is logged.

`strands_robots/drivers/robotiq/driver.py`: **-3 executable statements** (258 -> 255); the added lines are docstring.

## Why the existing guard did not catch it

`tests/drivers/test_stop_hook_logs_the_halt_it_could_not_complete.py` derives its population as *a `stop` that calls one of its own envelope-returning verbs*. Robotiq's `stop` re-implemented the halt at the wire instead of calling `stop_task`, so it was structurally invisible to it - while that file's own premise counted robotiq among "seven log the failure directly at the wire", a report no operator receives. The premise is corrected and a second relation added, derived the same way: *a `stop` that catches its own wire failure must report it at a level a default configuration emits, naming the robot.* That population is now `MicroduckDriver` and `URDriver`, both already compliant.

## Evidence

Pre-fix, with only the tests applied to `upstream/main`: **3 failed**, including the diagnostic
`{'RobotiqDriver': ["except (OSError, ProtocolError): reports at ['debug']"]}`.

| mutation | cells failed |
|---|---|
| unmutated | 0 |
| the fix reverted (own write + `logger.debug`) | 3 |
| delegates, but reports at `debug` | 1 |
| reports at `error`, but does not name the gripper | 1 |
| the guard counts `debug` as a report | 1 |
| the guard stops requiring the robot be named | 1 |

Full `tests/`: **52308 passed, 304 skipped, 0 failed** (29m49s). `ruff check` + `ruff format --check` clean over 1994 files; `mypy` clean over 1940. `tests/drivers/` 2725 passed on the rebased base.

`FakeGripper.exception_code` became public so a test can make an already-connected controller *start* refusing, which is how the wire fails in the field.