### PR TITLE
refactor(training): the training core states the domain it checks, not the history of the check

### DIFF
--- a/changelog.d/3391-training-core-docstring-diet.md
+++ b/changelog.d/3391-training-core-docstring-diet.md
@@ -1,0 +1,24 @@
+### Docs: the training core states the domain it checks, not the history of the check
+
+`training/base.py` and `training/_validate.py` were 82% and 85% docstring: a
+158-line module docstring that enumerated the shared validation gates as
+ordinals ("the eleventh", "the twelfth" ...), 27 `Trainer._*_problems`
+forwarders carrying 20-48 lines of narration each over a two-line lazy-import
+body, and gate docstrings that restated the same `Args:`/`Returns:` block 27
+times. A reader looking for a field's domain had to read a measurement of a
+past run to find it.
+
+The two files now say what each surface accepts. The five shared domains
+(count, cadence, rate, weight, clip bound, unit interval) are stated once in
+`_validate`'s module docstring and each gate names its field and its domain in
+a line or two; the lazy-import rule and the reads-the-field scoping rule are
+stated once on `Trainer` instead of once per method; `TrainSpec`'s `Attributes`
+block keeps every field and its domain and drops the per-field history.
+`RLTrainSpec.actor_obs_keys` and `critic_obs_keys` shared one combined entry
+and now have one each. No code changed: with docstrings stripped, both files
+are byte-identical to before.
+
+`tests/training/test_spec_fields_are_documented.py` pins what the prose is for
+- every `TrainSpec` / `RLTrainSpec` field has its own `Attributes` entry, and
+every shared gate names the field it reports on - so a future distillation
+cannot drop a field an agent has to populate or a knob a refusal names.

--- a/strands_robots/training/_validate.py
+++ b/strands_robots/training/_validate.py
@@ -1,160 +1,39 @@
-"""Shared, defense-in-depth input validation for the training backends.
+"""Shared input validation for the training backends.
 
-Every concrete :class:`~strands_robots.training.base.Trainer` translates a
-:class:`~strands_robots.training.base.TrainSpec` into its backend's native
-config object and runs it IN-PROCESS (imported and called as a library - no
-subprocess). The ``train_policy`` ``@tool`` lets an agent (LLM) populate that
-``TrainSpec`` directly, so the path fields and the free-form ``extra`` dict are
-*untrusted input that reaches backend internals*. Per ``AGENTS.md`` > Review
-Learnings (#92) > "LLM Input Safety", those values MUST be validated before they
-can become a config field, a Hydra override, or a token in a backend's
-argv-parity helper: a value beginning with ``-`` could read as a *new flag*, and
-an arbitrary ``extra`` key could set an arbitrary config attribute / override.
+Two kinds of gate live here.
 
-:func:`validate_train_inputs` is the single source of that check. It is invoked
-from every backend's :meth:`Trainer.validate`, which each backend's
-:meth:`Trainer.train` calls (fail-closed) before building any config - so no
-run can start with unvalidated input regardless of the call path.
+:func:`validate_train_inputs` is the input-safety gate. An agent populates
+:class:`~strands_robots.training.base.TrainSpec` directly, so its path fields,
+its flag-bound scalars and its free-form ``extra`` keys are untrusted values
+that reach backend internals: they must be safe to interpolate into a config
+field, a Hydra override or an argv token before any config is built. Every
+concrete :meth:`~strands_robots.training.base.Trainer.validate` calls it, and
+every ``train`` calls ``validate`` fail-closed.
 
-:func:`run_size_problems` is the second shared gate, on a different axis: the
-*run size* numerics. ``steps`` and ``global_batch_size`` are the two factors of
-how much training a spec asks for, and both are read straight into a backend's
-loop bound / dataloader. They live in their own gate rather than in
-:func:`validate_train_inputs` because :class:`TrainSpec` documents that a
-backend "reads the fields it supports and ignores the rest": the RL trainers
-drive training from ``total_timesteps`` / ``batch_size`` and never read either
-field, so reporting a problem for them there would be a false rejection of a
-field that backend does not use.
+The ``*_problems(spec, *, context)`` gates are read-only domain preflights.
+Each returns one message per field of *spec* it cannot honor and an empty list
+when the spec is usable; *context* is the caller's
+:attr:`~strands_robots.training.base.Trainer.provider_name`, prefixed to every
+message so a problem names the backend that refused the value. A gate reports
+only on fields its caller reads - :class:`TrainSpec` documents that a backend
+"reads the fields it supports and ignores the rest", so a backend that never
+reads a field must not call the gate that bounds it. Fields are grouped per
+gate by the axis they configure, not per backend.
 
-:func:`learning_rate_problems` is the third, on the optimization axis. It lives
-in its own gate for the opposite reason to :func:`run_size_problems`: *every*
-backend reads ``learning_rate`` -- the three supervised ones map it onto their
-config's optimizer field, and the RL trainers hand it straight to
-``torch.optim.Adam`` -- so there is no backend for which reporting on it would
-be a false rejection, and :class:`~strands_robots.training.rl.base_algo.RLTrainSpec`
-documents the field as one of the "universal" ones. It is separate from
-:func:`validate_train_inputs` because that gate answers a different question
-(is this value safe to interpolate into a config or an argv token) from this one
-(can this value be honored at all).
+The domains are the shared ones from :mod:`strands_robots.utils`:
 
-:func:`launch_topology_problems` is the fourth, on the *launch topology* axis:
-``num_gpus`` and ``num_nodes``, the two process counts every distributed launch
-is sized from. It is scoped like :func:`run_size_problems` rather than like
-:func:`learning_rate_problems` - only the three supervised backends read either
-field (they become a ``torchrun``/``elastic_launch`` ``nproc_per_node`` /
-``nnodes``), so a backend that ignores them must not report on them.
-
-:func:`seed_problems` is the fifth, on the reproducibility axis, and
-:func:`validation_episodes_problems` the sixth, on the *evaluation* axis:
-``val_episodes``, the episode count a caller reserves as a held-out validation
-set. It is scoped like :func:`run_size_problems` - only the LeRobot backend
-reads the field (GR00T, Cosmos and the RL trainers never do), so a backend that
-ignores it must not report on it. What makes a shared gate the right home
-rather than a local test is the conversion: the count becomes a real-valued
-split fraction whose ceiling lerobot takes, so a comparison admits values that
-reserve a different number of episodes than the one asked for.
-
-:func:`lora_hyperparameter_problems` is the seventh, on the *adapter* axis:
-``lora_r`` and ``lora_alpha``, the rank and the scaling numerator of a LoRA
-fine-tune. It is scoped like :func:`run_size_problems` and narrowed once more -
-only the LeRobot backend reads either field, and only on its ``method == "lora"``
-branch, so a value a run's own strategy never reads must not be reported.
-
-:func:`discount_factor_problems` is the eighth, on the *return* axis:
-``gamma``, the discount factor of the return the algorithm optimizes. It is
-scoped like :func:`learning_rate_problems` rather than like
-:func:`run_size_problems` - it is the one
-:class:`~strands_robots.training.rl.base_algo.RLTrainSpec` coefficient that
-*every* RL backend reads (PPO discounts the GAE recursion with it, FastSAC
-discounts its target-Q bootstrap), so there is no RL backend for which
-reporting on it would be a false rejection.
-
-:func:`gae_lambda_problems` is the ninth, on the same *return* axis and for the
-sibling factor: ``lam``, the GAE trace-decay coefficient. It is a separate gate
-from :func:`discount_factor_problems` because the two fields are scoped
-differently - every RL backend reads ``gamma``, but only the on-policy backend
-estimates an advantage trace, so per :class:`TrainSpec` FastSAC must not report
-on a field it never reads. They are nonetheless one contract: the trace decays
-by the *product* ``gamma * lam``, so bounding one factor does not bound the
-trace.
-
-:func:`optimization_epochs_problems` is the tenth, on the *optimization* axis:
-``num_learning_epochs``, the number of passes the on-policy update makes over
-each rollout batch. It is the loop bound of the entire optimizer step
-(``for _ in range(spec.num_learning_epochs)`` wraps every ``optimizer.step()``),
-so a non-positive value takes no gradient step at all while the run still
-collects its rollouts, writes a deployable checkpoint and reports success. It is
-scoped like :func:`gae_lambda_problems`: only the on-policy backend has an epoch
-loop, so FastSAC must not report on a field it never reads.
-
-:func:`temperature_learning_rate_problems` is the eleventh, on the same
-*optimization* axis as :func:`learning_rate_problems` and for its sibling
-field. FastSAC builds *two* optimizers from two separate learning-rate fields -
-``learning_rate`` for the actor and both critics, and ``alpha_lr`` for the
-entropy temperature - and passes each straight to
-``torch.optim.Adam(..., lr=...)``, so the failure modes
-:func:`learning_rate_problems` documents apply to the second field verbatim.
-It is a separate gate for the same reason as :func:`gae_lambda_problems`: only
-the off-policy backend tunes a temperature.
-
-:func:`gradient_clip_problems` is the twelfth, on the same *optimization* axis:
-``max_grad_norm``, the norm the on-policy update clips every gradient to before
-stepping. It is scoped like :func:`gae_lambda_problems` - only the on-policy
-backend clips, so FastSAC must not report on a field it never reads - and it is
-the one coefficient of that group whose zero reading *is* settled, by
-``torch.nn.utils.clip_grad_norm_`` itself: see that gate for the measurement.
-
-:func:`loss_weight_problems` is the thirteenth, on the same *optimization* axis
-and the last of that group whose endpoints are not the question: ``value_loss_coef``
-and ``entropy_coef``, the two scalars that weight the terms of the composed
-on-policy objective. It is scoped like :func:`gradient_clip_problems` - only the
-on-policy backend composes that objective - and it bounds the *domain* rather than
-the floor: zero and negative are real configurations for both fields, while a
-non-finite or non-numeric weight is a value no reading makes usable.
-
-:func:`clip_range_problems` is the fourteenth, and the second of the two clip
-bounds on that same *optimization* axis: ``clip_param``, the half-width of the
-trust region the on-policy surrogate is clipped to, which also clips the value
-loss. It shares :func:`_clip_bound_error` with :func:`gradient_clip_problems`
-because the two bounds have one domain for one reason - a clip bound is a
-positive width, and positive infinity is each field's only spelling of "do not
-clip". It is scoped like :func:`gae_lambda_problems`: ``spec.clip_param`` is read
-in ``rl/ppo.py`` and nowhere else.
-
-:func:`policy_delay_problems` is the fifteenth, on the *optimization* axis:
-``policy_delay``, the number of critic updates FastTD3 runs per delayed actor /
-target update. It is consumed as the modulus of an ``update_count %
-policy_delay`` test, so a value that never satisfies the test silently trains
-the critics for the whole run while the deployable actor never takes a
-gradient step - under a successful result. It is scoped like
-:func:`gae_lambda_problems`: only the TD3 backend delays its policy, so a
-backend that does not read the field must not report on it.
-
-:func:`td3_noise_problems` is the sixteenth, on the *exploration/target* axis:
-``exploration_noise_std``, ``target_noise_std`` and ``target_noise_clip``, the
-three scalars that shape FastTD3's two noise mechanisms - exploration noise on
-collection and target policy smoothing in the critic's TD target. Gaussian
-noise is symmetric, so a negative scale is silently the identical
-distribution, zero silently removes the mechanism the field configures, and a
-non-finite value poisons the actions or the TD target. It is scoped like
-:func:`policy_delay_problems`: only the TD3 backend reads the three fields.
-
-:func:`network_width_problems` is the seventeenth, on the *architecture* axis:
-``hidden_dims``, the hidden layer widths every from-scratch RL backend builds
-its actor and its critics from. It is scoped like
-:func:`learning_rate_problems` rather than like :func:`gae_lambda_problems` -
-all three RL backends read the field, for every network they construct - and it
-is the only one of these gates whose field is a *sequence*, so the domain is
-asked of each element in turn and the message names the offending index.
-
-:func:`rl_checkpoint_interval_problems` is the eighteenth, and the second gate on
-the *cadence* axis :func:`checkpoint_cadence_problems` opened: ``log_interval``,
-the field the RL loop paces ``save_checkpoint`` by. It shares that gate's
-:func:`~strands_robots.utils.step_cadence_error` domain because the two fields
-are consumed identically - as the modulus of a periodic-checkpoint test - and
-differ only in which spec names them, so a cadence refused for a supervised run
-cannot be accepted for an RL one. It is scoped like
-:func:`network_width_problems`: all three RL backends run that loop.
+* count - a positive ``int``; ``bool`` and integral ``float`` are refused
+  (:func:`~strands_robots.utils.positive_count_error`).
+* cadence - a non-negative whole number of steps
+  (:func:`~strands_robots.utils.step_cadence_error`).
+* rate - a positive finite real
+  (:func:`~strands_robots.utils.positive_finite_number_error`).
+* weight - any finite real (:func:`~strands_robots.utils.finite_number_error`).
+* clip bound - a positive real, where ``inf`` spells "do not clip"
+  (:func:`_clip_bound_error`).
+* closed unit - a real in ``[0, 1]`` (:func:`_closed_unit_interval_error`);
+  half-open unit - a real in ``(0, 1]``
+  (:func:`_half_open_unit_interval_error`).
 """
 
 from __future__ import annotations
@@ -180,18 +59,14 @@ if TYPE_CHECKING:
     from strands_robots.training.base import TrainSpec
 
 # ``extra`` keys are interpolated into argv as ``--{key}=...`` (lerobot/groot)
-# or ``{key}=...`` (cosmos hydra). Allowlist the key FORMAT only: lowercase,
-# dotted (lerobot ``dataset.episodes`` / cosmos ``model.x.y``), no leading dash,
-# no ``=``, no whitespace or shell metacharacters. We deliberately do NOT try to
-# enumerate every valid backend flag - that allowlist is impossible to keep
-# current and would break the documented ``extra`` escape hatch.
+# or ``{key}=...`` (cosmos hydra). The key FORMAT is allowlisted, not the key
+# set: lowercase and dotted, no leading dash, no ``=``, no whitespace.
 _EXTRA_KEY_RE = re.compile(r"^[a-z][a-z0-9_.]*\Z")
 
-# Scalars that are interpolated as the value of a single argv flag
-# (e.g. ``--dataset.root={dataset_root}``). A leading ``-`` is the injection
-# vector: ``base_model="--config_path=/etc/passwd"`` would otherwise parse as a
-# separate flag. An interior ``=`` is harmless (the token stays single, no
-# shell) and is legitimate for HF revision refs, so it is NOT rejected.
+# Scalars interpolated as the value of a single argv flag (e.g.
+# ``--dataset.root={dataset_root}``). A leading ``-`` is the injection vector:
+# ``base_model="--config_path=/etc/passwd"`` would parse as a separate flag.
+# An interior ``=`` keeps the token single and is legitimate for HF refs.
 _FLAG_BOUND_FIELDS = ("dataset_root", "output_dir", "base_model", "embodiment", "dataset_repo_id")
 
 # Path-like fields additionally get the audited filesystem check (null bytes,
@@ -200,12 +75,11 @@ _PATH_FIELDS = ("dataset_root", "output_dir")
 
 
 def validate_train_inputs(spec: TrainSpec) -> list[str]:
-    """Return a list of input-safety problems for a :class:`TrainSpec`.
+    """Return input-safety problems for *spec*; empty when every value is safe.
 
-    An empty list means every agent-supplied value is safe to interpolate into
-    a backend config / argv-parity helper. Pure and side-effect-free
-    (read-only ``realpath`` only),
-    so it is safe to call from :meth:`Trainer.validate`.
+    Checks the path fields for traversal and protected directories, refuses a
+    flag-bound scalar that starts with ``-``, and refuses an ``extra`` key
+    outside the allowlisted format.
     """
     problems: list[str] = []
 
@@ -237,30 +111,7 @@ def validate_train_inputs(spec: TrainSpec) -> list[str]:
 
 
 def run_size_problems(spec: TrainSpec, *, context: str) -> list[str]:
-    """Return run-size problems for a :class:`TrainSpec`.
-
-    ``steps`` and ``global_batch_size`` are the two factors of the amount of
-    training a spec asks for, and each is consumed directly as a discrete
-    count: ``steps`` bounds the backend's optimizer loop (lerobot iterates
-    ``range(step, cfg.steps)``) and ``global_batch_size`` becomes a
-    ``DataLoader`` batch size / a ``--global_batch_size`` flag. Only a positive
-    integer can be honored, which is why both are checked against the one
-    shared :func:`~strands_robots.utils.positive_count_error` domain rather
-    than a local comparison: a bare ``value <= 0`` test admits every value that
-    is not comparably non-positive, so ``True`` reads as a silent run of one
-    step, a fractional or non-finite value reaches ``range()`` and raises
-    there, and a string raises out of the comparison itself - inside a
-    :meth:`Trainer.validate` that is documented to *return* problems.
-
-    Args:
-        spec: The spec to check.
-        context: Caller identity for the message prefix - the backend's
-            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
-            problem names the backend that refused the value.
-
-    Returns:
-        One problem per unusable field; empty when both are usable counts.
-    """
+    """Report ``steps`` and ``global_batch_size``, each a count."""
     problems: list[str] = []
     for param, value in (("steps", spec.steps), ("global_batch_size", spec.global_batch_size)):
         error = positive_count_error(value, param, context)
@@ -270,84 +121,11 @@ def run_size_problems(spec: TrainSpec, *, context: str) -> list[str]:
 
 
 def rl_run_size_problems(spec: TrainSpec, *, context: str) -> list[str]:
-    """Return run-size problems for a reinforcement-learning :class:`TrainSpec`.
+    """Report ``total_timesteps`` and ``rollout_steps``, each a count.
 
-    The RL peer of :func:`run_size_problems`. The supervised backends size a run
-    from ``steps`` / ``global_batch_size``; the RL trainers size theirs from
-    ``total_timesteps`` / ``rollout_steps``, the two caller-supplied factors of
-    the one loop bound both of them derive::
-
-        steps_per_iter = rollout_steps * num_envs
-        num_iters = max(1, total_timesteps // steps_per_iter)
-        for it in range(num_iters):  # collect, update
-
-    Because that bound is *derived* rather than read straight off the spec, a
-    bare ``value <= 0`` test on either factor is weaker here than the same test
-    would be on a field consumed directly: the ``max(1, ...)`` clamp turns every
-    value that survives the comparison but cannot divide into a **silent single
-    iteration** instead of an error. Measured on both trainers over a 16-step
-    run with ``rollout_steps=4``, before this gate existed:
-
-    =========================  =========  ===========  ====================
-    ``total_timesteps``        verdict    iterations   reported
-    =========================  =========  ===========  ====================
-    ``16`` (control)           success    4            ``latest_step=16``
-    ``True``                   success    **1**        ``latest_step=4``
-    ``0.5``                    success    **1**        ``latest_step=4``
-    ``nan``                    success    **1**        ``latest_step=4``
-    ``inf``                    success    **1**        ``latest_step=4``
-    ``100.5``                  TypeError  --           from ``range()``
-    ``"16"`` / ``None``        TypeError  --           from ``validate``
-    =========================  =========  ===========  ====================
-
-    ``inf`` lands in the silent column rather than the raising one because
-    ``inf // 4`` is ``nan`` and ``max(1, nan)`` is ``1`` - ``nan`` compares false
-    against everything. So four of the five values that pass a ``<= 0`` test
-    report ``status="success"``, write a checkpoint, and announce
-    ``"1 iterations x 4 steps complete"`` for a run the caller asked to be tens
-    of thousands of steps long. The one value that does raise
-    (``100.5 // 4 == 25.0``, a float ``range()`` bound) raises only after
-    ``setup`` has built the environment, the networks, the optimizers and - for
-    FastSAC - the replay buffer, which is the cost a read-only preflight exists
-    to precede. A string or ``None`` raises out of the comparison itself, from a
-    :meth:`Trainer.validate` documented to *return* problems.
-
-    ``rollout_steps`` fails the same three ways through the other factor, and its
-    silent case is worse than a short run because it changes the *shape* of the
-    run rather than its length: ``True`` makes ``steps_per_iter`` one, so FastSAC
-    ran 16 single-step iterations instead of 4 of 4 (reported as success), and
-    PPO normalized advantages over a length-one batch - the standard deviation of
-    one sample is ``nan`` - and failed inside torch's ``Normal`` constraint with
-    a message naming neither the field nor the run.
-
-    Only a positive integer can be honored, so both factors are checked against
-    the one shared :func:`~strands_robots.utils.positive_count_error` domain: the
-    same domain :func:`run_size_problems` uses for the supervised pair, and the
-    domain whose own contract is that its values are consumed directly as
-    ``range()`` bounds.
-
-    ``num_envs``, the third factor of ``steps_per_iter``, is deliberately not
-    here, and the reason is narrower than the whole field: which *counts* are
-    usable differs between the backends - PPO parallelizes and accepts any
-    positive count, while the MuJoCo-backed FastSAC is single-env and requires
-    exactly ``1`` - so that half is not one shared rule and each backend keeps it.
-    That the value must be a count *at all* is not per-backend, and it is this
-    same domain, so both backends consult it before asking their own count rule.
-    Excluding the whole field would have left the third factor of this very
-    product outside the domain its two siblings are held to, which is what a bare
-    per-backend comparison could not carry: it read ``nan`` and ``inf`` as usable
-    and the ``max(1, ...)`` clamp turned them into a 1000-iteration and a
-    one-iteration run under ``status="success"``, and ``True`` into a count of one
-    from a value that reads as a flag.
-
-    Args:
-        spec: The spec to check.
-        context: Caller identity for the message prefix - the backend's
-            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
-            problem names the backend that refused the value.
-
-    Returns:
-        One problem per unusable factor; empty when both are usable counts.
+    ``num_envs`` is not here: which *counts* are usable differs between the
+    backends that read it, but being a count *at all* is not per-backend, so
+    the shared factor is graded by the caller that reads it.
     """
     problems: list[str] = []
     for param in ("total_timesteps", "rollout_steps"):
@@ -358,53 +136,9 @@ def rl_run_size_problems(spec: TrainSpec, *, context: str) -> list[str]:
 
 
 def torch_device_problems(spec: TrainSpec, *, context: str) -> list[str]:
-    """Return device problems for a from-scratch RL :class:`RLTrainSpec`.
+    """Report ``device`` when stated: one torch can place tensors on.
 
-    All three RL backends resolve the device the same way in :meth:`setup`::
-
-        self.device = torch.device(spec.device or ("cuda" if torch.cuda.is_available() else "cpu"))
-
-    so ``device`` is spent by ``torch.device`` itself, which judges nothing on
-    this spec's behalf, and every network, buffer and rollout tensor the run
-    allocates is placed on the result. ``device`` was the one caller-supplied
-    knob on this spec with no domain - the sentence the sibling supervised
-    preflight already uses about its own surface - while the counts, the
-    interval coefficients, the loss weights, the learning rate, the seed, the
-    launch topology and the network width beside it are all held to one.
-
-    Measured on a 6-DoF SO-101 MuJoCo env with PPO, ``validate()`` returning
-    ``[]`` - which :meth:`~strands_robots.training.base.Trainer.validate`
-    documents as meaning the spec IS launchable - for each of these:
-
-    * ``"gpu"`` (the ordinary mistake: the word the rest of the world uses)
-      and ``"cuda:abc"`` raise ``RuntimeError`` out of ``setup`` from the
-      ``torch.device`` line itself, after the preflight passed.
-    * ``1`` is worse, and is why a non-``str`` is refused before torch is
-      consulted: ``torch.device(1)`` constructs on ANY host, so the run reaches
-      the first ``.to()`` and dies with ``CUDA error: invalid device ordinal``
-      raised from a ``torch/nn/modules/module.py`` frame that names neither the
-      field nor the run - and the same spec would train on a host with more
-      GPUs. One spec, two answers, decided by the machine's inventory.
-
-    The domain is :func:`~strands_robots.utils.torch_device_error`, the one owner
-    the ``lerobot_train`` tool and :class:`~strands_robots.training.lerobot.LerobotTrainer`
-    also consult, so a device the supervised trainer refuses is not accepted by
-    the RL backend beside it.
-
-    A falsy ``device`` is NOT refused: the ``spec.device or ...`` above documents
-    it as "resolve the default", exactly as the supervised trainer's constructor
-    does, so it never reaches ``torch.device`` as written and is not this gate's
-    to judge. Availability is not graded either - ``"cuda"`` on a CPU-only box is
-    a valid spec, because a queued run is written on one host and executed on
-    another.
-
-    Args:
-        spec: The spec to preflight.
-        context: Provider name, prefixed to the message.
-
-    Returns:
-        A single-element list when ``device`` cannot be honored; empty when it
-        can, when it is unstated, or when torch is not importable.
+    Empty when the field is unstated or torch is not importable.
     """
     device = getattr(spec, "device", None)
     if not device:
@@ -414,74 +148,10 @@ def torch_device_problems(spec: TrainSpec, *, context: str) -> list[str]:
 
 
 def rl_replay_problems(spec: TrainSpec, *, context: str) -> list[str]:
-    """Return replay-loop problems for an off-policy :class:`RLTrainSpec`.
+    """Report ``buffer_size``, ``batch_size`` and ``gradient_steps``, each a count.
 
-    The three caller-supplied counts of an off-policy (SAC / TD3) run's replay
-    loop:
-
-    * ``buffer_size`` - the replay buffer's capacity, a tensor dimension built
-      in :meth:`~strands_robots.training.rl.fast_sac.FastSacTrainer.setup`.
-    * ``batch_size`` - the transitions sampled per gradient step, passed to
-      ``ReplayBuffer.sample``.
-    * ``gradient_steps`` - the off-policy updates run per iteration, a
-      ``range()`` bound.
-
-    Each is consumed directly as a count - a capacity, a sample size, a
-    ``range()`` bound - so the same strict-``int``
-    :func:`~strands_robots.utils.positive_count_error` domain applies that
-    :func:`run_size_problems` uses, and for the same reason: a value that is not
-    a positive ``int`` cannot be a tensor dimension or a ``range()`` argument and
-    raises ``TypeError`` there rather than being coerced.
-
-    A local ``value <= 0`` test is weaker than that domain, and both of its
-    failure modes were measured on the MuJoCo reach env before this gate existed
-    (an otherwise-valid run, one field mutated):
-
-    =====================  ==========  =========================================
-    value                  verdict     what happened
-    =====================  ==========  =========================================
-    ``buffer_size=True``   success     a one-slot buffer that never reaches
-                                       ``learning_starts``, so **zero** gradient
-                                       updates ran, yet the run reported success
-                                       and "10 iterations x 4 steps complete"
-    ``buffer_size=0.5``    IndexError  ``int(0.5) == 0``: a zero-capacity buffer,
-                                       raised from ``ReplayBuffer.add`` after setup
-    ``batch_size=0.5``     TypeError   raised from ``torch.randint`` in
-                                       ``ReplayBuffer.sample`` after setup
-    ``batch_size=True``    TypeError   the same, from a batch of ``True``
-    ``gradient_steps=0.5`` TypeError   raised from ``range()`` in the update loop
-    ``"256"`` / ``None``   TypeError   raised from the ``<= 0`` comparison itself,
-                                       out of a ``validate`` documented to return
-    =====================  ==========  =========================================
-
-    So a ``bool`` reads as a silent degenerate size - the ``buffer_size`` case
-    runs a whole training loop that learns nothing and reports success - a
-    fraction or a non-finite value passes the comparison and raises deep inside
-    the update loop after the environment, the networks, the optimizers and the
-    replay buffer have been built (the cost a read-only preflight exists to
-    precede), and a string or ``None`` raises out of the comparison itself, from
-    a :meth:`~strands_robots.training.base.Trainer.validate` documented to
-    *return* its problems.
-
-    Only the off-policy backends (FastSAC and FastTD3) read these three fields;
-    PPO sizes its minibatches from ``num_mini_batches`` and never reads them, so
-    a backend that ignores them must not report on them - which is why this is a
-    gate scoped to the field rather than part of :func:`validate_train_inputs`.
-
-    ``learning_starts`` stays in the backend's own ``validate``: it is one side
-    of a relation (``>= batch_size``) rather than a bare count, so it does not
-    share this domain. ``tau`` does not either - it is a coefficient in
-    ``(0, 1]`` rather than a count - but it no longer stays local for that
-    reason: it has its own gate on its own interval, in
-    :func:`polyak_coefficient_problems`.
-
-    Args:
-        spec: The spec to check.
-        context: Caller identity for the message prefix - the backend's
-            :attr:`~strands_robots.training.base.Trainer.provider_name`.
-
-    Returns:
-        One problem per unusable count; empty when all three are usable counts.
+    A zero ``gradient_steps`` takes zero gradient updates for the whole run and
+    still reports success with a written checkpoint.
     """
     problems: list[str] = []
     for param in ("buffer_size", "batch_size", "gradient_steps"):
@@ -492,43 +162,9 @@ def rl_replay_problems(spec: TrainSpec, *, context: str) -> list[str]:
 
 
 def launch_topology_problems(spec: TrainSpec, *, context: str) -> list[str]:
-    """Return launch-topology problems for a :class:`TrainSpec`.
+    """Report ``num_gpus`` and ``num_nodes``, each a count.
 
-    ``num_gpus`` and ``num_nodes`` are the two process counts a distributed run
-    is sized from. Each is consumed as a discrete count in three places: a
-    ``spec.num_gpus > 1`` / ``spec.num_nodes > 1`` test that selects between the
-    single-process and the multi-process launch path, a ``nproc_per_node`` /
-    ``nnodes`` argument to torch's ``elastic_launch``, and a
-    ``--nproc_per_node=`` / ``--nnodes=`` / ``--num_gpus=`` argv token. Only a
-    positive integer can be honored, and each of the three ways a bad value
-    fails is silent or late:
-
-    * ``0``, a negative, ``nan`` and ``True`` all read as *not* greater than one
-      -- ``nan`` compares false against everything -- so the selector routes
-      them to the single-process path and the run proceeds on one process under
-      a successful result. The topology the caller asked for is simply not the
-      one that ran, and for ``num_nodes`` that also slips past the multi-node
-      refusal the backends raise for an unsupported topology.
-    * ``2.7`` and ``inf`` *are* greater than one, so they select the
-      multi-process path and reach ``elastic_launch`` as the worker count.
-      ``LaunchConfig`` accepts both without complaint, so nothing downstream
-      rejects them either.
-    * A string, ``None`` or a list raises ``TypeError`` out of the comparison
-      itself -- from inside a :meth:`Trainer.validate` that is documented to
-      *return* problems.
-
-    Both are therefore checked against the one shared
-    :func:`~strands_robots.utils.positive_count_error` domain, the same one
-    :func:`run_size_problems` uses, rather than by a local comparison.
-
-    Args:
-        spec: The spec to check.
-        context: Caller identity for the message prefix - the backend's
-            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
-            problem names the backend that refused the value.
-
-    Returns:
-        One problem per unusable field; empty when both are usable counts.
+    Both become a ``torchrun`` ``nproc_per_node`` / ``nnodes``.
     """
     problems: list[str] = []
     for param, value in (("num_gpus", spec.num_gpus), ("num_nodes", spec.num_nodes)):
@@ -539,53 +175,7 @@ def launch_topology_problems(spec: TrainSpec, *, context: str) -> list[str]:
 
 
 def learning_rate_problems(spec: TrainSpec, *, context: str) -> list[str]:
-    """Return optimizer learning-rate problems for a :class:`TrainSpec`.
-
-    ``learning_rate`` is the one numeric on a :class:`TrainSpec` that decides
-    whether a run *learns* rather than how much work it does, and every backend
-    reads it: the supervised three assign it to their config's optimizer field
-    (LeRobot ``policy.optimizer_lr``, GR00T ``FinetuneConfig.learning_rate``,
-    Cosmos ``optimizer.lr``) and the RL trainers pass it directly to
-    ``torch.optim.Adam(..., lr=...)``.
-
-    Only a positive finite value can be honored, and the two ends of the domain
-    fail *silently* rather than loudly, which is why this is a preflight rather
-    than something the backend can be left to notice:
-
-    * ``0`` (and ``False``, which is ``0`` to every consumer) runs the full
-      ``steps`` x ``global_batch_size`` of work and updates no weight, so the
-      run reports success and writes a checkpoint identical to its
-      initialisation. That is the pathology :func:`run_size_problems` exists to
-      prevent, reached by a different route and at full cost.
-    * ``inf`` diverges on the first optimizer step, so the checkpoint is all
-      ``NaN`` -- again under a successful result.
-    * ``True`` is a silent learning rate of ``1.0``, four orders of magnitude
-      above a typical fine-tuning preset.
-
-    A negative or ``nan`` value *is* refused by ``torch.optim.Adam``
-    (``ValueError: Invalid learning rate``), but only once the dataset and model
-    are already loaded -- after the point :meth:`Trainer.validate` documents
-    itself as running before ("it powers a ``plan`` advisor that runs *before*
-    anything expensive starts").
-
-    ``None`` is the documented sentinel for "use the backend's own default" and
-    is therefore not a problem. It is checked against the shared
-    :func:`~strands_robots.utils.positive_finite_number_error` domain rather
-    than a local comparison because a bare ``value <= 0`` test admits ``nan``
-    (every comparison against it is ``False``), admits a ``bool``, and raises
-    out of the comparison itself for a non-numeric value -- inside a method
-    documented to *return* problems.
-
-    Args:
-        spec: The spec to check.
-        context: Caller identity for the message prefix - the backend's
-            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
-            problem names the backend that refused the value.
-
-    Returns:
-        A single problem when ``learning_rate`` is supplied and unusable;
-        empty when it is usable or left at ``None``.
-    """
+    """Report ``learning_rate`` when supplied: a rate. Empty when ``None``."""
     if spec.learning_rate is None:
         return []
     error = positive_finite_number_error(spec.learning_rate, "learning_rate", context)
@@ -593,54 +183,7 @@ def learning_rate_problems(spec: TrainSpec, *, context: str) -> list[str]:
 
 
 def seed_problems(spec: TrainSpec, *, context: str) -> list[str]:
-    """Return reproducibility-seed problems for a :class:`TrainSpec`.
-
-    ``seed`` is the field a caller sets to make a run reproducible, and the four
-    backends that read it apply it through appliers that disagree about what a
-    single value means:
-
-    * The RL trainers hand it to ``torch.manual_seed``, which reduces it modulo
-      ``2**64``. A negative seed is therefore *silently a different seed*:
-      ``manual_seed(-1)`` and ``manual_seed(2**64 - 1)`` draw the identical
-      stream, so two seeds the caller means to be distinct collapse onto one and
-      the run is reproducible under a number nobody asked for. ``True`` is
-      likewise a silent seed of ``1`` and ``2.7`` a silent seed of ``2``.
-    * LeRobot assigns it to ``cfg.seed``, which reaches lerobot's ``set_seed``:
-      ``random.seed`` first, then ``numpy.random.seed``. NumPy is far narrower
-      than torch - it refuses a negative value and a float or string outright -
-      but only *after* ``random.seed`` has run, so a refused seed leaves the
-      process RNG reseeded by a call that failed.
-    * Cosmos interpolates it into a ``trainer.seed=`` Hydra override, and
-      LeRobot's argv-parity path into a ``--seed=`` token. There every value
-      renders - ``nan``, ``2.7``, ``[7]`` - and fails, if at all, inside the
-      run after the dataset and model are already loaded.
-
-    So the same ``seed=-1`` is silently rewritten by one backend and refused with
-    a bare third-party message by the next. Only a non-negative integer can be
-    honored by all of them, so it is checked against the one shared
-    :func:`~strands_robots.utils.non_negative_count_error` domain: the same
-    non-negative-integer rule, whose ``0`` is first-class here too (seed ``0`` is
-    a seed), and which rejects ``bool`` explicitly because a bare ``value < 0``
-    test lets ``True`` through as a silent seed of one.
-
-    ``None`` is the documented sentinel for "use the backend's own default"
-    (LeRobot's is ``1000``) and is therefore not a problem, exactly as it is not
-    one for :func:`learning_rate_problems`.
-
-    One boundary this does not decide: the appliers also disagree about the
-    upper end - torch accepts up to ``2**64 - 1`` while NumPy's legacy seeder
-    stops at ``2**32 - 1`` - so a per-backend ceiling is a separate question from
-    the floor and type checked here.
-
-    Args:
-        spec: The spec to check.
-        context: Caller identity for the message prefix - the backend's
-            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
-            problem names the backend that refused the value.
-
-    Returns:
-        A single problem when ``seed`` is supplied and unusable; empty otherwise.
-    """
+    """Report ``seed`` when supplied: a non-negative count. Empty when ``None``."""
     if spec.seed is None:
         return []
     error = non_negative_count_error(spec.seed, "seed", context)
@@ -648,116 +191,16 @@ def seed_problems(spec: TrainSpec, *, context: str) -> list[str]:
 
 
 def checkpoint_cadence_problems(spec: TrainSpec, *, context: str) -> list[str]:
-    """Return checkpoint-cadence problems for a :class:`TrainSpec`.
-
-    ``save_freq`` is how often a run writes a checkpoint, and the four backends
-    that read it deliver the value to a destination that requires a genuine
-    ``int`` - by four different routes, each of which mis-handles every other
-    spelling differently and none of which reports it:
-
-    * LeRobot in-process assigns it to ``cfg.save_freq``, which reaches
-      lerobot's own ``should_save_checkpoint(step, save_freq, total_steps)`` -
-      ``(save_freq > 0 and step % save_freq == 0) or step == total_steps``. No
-      parser stands between the spec and that expression, so ``True`` is a
-      modulus of one and writes a **full checkpoint every single step** (9999
-      of them in a 10 000-step run that asked for 9), a fractional or
-      non-finite cadence never satisfies ``step % cadence == 0`` for an
-      integral step and so silently becomes the *disabled* mode, and a ``str``
-      raises ``TypeError`` out of the comparison - inside the training loop,
-      after the dataset and the model are loaded.
-    * LeRobot's argv-parity path renders ``--save_freq={value}``, which lerobot
-      decodes into the same ``int`` field with draccus: ``True``, ``2.7``,
-      ``5000.0``, ``nan`` and ``inf`` all raise ``DecodingError`` there.
-    * GR00T renders ``--save_steps={value}`` and Cosmos a
-      ``checkpoint.save_iter={value}`` Hydra override, where an unusable value
-      fails - if at all - inside the launched run.
-    * SageMaker forwards it as a hyperparameter string via ``json.dumps``, so
-      ``nan`` and ``inf`` travel as ``NaN`` / ``Infinity``, which only a
-      permissive JSON decoder accepts.
-
-    The two LeRobot routes disagree about the *same* spec, which is what makes a
-    shared gate the only fix that holds: a ``"5000"`` renders the perfectly
-    decodable token ``--save_freq=5000`` and raises ``TypeError`` in-process,
-    while ``2.7`` is refused on the argv path and silently disables periodic
-    saving in-process. One spec has to mean one run whichever path the backend
-    takes - the rule :attr:`TrainSpec.extra` already states for its own values -
-    so the cadence is checked against the one shared
-    :func:`~strands_robots.utils.step_cadence_error` domain, which the
-    ``lerobot_train`` tool holds the same field to when it builds the argv
-    itself.
-
-    Only the *type* is graded. A non-positive cadence is a documented
-    capability - lerobot's ``should_save_checkpoint`` reads "a non-positive
-    ``save_freq`` disables periodic saving (only the final checkpoint is
-    written)" - and the ``eval_steps`` fallback in the LeRobot backend
-    (``spec.save_freq if spec.save_freq > 0 else spec.steps``) is written for
-    exactly that case, so ``0`` and a negative are first-class here. Whether a
-    given backend's own trainer accepts the disabled mode is a per-backend
-    question, like the per-backend seed ceiling :func:`seed_problems` leaves
-    open, and separate from the type checked here.
-
-    Args:
-        spec: The spec to check.
-        context: Caller identity for the message prefix - the backend's
-            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
-            problem names the backend that refused the value.
-
-    Returns:
-        A single problem when ``save_freq`` is not a whole number of steps;
-        empty otherwise.
-    """
+    """Report ``save_freq``: a cadence in steps."""
     error = step_cadence_error(spec.save_freq, "save_freq", context)
     return [] if error is None else [error]
 
 
 def validation_episodes_problems(spec: TrainSpec, *, context: str) -> list[str]:
-    """Return held-out-validation-set problems for a :class:`TrainSpec`.
+    """Report ``val_episodes`` when supplied: a count. Empty when ``None``.
 
-    ``val_episodes`` is the count of episodes a caller reserves from the tail of
-    the dataset to validate on. It is not read straight into a loop bound like
-    :func:`run_size_problems`' fields: the LeRobot backend converts it into
-    lerobot's ``dataset.eval_split`` FRACTION via
-    :func:`~strands_robots.utils.validation_split_fraction`, and lerobot then
-    holds out ``ceil(episodes_in_task * eval_split)``. That conversion is what
-    makes a local comparison unsafe in both directions at once:
-
-    * A non-positive value is *silently dropped*. The fraction is only computed
-      for a count in ``(0, total)``, so ``val_episodes=0`` (or a negative)
-      produces no ``eval_split`` and no ``eval_steps`` at all: the run trains on
-      the whole dataset, records no validation loss, and reports no problem. The
-      caller asked for a validation set and got a run without one.
-    * A value that merely *compares* as positive is silently rewritten, because
-      the fraction is real-valued and lerobot takes its ceiling: ``True``
-      reserves 1 episode and ``2.7`` reserves 3 - a whole number the caller never
-      named. ``0.5`` is the sharpest of these: it clears the ``0 < count <
-      total`` test, so it emits ``eval_split=0.0`` - a held-out set of zero
-      episodes - *together with* an ``eval_steps`` cadence, asking lerobot to
-      validate periodically on nothing.
-    * A non-numeric value raises out of the comparison itself, from a
-      :meth:`~strands_robots.training.base.Trainer.validate` documented to
-      *return* problems.
-
-    Only a positive integer strictly below the dataset's episode count can be
-    honored, so the type and floor are checked here against the same shared
-    :func:`~strands_robots.utils.positive_count_error` domain that
-    :func:`run_size_problems` uses. The upper bound is dataset-dependent (it needs
-    ``total_episodes`` from ``meta/info.json``) and stays with the backend that
-    reads the metadata, which also owns the per-task-fraction refusal in
-    :func:`~strands_robots.utils.validation_split_error`.
-
-    ``None`` is the documented sentinel for "train on every episode, no held-out
-    set" and is therefore not a problem, exactly as it is not one for
-    :func:`seed_problems` or :func:`learning_rate_problems`.
-
-    Args:
-        spec: The spec to check.
-        context: Caller identity for the message prefix - the backend's
-            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
-            problem names the backend that refused the value.
-
-    Returns:
-        A single problem when ``val_episodes`` is supplied and unusable as a
-        count; empty otherwise.
+    The count becomes a real-valued split fraction whose ceiling lerobot takes,
+    so a fractional value reserves a different number of episodes than asked.
     """
     if spec.val_episodes is None:
         return []
@@ -766,7 +209,7 @@ def validation_episodes_problems(spec: TrainSpec, *, context: str) -> list[str]:
 
 
 def _posture_flag_problems(spec: TrainSpec, fields: Sequence[str], *, context: str) -> list[str]:
-    """One problem per field in *fields* that is not a boolean, in that order."""
+    """One problem per field in *fields* that is not a ``bool``, in that order."""
     problems: list[str] = []
     for param in fields:
         error = boolean_flag_error(getattr(spec, param), param, context)
@@ -776,141 +219,19 @@ def _posture_flag_problems(spec: TrainSpec, fields: Sequence[str], *, context: s
 
 
 def resume_problems(spec: TrainSpec, *, context: str) -> list[str]:
-    """Return resume-posture problems for a :class:`TrainSpec`.
-
-    ``resume`` selects one of two postures - continue the run under
-    ``output_dir`` from its last checkpoint, or start a fresh one there - and
-    every backend that reads it does so by truthiness. Every non-empty string is
-    truthy, so ``"false"``, ``"no"`` and ``"0"`` - the spellings a caller reaches
-    for when opting *out* - select the resume, and what that resume does with
-    the rest of the spec is the reason this is a preflight problem rather than a
-    downstream one:
-
-    * LeRobot's ``build_config`` returns the checkpoint's own ``train_config.json``
-      in place of a config built from the spec when ``resume`` is truthy and a
-      checkpoint exists, so the fresh run that was asked for silently becomes a
-      resume of a previous configuration and the spec's ``steps``,
-      ``global_batch_size``, ``save_freq`` and learning rate never reach it.
-      That is the same defect the sibling ``lerobot_train`` tool's argv
-      builder already refuses for its own ``resume``, reached here through the
-      provider-agnostic ``train_policy`` tool one layer up.
-    * LeRobot's ``train`` clears a stale *empty* ``output_dir`` only when
-      ``not spec.resume``, so a truthy opt-out leaves it for lerobot to refuse as
-      already existing - a refusal whose remedy the caller already followed.
-    * GR00T emits ``--resume_from_checkpoint`` and passes the raw value as
-      ``FinetuneConfig.resume_from_checkpoint``, and SageMaker forwards the raw
-      value as a hyperparameter string, so the container is told ``"false"``
-      where the wrapped trainer expects a boolean it can test.
-
-    The falsy non-booleans invert the other way: ``0``, ``None`` and ``""`` take
-    the fresh-start branch without being a declared spelling of it. Nothing
-    reports either direction, because nothing raised.
-
-    The flag is checked against the one shared
-    :func:`~strands_robots.utils.boolean_flag_error` domain rather than parsed:
-    it arrives already typed, and a vocabulary would only move which spellings
-    invert. The check is placed ahead of every read the backend makes of the
-    field, so no reader ever sees a value it can only misread.
-
-    Args:
-        spec: The spec to check.
-        context: Caller identity for the message prefix - the backend's
-            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
-            problem names the backend that refused the value.
-
-    Returns:
-        A single problem when ``resume`` is not a boolean; empty otherwise.
-    """
+    """Report ``resume``: a ``bool``."""
     return _posture_flag_problems(spec, ("resume",), context=context)
 
 
 def streaming_problems(spec: TrainSpec, *, context: str) -> list[str]:
-    """Return streaming-posture problems for a :class:`TrainSpec`.
-
-    ``streaming`` selects whether the dataset is materialized or streamed, and
-    the two backends that read it do so by truthiness, so the same inversion
-    :func:`resume_problems` describes applies: ``"false"`` streams. On LeRobot it
-    also *gates* another check - ``validate`` refuses ``streaming`` together with
-    ``val_episodes`` because a held-out split annuls the stream - so a truthy
-    opt-out beside a split was refused with "set streaming=False to keep the
-    validation split", a remedy the caller had already spelled. That is why the
-    backend consults this gate ahead of the pair check rather than beside it: a
-    posture guard placed after the option it gates still refuses, but names the
-    option the misread posture selected rather than the flag.
-
-    Kept separate from :func:`resume_problems` because the two fields have
-    different readers - GR00T reads ``resume`` and ignores ``streaming`` - and a
-    backend that ignores a field MUST NOT report on it (see :class:`TrainSpec`).
-
-    Args:
-        spec: The spec to check.
-        context: Caller identity for the message prefix - the backend's
-            :attr:`~strands_robots.training.base.Trainer.provider_name`.
-
-    Returns:
-        A single problem when ``streaming`` is not a boolean; empty otherwise.
-    """
+    """Report ``streaming``: a ``bool``."""
     return _posture_flag_problems(spec, ("streaming",), context=context)
 
 
 def lora_hyperparameter_problems(spec: TrainSpec, *, context: str) -> list[str]:
-    """Return LoRA adapter-hyperparameter problems for a :class:`TrainSpec`.
+    """Report ``lora_r`` and ``lora_alpha``, each a count when supplied.
 
-    ``lora_r`` and ``lora_alpha`` are the rank and the scaling numerator of a
-    LoRA fine-tune: peft builds a rank-``r`` adapter and applies its update
-    scaled by ``lora_alpha / r``. The two fields fail in opposite ways, and only
-    one of them fails loudly:
-
-    * ``lora_r`` is refused by peft, but only from inside
-      ``get_peft_model`` - after the base model has been downloaded and loaded.
-      A non-positive rank raises ``ValueError: `r` should be a positive integer
-      value``, and a ``bool``/float/string one raises out of torch's tensor
-      allocation with a message naming neither the field nor the run.
-    * ``lora_alpha`` is **accepted for every unusable value**. It is only ever a
-      numerator, so nothing downstream compares it: ``lora_alpha=0`` builds the
-      adapter, reports its trainable parameters and trains them with a scaling
-      of ``0.0``, so the adapter provably cannot change the model's output - the
-      fine-tune runs to completion, writes checkpoints, and has learned nothing
-      that can ever be applied. A negative value applies the negation of what
-      the adapter learned, and ``True`` is a silent alpha of one.
-
-    The two paths that carry these fields also disagree about a fractional
-    value. In-process, peft accepts ``lora_alpha=2.7`` and scales by
-    ``2.7 / r``; on the argv-parity path the same value reaches lerobot's
-    ``PeftConfig``, whose ``r`` and ``lora_alpha`` are declared ``int``, and
-    draccus refuses it. So one spelling of one run honors a value the other
-    rejects.
-
-    A positive integer is therefore the only thing both paths can honor, and it
-    is checked against the same shared
-    :func:`~strands_robots.utils.positive_count_error` domain
-    :func:`run_size_problems` uses - the domain that also rejects ``bool``,
-    which a bare ``value < 1`` test would let through as a silent rank or alpha
-    of one.
-
-    ``None`` is the documented sentinel for "omit the option and keep peft's own
-    default" and is therefore not a problem, exactly as it is not one for
-    :func:`seed_problems` or :func:`validation_episodes_problems`.
-
-    Both fields are read only on the ``method == "lora"`` branch, so a spec that
-    carries them under another strategy reports nothing: the fields are inert
-    there, and refusing a value the run never reads would be a false rejection -
-    the same reason this is a separate gate from :func:`learning_rate_problems`
-    rather than part of it.
-
-    ``lora_target_modules`` is out of scope: it is a module-name string rather
-    than a count, and :func:`validate_train_inputs` already owns what may be
-    interpolated into a config field or an argv token.
-
-    Args:
-        spec: The spec to check.
-        context: Caller identity for the message prefix - the backend's
-            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
-            problem names the backend that refused the value.
-
-    Returns:
-        One problem per supplied-and-unusable adapter hyperparameter; empty when
-        the spec does not request LoRA or both values are usable.
+    Empty unless ``method == "lora"`` - the only strategy that reads them.
     """
     if spec.method != "lora":
         return []
@@ -925,25 +246,7 @@ def lora_hyperparameter_problems(spec: TrainSpec, *, context: str) -> list[str]:
 
 
 def _closed_unit_interval_error(value: Any, param: str, context: str) -> str | None:
-    """Error text when *value* is not a real number in the closed range [0, 1].
-
-    Numeric-ness, ``bool`` rejection and finiteness are delegated to the shared
-    :func:`~strands_robots.utils.finite_number_error` domain, so those refusals
-    read identically to every other numeric field's. The only thing decided here
-    is the interval, which no shared domain expresses: ``utils`` carries
-    open-ended families (positive, non-negative) rather than a bounded one.
-
-    Both endpoints are inside the domain and neither is a degenerate spelling of
-    "disabled", which is why the interval is closed rather than half-open.
-
-    Args:
-        value: The caller-supplied value.
-        param: Field name for the message.
-        context: Caller label the message is prefixed with.
-
-    Returns:
-        The error text, or None when *value* is a real number in [0, 1].
-    """
+    """Error text when *value* is not a real number in ``[0, 1]``; else ``None``."""
     error = finite_number_error(value, param, context)
     if error is not None:
         return error
@@ -953,267 +256,34 @@ def _closed_unit_interval_error(value: Any, param: str, context: str) -> str | N
 
 
 def discount_factor_problems(spec: TrainSpec, *, context: str) -> list[str]:
-    """Return discount-factor problems for an RL :class:`TrainSpec`.
-
-    ``gamma`` weights every future reward in the return the algorithm optimizes,
-    and it is the one coefficient both RL backends read: PPO discounts the GAE
-    recursion with it (twice - the single-env and vectorized rollout paths), and
-    FastSAC discounts its target-Q bootstrap. A discounted return is a geometric
-    series, so the domain is not a matter of taste:
-
-    * ``gamma > 1`` makes that series **diverge**. The advantages grow without
-      bound in the rollout horizon rather than being merely large - over a
-      24-step rollout of unit rewards, ``gamma=1.5`` inflates the largest
-      advantage from 12.9 to 1.2e4, and ``gamma=5`` to 4.6e15. Nothing refuses
-      it: the run trains on those advantages, reports success, and writes a
-      checkpoint.
-    * ``gamma < 0`` alternates the sign of each successive reward, so the trace
-      no longer accumulates future return at all - the same rollout collapses
-      the largest advantage to the immediate reward, 1.0.
-    * ``nan``/``inf`` make every advantage non-finite, which surfaces only once
-      the update samples the action distribution: ``ValueError: Expected
-      parameter loc ... of distribution Normal ... to satisfy the constraint
-      Real()``, a torch message that names neither the field nor the run, raised
-      after the env, the networks and a full rollout have been built. That is
-      exactly the "deep stack trace" a read-only preflight exists to replace.
-    * ``True`` is a silent ``gamma`` of one, because a bare comparison against
-      the interval bounds accepts it - ``bool`` is an ``int`` subclass.
-
-    Both endpoints are legitimate and standard: ``gamma=1`` is the undiscounted
-    episodic return, ``gamma=0`` a myopic agent that optimizes the immediate
-    reward only. So the domain is the *closed* interval [0, 1], checked through
-    :func:`_closed_unit_interval_error`.
-
-    The off-policy backends bound their own interval coefficient this way
-    (``tau`` must be in ``(0, 1]``), which is the shape this gate generalizes: an
-    interval coefficient is checked against its interval rather than left to the
-    arithmetic that consumes it. That precedent is now a shared gate too rather
-    than a bare comparison inside each backend - see
-    :func:`polyak_coefficient_problems`, which is half-open where this one is
-    closed because zero freezes a target network instead of reading as a
-    myopic agent.
-
-    ``lam``, the other factor of the trace-decay product, has its own gate for
-    that same scoping reason - see :func:`gae_lambda_problems`,
-    ``num_learning_epochs`` likewise in :func:`optimization_epochs_problems`,
-    and ``max_grad_norm`` in :func:`gradient_clip_problems`.
-    The two *loss weights* named there - ``entropy_coef`` and ``value_loss_coef`` -
-    now have their own gate too, in :func:`loss_weight_problems`, on the domain
-    rather than on the endpoint this docstring called undecided: their zero
-    readings are still unsettled and still accepted, but a non-finite weight has
-    no reading at all. ``clip_param`` now has its own gate too, in
-    :func:`clip_range_problems`: this docstring left it out because it needed the
-    endpoint decision :func:`gradient_clip_problems` records for the sibling clip
-    bound, and that decision is now shared rather than duplicated - both read
-    :func:`_clip_bound_error`. ``init_noise_std`` remains out of scope in all
-    six, for a measured reason rather than by omission: every non-finite value is
-    refused by ``torch``, which rejects a ``Normal`` of non-positive or
-    non-finite scale.
-
-    Args:
-        spec: The spec to check.
-        context: Caller identity for the message prefix - the backend's
-            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
-            problem names the backend that refused the value.
-
-    Returns:
-        A single-element list when ``gamma`` cannot be honored; empty otherwise.
-    """
+    """Report ``gamma``: a closed unit. Every RL backend reads it."""
     error = _closed_unit_interval_error(getattr(spec, "gamma", 0.0), "gamma", context)
     return [error] if error is not None else []
 
 
 def gae_lambda_problems(spec: TrainSpec, *, context: str) -> list[str]:
-    """Return GAE-lambda problems for an on-policy RL :class:`TrainSpec`.
+    """Report ``lam``: a closed unit.
 
-    ``lam`` is the second factor of the advantage trace's decay. The GAE
-    recursion carries it forward as ``last_adv = delta + gamma * lam *
-    (1 - done) * last_adv``, so the trace decays by the **product**
-    ``gamma * lam`` and :func:`discount_factor_problems` bounding ``gamma``
-    alone does not bound it: with a ``gamma`` of ``0.99`` - comfortably inside
-    that gate's closed interval - a ``lam`` of ``1.5`` gives a decay factor of
-    ``1.485`` and the same divergence, measured on this backend's own
-    ``compute_gae`` over a rollout of unit rewards:
-
-    ======  =========  =========  =========  =========
-    ``lam``  ``T=12``   ``T=24``   ``T=48``   ``T=96``
-    ======  =========  =========  =========  =========
-    0.95      8.8        13.0       15.9       16.8
-    1.5     235.1      2.7e+04    3.6e+08    6.3e+16
-    1e6       inf        inf        inf        inf
-    ======  =========  =========  =========  =========
-
-    The largest advantage grows without bound in the rollout horizon rather than
-    being merely large, and nothing refuses it: the run trains on those
-    advantages, reports success, and writes a checkpoint.
-
-    The remaining values outside the interval fail in three further ways:
-
-    * ``lam < -1 / gamma`` diverges as well, because the trace decays by
-      ``|gamma * lam|`` - ``lam=-2`` reaches ``1.0e+28`` by ``T=96`` - while a
-      ``lam`` merely below zero (``-0.5``) collapses the trace to the immediate
-      reward, so the estimator stops accumulating future advantage at all.
-    * ``nan``/``inf`` make every advantage non-finite, which surfaces only once
-      the update samples the action distribution - a torch constraint error
-      naming neither the field nor the run, after the env, the networks and a
-      full rollout have been built.
-    * ``True`` is a silent ``lam`` of one, because a bare comparison against the
-      interval bounds accepts it: ``bool`` is an ``int`` subclass. That is a
-      different estimator from the one the caller asked for - Monte-Carlo return
-      rather than a bootstrapped trace.
-
-    Both endpoints are legitimate and standard, which is why the domain is the
-    *closed* interval [0, 1]: ``lam=1`` is the Monte-Carlo advantage (no
-    bootstrapping, 61.9 at ``T=96`` above) and ``lam=0`` is TD(0), the
-    one-step advantage.
-
-    Unlike ``gamma`` this is read by the on-policy backend only, so it is scoped
-    like :func:`run_size_problems`: FastSAC has no advantage trace and must not
-    report on a field it never reads.
-
-    Args:
-        spec: The spec to check.
-        context: Caller identity for the message prefix - the backend's
-            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
-            problem names the backend that refused the value.
-
-    Returns:
-        A single-element list when ``lam`` cannot be honored; empty otherwise.
+    The trace decays by the product ``gamma * lam``, so bounding one factor
+    does not bound the trace; only the on-policy backend estimates a trace.
     """
     error = _closed_unit_interval_error(getattr(spec, "lam", 0.0), "lam", context)
     return [error] if error is not None else []
 
 
 def optimization_epochs_problems(spec: TrainSpec, *, context: str) -> list[str]:
-    """Return optimization-epoch problems for an on-policy RL :class:`TrainSpec`.
+    """Report ``num_learning_epochs``: a count.
 
-    ``num_learning_epochs`` is the number of passes the update makes over each
-    rollout batch, and it is consumed as a bare loop bound around the whole
-    optimizer step - ``for _ in range(spec.num_learning_epochs)`` encloses every
-    ``optimizer.step()`` in the PPO update. So the field does not merely scale
-    how much optimization happens; a non-positive value removes *all* of it, and
-    nothing downstream notices:
-
-    ==========================  =========  ==============  ==============
-    ``num_learning_epochs``     verdict    optimizer       reported
-                                           steps taken     losses
-    ==========================  =========  ==============  ==============
-    5 (the shipped default)     honored    24              real values
-    0                           accepted   **0**           all ``0.0``
-    -3                          accepted   **0**           all ``0.0``
-    ==========================  =========  ==============  ==============
-
-    Measured on this backend over a 60-step run: ``0`` and ``-3`` both report
-    ``status="success"``, take **zero** gradient steps, and write a checkpoint
-    whose parameters are bit-identical to each other - the untrained
-    initialisation. The losses read ``0.0`` rather than blank because the update
-    averages its accumulators through ``max(1, n_updates)``, so an epoch count
-    that ran no minibatch reports plausible metrics for a run that learned
-    nothing. A caller therefore gets a deployable-looking checkpoint, a
-    successful result and a metrics dict, with no signal anywhere that the
-    optimizer never ran.
-
-    The remaining values outside the domain fail in two further ways:
-
-    * ``True`` is a silent single epoch, because ``range(True)`` is
-      ``range(1)`` - the same run takes 12 optimizer steps instead of 24. That
-      is a different amount of optimization from the one requested, reported as
-      success.
-    * ``2.7``/``nan``/``inf``/``"5"``/``None`` raise a bare ``TypeError:
-      'float' object cannot be interpreted as an integer`` out of ``range()``,
-      naming neither the field nor the run, and only after the environment, the
-      networks and a full rollout have been built - exactly the deep stack trace
-      a read-only preflight exists to replace. No checkpoint is written at all.
-
-    The domain is therefore a positive integer, checked by
-    :func:`~strands_robots.utils.positive_count_error`, which is already the
-    domain this repository uses for a value consumed as a ``range()`` bound: an
-    integral float is not usable there (``range(2.0)`` raises) and ``bool`` must
-    be rejected rather than silently read as one.
-
-    Unlike ``gamma`` this is read by the on-policy backend only - FastSAC
-    optimizes per gradient step from a replay buffer and has no epoch loop over a
-    rollout batch - so it is scoped like :func:`gae_lambda_problems`: per
-    :class:`TrainSpec` a backend ignores the fields it does not support, so
-    reporting on one it never reads would be a false rejection.
-
-    Args:
-        spec: The spec to check.
-        context: Caller identity for the message prefix - the backend's
-            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
-            problem names the backend that refused the value.
-
-    Returns:
-        A single-element list when ``num_learning_epochs`` cannot be honored;
-        empty otherwise.
+    It is the ``range()`` bound enclosing every ``optimizer.step()``, so a
+    non-positive value takes no gradient step while the run still reports
+    success and writes an untrained checkpoint.
     """
     error = positive_count_error(getattr(spec, "num_learning_epochs", 1), "num_learning_epochs", context)
     return [error] if error is not None else []
 
 
 def temperature_learning_rate_problems(spec: TrainSpec, *, context: str) -> list[str]:
-    """Return entropy-temperature learning-rate problems for a :class:`TrainSpec`.
-
-    ``alpha_lr`` is documented on :class:`~strands_robots.training.rl.RLTrainSpec`
-    as the "Learning rate for the temperature optimizer (SAC)", and FastSAC hands
-    it to the same constructor as the already-guarded ``learning_rate`` two lines
-    above it::
-
-        self.actor_optimizer = torch.optim.Adam(actor_params, lr=spec.learning_rate)
-        self.critic_optimizer = torch.optim.Adam(critic_params, lr=spec.learning_rate)
-        ...
-        self.alpha_optimizer = torch.optim.Adam([self.log_alpha], lr=spec.alpha_lr)
-
-    So every failure mode :func:`learning_rate_problems` documents applies to it
-    unchanged, and each was measured on a 40-timestep FastSAC run whose
-    temperature starts at ``init_alpha=1.0``:
-
-    * ``0`` (and ``0.0``, and ``False``, which is ``0`` to the optimizer) builds
-      the optimizer and moves ``log_alpha`` by nothing, so the temperature stays
-      at ``init_alpha`` for the whole run. ``autotune_alpha=True`` then behaves
-      exactly like ``autotune_alpha=False`` while reporting the automatic
-      temperature it was asked for - the "runs the full work and updates no
-      weight" pathology, on the one parameter whose job is to adapt.
-    * ``inf`` also builds, and the first step sends ``log_alpha`` to an infinity.
-      Because ``alpha`` multiplies the log-probability in the *actor* loss, the
-      damage is not confined to the temperature: the run finished with
-      ``status="success"`` and a checkpoint whose largest parameter magnitude was
-      ``inf``.
-    * ``True`` is a silent learning rate of ``1.0``, over three thousand times
-      the ``3e-4`` default, and moved the temperature 407x further in the same
-      40 steps.
-    * A negative value and ``nan`` *are* refused, by ``torch.optim.Adam``
-      (``ValueError: Invalid learning rate``), and a ``str`` / ``None`` /
-      ``list`` raises a bare ``TypeError: '<=' not supported between instances of
-      'float' and 'str'`` naming neither the field nor the value. Both arrive in
-      :meth:`~strands_robots.training.rl.base_algo.BaseRLAlgo.setup`, after the
-      env and both networks are built - past the point :meth:`Trainer.validate`
-      documents itself as running before.
-
-    Unlike ``learning_rate`` there is no ``None`` sentinel to exempt: the field is
-    annotated ``float`` with a concrete ``3e-4`` default, so ``None`` is a value
-    the temperature optimizer cannot take rather than a request for a default.
-
-    The value is read only when ``autotune_alpha`` is set, which is the only
-    branch that constructs a temperature optimizer, so a spec that tunes no
-    temperature is not reported on - refusing a field that call path never reads
-    would be a false rejection. A plain :class:`TrainSpec` has no
-    ``autotune_alpha`` at all and is likewise silent.
-
-    Only the SAC backend tunes a temperature, so this is scoped like
-    :func:`gae_lambda_problems` rather than :func:`learning_rate_problems`: a
-    backend that does not read the field MUST NOT call this.
-
-    Args:
-        spec: The spec to check.
-        context: Caller identity for the message prefix - the backend's
-            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
-            problem names the backend that refused the value.
-
-    Returns:
-        A single-element list when a tuned temperature's ``alpha_lr`` cannot be
-        honored; empty when it is usable or no temperature is being tuned.
-    """
+    """Report ``alpha_lr``: a rate. Empty unless ``autotune_alpha`` is set."""
     if not getattr(spec, "autotune_alpha", False):
         return []
     error = positive_finite_number_error(getattr(spec, "alpha_lr", 3e-4), "alpha_lr", context)
@@ -1221,180 +291,15 @@ def temperature_learning_rate_problems(spec: TrainSpec, *, context: str) -> list
 
 
 def initial_temperature_problems(spec: TrainSpec, *, context: str) -> list[str]:
-    """Return entropy-temperature starting-value problems for a :class:`TrainSpec`.
-
-    ``init_alpha`` is documented on :class:`~strands_robots.training.rl.RLTrainSpec`
-    as the "Initial entropy temperature (SAC)". FastSAC does not hold it directly:
-    it stores the temperature's *logarithm*, so the field reaches ``torch.log``
-    on both temperature branches::
-
-        self.log_alpha = torch.tensor(float(torch.log(torch.tensor(spec.init_alpha))), ...)
-
-    and ``alpha`` - which scales the entropy term in the critic's TD target and
-    in the actor loss - is ``log_alpha.exp()`` from there on. Only a positive
-    finite value has a finite logarithm, so this is the same domain as
-    :func:`temperature_learning_rate_problems` applies to the temperature's
-    learning rate. That gate's own reasoning already names this field: an
-    ``alpha_lr`` of ``0`` is refused because "the temperature stays at
-    ``init_alpha`` for the whole run", which is only a usable statement if
-    ``init_alpha`` is itself usable.
-
-    Each failure mode below was measured on a 40-timestep FastSAC run:
-
-    * ``0`` (and ``0.0``, and ``False``, which is ``0`` to ``torch.log``) makes
-      ``log(0) == -inf``, so ``alpha`` is exactly ``0`` and the entropy term is
-      gone from both losses - the run is no longer the maximum-entropy algorithm
-      that was asked for. Automatic tuning cannot recover it: ``log_alpha``
-      remained ``-inf`` after further gradient steps, because no finite update
-      moves an infinity. The run reported ``status="success"`` and saved a
-      checkpoint holding ``log_alpha == -inf``, so the unusable temperature
-      outlives the run that produced it.
-    * ``True`` is a silent temperature of exactly ``1.0`` - the default - rather
-      than a value the caller chose.
-    * A negative value and ``nan`` make the logarithm ``nan``, and ``inf`` makes
-      it ``inf``; either way the temperature poisons the actor loss, and the
-      first update raises ``ValueError`` from ``torch.distributions.Normal``
-      reporting a tensor of ``nan`` policy means. That message names the
-      distribution's ``loc`` parameter, not the field or the value that produced
-      it, and it arrives inside ``train`` - after the env and both networks are
-      built, past the point :meth:`Trainer.validate` documents itself as running
-      before.
-
-    Unlike :func:`temperature_learning_rate_problems` this is **not** scoped to
-    ``autotune_alpha``: that gate guards an optimizer only the tuning branch
-    constructs, whereas ``init_alpha`` is read on both branches. With tuning off
-    it is the temperature for the whole run and nothing can move it afterwards,
-    so a spec that tunes nothing needs the check more, not less.
-
-    There is no ``None`` sentinel to exempt: the field is annotated ``float``
-    with a concrete ``1.0`` default, so ``None`` is a value ``torch.log`` cannot
-    take rather than a request for a default.
-
-    Only the SAC backend holds an entropy temperature, so this is scoped
-    like :func:`gae_lambda_problems` rather than :func:`learning_rate_problems`:
-    a backend that does not read the field MUST NOT call this. A plain
-    :class:`TrainSpec` has no ``init_alpha`` at all and is likewise silent.
-
-    Args:
-        spec: The spec to check.
-        context: Caller identity for the message prefix - the backend's
-            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
-            problem names the backend that refused the value.
-
-    Returns:
-        A single-element list when ``init_alpha`` has no finite logarithm; empty
-        when it is usable.
-    """
+    """Report ``init_alpha``: a rate, since the temperature is stored as its log."""
     error = positive_finite_number_error(getattr(spec, "init_alpha", 1.0), "init_alpha", context)
     return [error] if error is not None else []
 
 
 def target_entropy_problems(spec: TrainSpec, *, context: str) -> list[str]:
-    """Return target-entropy problems for a :class:`TrainSpec`.
+    """Report ``target_entropy`` when stated: a finite real.
 
-    ``target_entropy`` is the third caller-supplied field of FastSAC's
-    temperature block, and the only one nothing judged. It is the constant the
-    temperature is optimized *against* - the one term of the temperature loss a
-    caller supplies::
-
-        alpha_loss = -(self.log_alpha * (logp + self.target_entropy).detach()).mean()
-
-    and it reaches that expression through an unconditional coercion in
-    :meth:`~strands_robots.training.rl.fast_sac.FastSacTrainer.setup`::
-
-        self.target_entropy = (
-            float(spec.target_entropy) if spec.target_entropy is not None else -float(self.env.num_actions)
-        )
-
-    Its two neighbours in the same block - the temperature's starting value in
-    :func:`initial_temperature_problems` and the rate that moves it in
-    :func:`temperature_learning_rate_problems` - are both held to a *positive*
-    finite domain, and this field was explicitly left out of both: it is signed
-    by construction, defaulting to ``-num_actions``, so it needs a domain neither
-    of them can express. That domain is
-    :func:`~strands_robots.utils.finite_number_error`, the signed counterpart the
-    two loss weights of :func:`loss_weight_problems` already read - the same
-    "finite real, either sign" shape, for the same reason: every reading of this
-    field is a signed entropy in nats, so no endpoint is decidable, but a value
-    that is not a finite real has no reading at all.
-
-    Each row below was measured on a 40-timestep FastSAC run, with ``validate()``
-    returning ``[]`` for every one of them:
-
-    ============================  ===========================================
-    ``target_entropy``            Outcome
-    ============================  ===========================================
-    ``None`` (the default)        trains; ``log_alpha == -0.001801646314``
-    ``-6.0`` (``-num_actions``)   trains; identical to the default
-    ``True``                      **trains against a target entropy of +1.0**
-    ``'-6'``                      trains; ``float()`` coerces it, so the run
-                                  is identical to ``-6.0``
-    ``nan`` / ``inf`` / ``-inf``  raises mid-update, from inside ``torch``
-    ``[-6.0]`` / ``{}``           raises in ``setup``, from ``float()``
-    ============================  ===========================================
-
-    Both failing shapes are what make this a gate rather than a lint:
-
-    * **A boolean is a silent sign flip.** ``bool`` is an ``int`` subclass, so
-      ``target_entropy=True`` is a target entropy of ``+1.0`` where every
-      documented reading of the field is negative - the field's own default is
-      ``-num_actions``, which is ``-6.0`` for this env. The run reported
-      ``success`` and checkpointed ``log_alpha == -0.0018031001091003418``
-      against the honored run's ``-0.001801646314561367``, so it demonstrably
-      drove the temperature somewhere else rather than harmlessly.
-    * **A non-finite value poisons the temperature; a non-real one raises in
-      ``setup``.** ``nan`` makes ``alpha_loss`` ``nan``, the temperature
-      optimizer writes ``nan`` into ``log_alpha``, and ``alpha`` scales the
-      entropy term of *both* the critic's TD target and the actor loss - so the
-      next rollout samples the action distribution from ``nan`` policy means:
-      ``ValueError: Expected parameter loc ... of distribution Normal ... to
-      satisfy the constraint Real()``, a torch message that names that
-      distribution's parameter rather than the field, raised after the env, both
-      networks and a full rollout have been built. A list or a dict raises
-      ``TypeError: float() argument must be a string or a real number`` out of
-      the coercion instead. That is exactly the "deep stack trace" a read-only
-      preflight exists to replace.
-
-    **A numeric string is refused even though ``float()`` coerces it.** That is the
-    one accepting-to-refusing change this gate makes, and it is a consistency one:
-    the field is annotated ``float | None``, so a ``str`` reaches the coercion only
-    by accident of ``float()`` accepting one, and both neighbouring fields of the
-    same temperature block already refuse it - a spec whose ``alpha_lr`` is
-    ``"3e-4"`` is rejected by name while ``target_entropy="-6"`` was not. Accepting
-    it here alone would leave the three fields of one block disagreeing about which
-    spellings a config may use.
-
-    ``None`` is the one value in scope that is not a value: unlike ``init_alpha``
-    and ``alpha_lr``, which are annotated ``float`` with concrete defaults, this
-    field is annotated ``float | None`` and its ``None`` is the documented
-    request for the ``-num_actions`` heuristic, which the coercion above honors.
-    So the sentinel is exempt rather than refused - the only difference in domain
-    between this gate and its two neighbours.
-
-    Like :func:`initial_temperature_problems`, and unlike
-    :func:`temperature_learning_rate_problems`, this is **not** scoped to
-    ``autotune_alpha``: the coercion is unconditional, so a non-real value raises
-    in ``setup`` on either branch - measured with tuning off, ``[-6.0]`` raised
-    the same ``TypeError`` while ``nan`` reached a successful run that simply
-    never spent it. A check conditioned on the tuning branch would therefore let
-    the raising shape through for the untuned one.
-
-    Only the SAC backend optimizes a temperature against a target entropy -
-    ``spec.target_entropy`` appears in ``rl/fast_sac.py`` and nowhere else - so
-    this is scoped like :func:`gae_lambda_problems` rather than
-    :func:`learning_rate_problems`: a backend that does not read the field MUST
-    NOT call this, because per :class:`TrainSpec` a backend ignores the fields it
-    does not support and reporting on one would be a false rejection.
-
-    Args:
-        spec: The spec to check.
-        context: Caller identity for the message prefix - the backend's
-            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
-            problem names the backend that refused the value.
-
-    Returns:
-        A single-element list when ``target_entropy`` is neither the ``None``
-        sentinel nor a finite real; empty when it can be honored.
+    ``None`` is the sentinel for the heuristic default, not a missing value.
     """
     value = getattr(spec, "target_entropy", None)
     if value is None:
@@ -1404,65 +309,19 @@ def target_entropy_problems(spec: TrainSpec, *, context: str) -> list[str]:
 
 
 def _clip_bound_error(value: Any, param: str, context: str) -> str | None:
-    """Error text when *value* is not a clip bound its consumer honors.
+    """Error text when *value* is not a clip bound; ``None`` when it is.
 
-    Shared by the two on-policy clip bounds, which have the same domain for the
-    same reason: ``max_grad_norm`` (see :func:`gradient_clip_problems`) and
-    ``clip_param`` (see :func:`clip_range_problems`). One rule, one home - a
-    second copy of it would be free to drift from this one.
-
-    The whole of this function's own contribution is that positive **infinity is
-    also accepted**; every other decision - numeric-ness, ``bool`` rejection,
-    the positivity floor and the message text - is delegated to the shared
-    :func:`~strands_robots.utils.positive_finite_number_error` domain, so those
-    refusals read identically to every other positive-scalar field's.
-
-    Infinity is carved out because both consumers honor it, and it is the only
-    spelling of "do not clip" either field has:
-
-    * ``clip_grad_norm_`` scales a gradient by ``max_norm / total_norm`` only
-      when that ratio is below one, so an infinite bound leaves every gradient
-      untouched - measured on a parameter whose gradient norm is 5, ``inf``
-      returns it as ``[3.0, 4.0]`` unchanged.
-    * ``torch.clamp(ratio, 1 - clip_param, 1 + clip_param)`` becomes
-      ``clamp(ratio, -inf, inf)``, which returns ``ratio`` unchanged, so the
-      surrogate and value clips both fall away and the update descends the
-      unclipped objective - a coherent, finite run.
-
-    A guard that refused a value its own consumer applies coherently would be
-    narrower than the code it protects.
-
-    Nothing raises out of here, for any input. The carve-out asks the
-    *conversion* - that is what the consumer performs, ``clip_grad_norm_``
-    reading its bound through ``float()`` - and it wraps that conversion, so a
-    real past the float64 range and a :class:`numbers.Real` registration with
-    no working ``__float__`` are delegated rather than raised on. ``10**400``
-    is a registered real that is neither a ``bool`` nor convertible, and
-    ``Fraction(10**400, 3)`` overflows identically; the shared domain already
-    names that boundary and answers each with a reason of its own. Raising
-    here would fail on the one path that exists to answer an unusable value
-    with a message rather than an exception - the contract every caller of
-    this gate documents.
-
-    Args:
-        value: The caller-supplied value.
-        param: Field name for the message.
-        context: Caller label the message is prefixed with.
-
-    Returns:
-        The error text, or None when *value* is a positive real number (finite
-        or positive infinity).
+    A clip bound is a positive real, and ``inf`` is the spelling of "do not
+    clip" that both consumers honor.
     """
     if isinstance(value, numbers.Real) and not isinstance(value, bool):
         try:
             is_no_clip = float(value) == math.inf
         except Exception:
-            # Decline to answer rather than raise. A ``numbers.Real``
-            # registration owes this function no working ``__float__``, and a
-            # real past the float64 range raises ``OverflowError`` from the
-            # conversion - ``10**400`` and ``Fraction(10**400, 3)`` both do.
-            # Neither is the no-clip spelling, and the shared domain below
-            # answers each with a reason of its own.
+            # A ``numbers.Real`` registration owes this no working
+            # ``__float__``, and a real past the float64 range raises
+            # ``OverflowError`` (``10**400``, ``Fraction(10**400, 3)``).
+            # Neither is the no-clip spelling; the domain below answers both.
             is_no_clip = False
         if is_no_clip:
             return None
@@ -1470,145 +329,16 @@ def _clip_bound_error(value: Any, param: str, context: str) -> str | None:
 
 
 def gradient_clip_problems(spec: TrainSpec, *, context: str) -> list[str]:
-    """Return gradient-clip problems for an on-policy RL :class:`TrainSpec`.
-
-    ``max_grad_norm`` is the last thing that touches a gradient before the
-    optimizer steps - the on-policy update ends every mini-batch with
-    ``clip_grad_norm_(self.actor_critic.parameters(), spec.max_grad_norm)`` -
-    and nothing judged it. ``clip_grad_norm_`` does not either: it multiplies
-    every gradient by ``max_norm / total_norm`` whenever that ratio is below
-    one, and that expression is defined for values no caller can have meant.
-    Measured on this backend, over a seeded 60-step run whose parameter sum
-    starts at ``17.9251941755865118``:
-
-    ======================  =========================================
-    ``max_grad_norm``       Outcome
-    ======================  =========================================
-    ``1.0`` (the default)   trains; parameter sum ``17.9833114612``
-    ``inf``                 trains, unclipped; sum ``17.9604155714``
-    ``0`` / ``0.0``         **succeeds having learned nothing**
-    ``-1.0`` / ``-0.5``     **trains in the opposite direction**
-    ``True``               a silent clip of one
-    ``"1.0"``              silently accepted
-    ``nan``                 raises mid-update, from inside ``torch``
-    ``None`` / ``[1.0]``    raises mid-update, from inside ``torch``
-    ======================  =========================================
-
-    The two silent rows are the reason this is a gate rather than a lint:
-
-    * **Zero scales every gradient to zero**, so the optimizer steps with no
-      information. The run collects its rollouts, reports ``success`` and writes
-      a deployable checkpoint whose parameters are *bit-identical* to a
-      never-trained control - the parameter delta is exactly ``0.0000000000``.
-      This is the same shape as :func:`optimization_epochs_problems`, reached
-      through a different field.
-    * **A negative bound negates the ratio**, so every gradient is flipped and
-      scaled: the same parameter whose gradient is ``[3.0, 4.0]`` comes out of
-      ``clip_grad_norm_(-1.0)`` as ``[-0.6, -0.8]``. The update is therefore
-      gradient *ascent* on the loss - the seeded run above moves its parameter
-      sum to ``17.8211606460`` while the honored run moves it to
-      ``17.9833114612``, i.e. away from the objective, silently, under a
-      successful run.
-
-    Zero is **not** the "no clipping" spelling, which is the one reading that
-    might have made it a contract question rather than a defect: infinity is,
-    and it is accepted (see :func:`_clip_bound_error`). So the domain is a
-    positive real, finite or infinite, with no undecided endpoint.
-
-    Only the on-policy backend clips gradients - ``grep`` finds
-    ``clip_grad_norm_`` in ``rl/ppo.py`` and nowhere else - so this is scoped
-    like :func:`gae_lambda_problems` rather than
-    :func:`learning_rate_problems`: a backend that does not clip MUST NOT call
-    it, because per :class:`TrainSpec` a backend ignores the fields it does not
-    support and reporting on one would be a false rejection.
-
-    Args:
-        spec: The spec to check.
-        context: Caller identity for the message prefix - the backend's
-            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
-            problem names the backend that refused the value.
-
-    Returns:
-        A single-element list when ``max_grad_norm`` cannot be honored; empty
-        otherwise.
-    """
+    """Report ``max_grad_norm``: a clip bound."""
     error = _clip_bound_error(getattr(spec, "max_grad_norm", 1.0), "max_grad_norm", context)
     return [error] if error is not None else []
 
 
 def loss_weight_problems(spec: TrainSpec, *, context: str) -> list[str]:
-    """Return loss-weight problems for an on-policy RL :class:`TrainSpec`.
+    """Report ``value_loss_coef`` and ``entropy_coef``, each a weight.
 
-    ``value_loss_coef`` and ``entropy_coef`` are the two scalars that weight the
-    terms of the objective the on-policy update descends. They are read in
-    exactly one place - the single expression that composes it::
-
-        loss = surrogate_loss + spec.value_loss_coef * value_loss - spec.entropy_coef * entropy
-
-    Nothing judged either of them, and the multiplication cannot: it is defined
-    for values no caller can have meant, and every one of them reaches the
-    backward pass. Measured on this backend, over a seeded 60-step run whose
-    checkpoint parameter sum is ``140.6023186540351162`` when both weights are
-    honored:
-
-    =========================  =========================================
-    Weight                     Outcome
-    =========================  =========================================
-    defaults (``1.0`` / ``0.0``)  trains; sum ``140.6023186540``
-    ``True``                   **trains with a different coefficient**
-    ``nan``                    raises mid-update, from inside ``torch``
-    ``inf`` / ``-inf``         raises mid-update, from inside ``torch``
-    ``"1.0"``                  raises mid-update, from inside ``torch``
-    ``None`` / ``[1.0]``       raises mid-update, from inside ``torch``
-    =========================  =========================================
-
-    Both rows are what make this a gate rather than a lint:
-
-    * **A boolean is a silently different coefficient.** ``bool`` is an ``int``
-      subclass, so ``entropy_coef=True`` is an entropy bonus at full weight where
-      the field ships defaulting to ``0.0`` - exploration is turned on by a value
-      that reads as a flag. The run reports ``success`` and writes a checkpoint
-      whose parameter sum is ``140.6158002523716277`` against the honored run's
-      ``140.6023186540351162``, so it demonstrably trained differently rather
-      than harmlessly.
-    * **Everything non-finite or non-numeric raises out of ``train()``**, which
-      is documented to return a terminal ``TrainResult`` and to fail closed on
-      :meth:`~strands_robots.training.base.Trainer.validate` first. A ``nan``
-      weight makes the loss ``nan``, the optimizer writes ``nan`` into every
-      parameter, and the *next* rollout samples the action distribution from
-      them: ``ValueError: Expected parameter loc ... of distribution Normal ...
-      to satisfy the constraint Real()`` - a torch message that names neither the
-      field nor the value, raised after the env, the networks and a full rollout
-      have been built. A string raises ``TypeError: only integer tensors of a
-      single element can be converted to an index`` from the same depth. That is
-      exactly the "deep stack trace" a read-only preflight exists to replace.
-
-    **The floor is deliberately not decided here.** Zero and negative are inside
-    the domain for both fields, because both have a real reading:
-    ``entropy_coef=0.0`` is the shipped default, a negative entropy weight is a
-    penalty that drives the policy deterministic, and ``value_loss_coef=0`` stops
-    training the critic. So the domain is a *finite real* - the one property no
-    reading of either field can want without - checked through
-    :func:`~strands_robots.utils.finite_number_error`, which also refuses the
-    ``bool`` a bare comparison against zero would accept. This is the narrower
-    counterpart of :func:`gradient_clip_problems`, whose endpoint *is* settled by
-    ``clip_grad_norm_`` and which therefore tests positivity.
-
-    Only the on-policy backend composes this objective - ``grep`` finds
-    ``spec.value_loss_coef`` and ``spec.entropy_coef`` in ``rl/ppo.py`` and
-    nowhere else - so this is scoped like :func:`gae_lambda_problems` rather than
-    :func:`learning_rate_problems`: a backend that does not compose it MUST NOT
-    call this, because per :class:`TrainSpec` a backend ignores the fields it does
-    not support and reporting on one would be a false rejection.
-
-    Args:
-        spec: The spec to check.
-        context: Caller identity for the message prefix - the backend's
-            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
-            problem names the backend that refused the value.
-
-    Returns:
-        One problem per weight that cannot be honored; empty when both can.
+    Zero and negative are real configurations for both; the domain bounds only
+    what no reading makes usable.
     """
     defaults = {"value_loss_coef": 1.0, "entropy_coef": 0.0}
     problems = []
@@ -1620,204 +350,27 @@ def loss_weight_problems(spec: TrainSpec, *, context: str) -> list[str]:
 
 
 def clip_range_problems(spec: TrainSpec, *, context: str) -> list[str]:
-    """Return trust-region problems for an on-policy RL :class:`TrainSpec`.
-
-    ``clip_param`` is the half-width of the trust region PPO is named for. The
-    on-policy update reads it twice, in the two expressions that clip::
-
-        surrogate_clipped = -adv * torch.clamp(ratio, 1.0 - spec.clip_param, 1.0 + spec.clip_param)
-        value_clipped = old_values + (value - old_values).clamp(-spec.clip_param, spec.clip_param)
-
-    Nothing judged it, and ``torch.clamp`` cannot: it is defined for every value
-    below, and each one produces a *finite, successful, deployable* run whose
-    objective is not the one the caller configured. Measured on this backend over
-    a seeded 60-step run, against a never-trained control whose checkpoint
-    parameter sum is ``139.8929914773252676``:
-
-    ==========================  =====================================================
-    ``clip_param``              Outcome (checkpoint parameter sum)
-    ==========================  =====================================================
-    ``0.2`` (shipped default)   clips; ``140.1741519418580992``
-    ``inf``                     no clip, finite losses; ``140.1735330768706262``
-    ``nan``                     **bit-identical to the unclipped run**, all losses ``nan``
-    ``True``                    silent half-width of one; ``140.1735330768706262``
-    ``-0.2``                    inverted bounds; ``140.1913412402318500``
-    ``0``                       degenerate window; ``140.2282075245283863``
-    ``-inf``                    trains on ``inf`` losses; ``140.0613218537641842``
-    ``"0.2"`` / ``None`` / ``[0.2]``  raise ``TypeError`` mid-update, from ``rl/ppo.py``
-    ==========================  =====================================================
-
-    Three of those rows are why this is a gate rather than a lint:
-
-    * **A ``nan`` half-width silently removes the trust region.** Both clipped
-      terms become ``nan``, so ``torch.max(surrogate, surrogate_clipped)``
-      returns ``nan`` - but its gradient flows to the *unclipped* branch, because
-      every comparison against ``nan`` is false. The run therefore descends the
-      unclipped objective and its checkpoint is bit-identical to the ``inf`` run,
-      while ``surrogate_loss``, ``value_loss`` and ``latest_loss`` are all
-      reported as ``nan``. PPO's defining mechanism is off and the only signal
-      that anything happened is a metric a caller cannot act on.
-    * **A negative half-width is not a window.** ``1 - c`` exceeds ``1 + c``, so
-      the clamp bounds are inverted and it returns a constant regardless of the
-      ratio - measured, ``clamp([0.7, 1.0, 1.4], 1.2, 0.8)`` is
-      ``[0.8, 0.8, 0.8]`` - and the reported surrogate loss changes sign, from
-      ``-0.008662`` to ``+0.081992``. Zero is the same failure at the boundary:
-      the value clip becomes ``clamp(-0, 0)``, so ``value_clipped`` is exactly
-      ``old_values`` and the critic's clipped branch is a constant.
-    * **A ``bool`` is a silently different trust region.** ``bool`` is an ``int``
-      subclass, so ``clip_param=True`` is a half-width of one - five times the
-      shipped ``0.2`` - written by a value that reads as a flag.
-
-    So the domain is a *positive* real, with positive infinity accepted as the
-    field's only spelling of "do not clip". That is the same rule and the same
-    reason as the sibling bound ``max_grad_norm``, so both read
-    :func:`_clip_bound_error` rather than carrying a copy each.
-
-    Only the on-policy backend clips a policy ratio - ``grep`` finds
-    ``spec.clip_param`` in ``rl/ppo.py`` and nowhere else - so this is scoped
-    like :func:`gae_lambda_problems` rather than :func:`learning_rate_problems`:
-    a backend that does not clip MUST NOT call this, because per
-    :class:`TrainSpec` a backend ignores the fields it does not support and
-    reporting on one would be a false rejection.
-
-    Args:
-        spec: The spec to check.
-        context: Caller identity for the message prefix - the backend's
-            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
-            problem names the backend that refused the value.
-
-    Returns:
-        A single-element list when ``clip_param`` cannot be honored; empty
-        otherwise.
-    """
+    """Report ``clip_param``: a clip bound, the half-width of the trust region."""
     error = _clip_bound_error(getattr(spec, "clip_param", 0.2), "clip_param", context)
     return [error] if error is not None else []
 
 
 def policy_delay_problems(spec: TrainSpec, *, context: str) -> list[str]:
-    """Return policy-delay problems for an off-policy TD3 :class:`RLTrainSpec`.
+    """Report ``policy_delay``: a count.
 
-    ``policy_delay`` is the number of critic updates FastTD3 runs per delayed
-    actor / target update - the "delayed" of Twin Delayed DDPG. It is consumed
-    as the modulus of the one test that decides whether the actor and the
-    target networks move at all::
-
-        if self._update_count % spec.policy_delay == 0:  # actor + Polyak step
-
-    Nothing downstream judges it, and the modulus mis-handles every unusable
-    spelling differently - measured on a CPU FastTD3 run of 6 gradient updates
-    (an otherwise-valid spec, one field mutated):
-
-    ======================  ==========  ===============  ======================
-    ``policy_delay``        verdict     actor updates    what happened
-    ======================  ==========  ===============  ======================
-    ``2`` (the default)     honored     3                the asked-for delay
-    ``float("nan")``        success     **0**            ``n % nan`` is ``nan``,
-                                                         never ``== 0``
-    ``2.5``                 success     **1** (not 3)    only multiples of 2.5
-    ``True``                success     6                a silent delay of one
-    ``0``                   raises      --               ``ZeroDivisionError``
-                                                         mid-update
-    ``"2"`` / ``None``      raises      --               ``TypeError`` from ``%``
-    ======================  ==========  ===============  ======================
-
-    The ``nan`` row is the reason this is a gate rather than a lint: the
-    critics train for the whole run, the losses are real numbers, the run
-    reports success and writes a checkpoint - but the actor inside it never
-    took a gradient step, so the deployable half of the policy is its untrained
-    initialisation with nothing anywhere reporting that. ``True`` and a
-    fraction are silently a *different* delay from the one the caller named,
-    and a non-positive or non-numeric value raises from inside the update loop
-    after the env, the networks, the optimizers and the replay buffer are
-    built - the cost a read-only preflight exists to precede.
-
-    The domain is a positive integer, checked by
-    :func:`~strands_robots.utils.positive_count_error` - the same rule this
-    package applies to every count consumed as a modulus or ``range()`` bound -
-    with ``1`` first-class: a delay of one is TD3 with the delay disabled,
-    which is a configuration, not a defect.
-
-    Only the TD3 backend delays its policy - PPO has no target networks and
-    SAC updates its actor every gradient step - so this is scoped like
-    :func:`gae_lambda_problems` rather than :func:`learning_rate_problems`: a
-    backend that does not read the field MUST NOT call this, because per
-    :class:`TrainSpec` a backend ignores the fields it does not support and
-    reporting on one would be a false rejection.
-
-    Args:
-        spec: The spec to check.
-        context: Caller identity for the message prefix - the backend's
-            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
-            problem names the backend that refused the value.
-
-    Returns:
-        A single-element list when ``policy_delay`` cannot be honored; empty
-        otherwise.
+    It is the modulus of an ``update_count % policy_delay`` test, so a value
+    that never satisfies it trains the critics while the deployable actor never
+    takes a gradient step.
     """
     error = positive_count_error(getattr(spec, "policy_delay", 1), "policy_delay", context)
     return [error] if error is not None else []
 
 
 def td3_noise_problems(spec: TrainSpec, *, context: str) -> list[str]:
-    """Return noise-scale problems for an off-policy TD3 :class:`RLTrainSpec`.
+    """Report ``exploration_noise_std``, ``target_noise_std`` and ``target_noise_clip``.
 
-    ``exploration_noise_std``, ``target_noise_std`` and ``target_noise_clip``
-    are the three scalars that shape FastTD3's two noise mechanisms, read in
-    exactly two expressions::
-
-        action = (action + torch.randn_like(action) * spec.exploration_noise_std).clamp(-1.0, 1.0)
-        noise = (torch.randn_like(a) * spec.target_noise_std).clamp(-spec.target_noise_clip, spec.target_noise_clip)
-
-    The first is the only exploration a deterministic policy has once the
-    random warmup ends; the second is target policy smoothing, the mechanism
-    that keeps the critic from exploiting its own sharp errors. Neither
-    expression judges its scalars, and each unusable value produces a finite,
-    successful run that is not the configured one:
-
-    * **Zero silently removes the mechanism.** ``randn * 0`` is exactly ``0``,
-      so ``exploration_noise_std=0`` collects with the deterministic action
-      alone - the policy revisits the identical trajectory instead of
-      exploring around it - and ``target_noise_std=0`` (or a clip of ``0``,
-      which clamps every sample to ``[0, 0]``) trains plain clipped double-Q
-      while reporting the smoothing knobs it was asked for. Neither run can be
-      told apart from an honored one by its result object.
-    * **A negative scale is silently the identical run.** Gaussian noise is
-      symmetric, so ``randn * (-s)`` draws from the same distribution as
-      ``randn * s`` - a value that reads as different and changes nothing. A
-      negative *clip* is worse than identical: ``clamp`` with inverted bounds
-      returns the constant upper bound, so every smoothing sample becomes the
-      same negative offset and the target is biased rather than smoothed.
-    * **A non-finite value poisons what the expression feeds.** A ``nan`` std
-      makes every collected action (or every TD target, and from there every
-      critic parameter) ``nan`` under a run that keeps stepping; an ``inf``
-      exploration std saturates the clamp so every action is a coin-flip
-      between the bounds ``-1`` and ``1`` - bang-bang control, not a large
-      noise. ``True`` is a silent scale of ``1.0``, ten times the shipped
-      exploration default, from a value that reads as a flag.
-
-    Only a positive finite number can be honored, so all three are checked
-    against the shared
-    :func:`~strands_robots.utils.positive_finite_number_error` domain - the
-    family that already owns the dimensionless-multiplier scalars - which also
-    refuses the ``bool`` a bare comparison would accept. There is no "disable"
-    spelling to carve out, unlike :func:`_clip_bound_error`'s infinity: a run
-    that wants no smoothing is a different algorithm, not a boundary value of
-    this one.
-
-    Only the TD3 backend reads the three fields - SAC explores through its
-    stochastic actor and smooths nothing - so this is scoped like
-    :func:`policy_delay_problems`: a backend that does not read them MUST NOT
-    call this, because per :class:`TrainSpec` a backend ignores the fields it
-    does not support and reporting on one would be a false rejection.
-
-    Args:
-        spec: The spec to check.
-        context: Caller identity for the message prefix - the backend's
-            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
-            problem names the backend that refused the value.
-
-    Returns:
-        One problem per unusable noise scalar; empty when all three are usable.
+    Each is a rate: Gaussian noise is symmetric, so a negative scale is the
+    identical distribution and zero removes the mechanism entirely.
     """
     problems: list[str] = []
     for param, default in (
@@ -1832,87 +385,7 @@ def td3_noise_problems(spec: TrainSpec, *, context: str) -> list[str]:
 
 
 def network_width_problems(spec: TrainSpec, *, context: str) -> list[str]:
-    """Return hidden-layer-width problems for a from-scratch RL :class:`TrainSpec`.
-
-    ``hidden_dims`` is the only spec field that decides the *shape* of the
-    networks a run trains. Every RL backend expands it the same way, once per
-    network it builds - the on-policy actor and critic, and off-policy the actor,
-    its Polyak target and all four Q heads::
-
-        for h in spec.hidden_dims:
-            layers += [nn.Linear(last, h), nn.ReLU()]
-            last = h
-        layers.append(nn.Linear(last, out_dim))
-
-    Nothing judged the widths, and ``nn.Linear`` does not either: a width of
-    zero is a legal layer. It builds a ``(n, 0)`` weight - ``torch`` only warns
-    "Initializing zero-element tensors is a no-op" - and every forward pass
-    through it produces a ``(batch, 0)`` activation, so the next layer sees no
-    input and emits its bias alone. **The output stops being a function of the
-    observation.** Measured on the fake one-joint env, over a full ``train()``
-    on each backend, comparing the trained actor's action for an all-zero
-    observation against an all-``50`` one:
-
-    ======================  ==============  ==================================
-    ``hidden_dims``         Verdict         Outcome
-    ======================  ==============  ==================================
-    ``(16,)`` (a control)   accepted        actions differ: ``0.109`` / ``-0.869``
-    ``()``                  accepted        a linear policy; actions differ
-    ``(0,)``               **accepted**    every action bit-identical
-    ``(16, 0)``            **accepted**    every action bit-identical
-    ``(-1,)``               accepted        raises inside ``setup``
-    ``(16.0,)`` / ``(True,)`` accepted      raises inside ``setup``
-    ``np.int64(16)``        accepted        trains, then the checkpoint raises
-    ``16`` / ``None``       accepted        raises inside ``setup``
-    a generator             accepted        a different shape per network
-    ======================  ==============  ==================================
-
-    The two bold rows are why this is a gate rather than a lint. A zero width
-    anywhere in the sequence severs the policy from the robot: the run collects
-    its rollouts, the critics train against a constant, ``train()`` returns
-    ``status="success"`` with a real ``actor_loss`` and a real ``actor_updates``
-    count, and it exports ``policy.pt`` + ``policy_meta.json`` - a *deployable*
-    checkpoint whose actor emits one fixed action for every state the robot can
-    ever be in. On hardware that is an arm driving to a single pose and staying
-    there, reported as a trained policy. This is the same shape as
-    :func:`gradient_clip_problems` (a run that reports success having learned
-    nothing), reached through the one field that can make learning *impossible*
-    rather than merely ineffective.
-
-    The empty sequence is **not** in that class and stays accepted: it is the
-    honest spelling of a linear policy (input straight to output, no hidden
-    layer), and its action still varies with the observation. So the domain is
-    per element, not on the length.
-
-    Each width is asked of the shared :func:`~strands_robots.utils.positive_count_error`
-    domain, the same one the loop-bound counts use, because a width is consumed
-    directly as a tensor dimension: an integral float raises ``TypeError``
-    inside ``torch`` rather than being coerced, and ``bool`` would otherwise
-    pass a bare ``< 1`` test as a silent width of one. That domain also refuses
-    ``np.int64``, which is not an over-refusal here even though ``nn.Linear``
-    accepts it - ``save_checkpoint`` writes ``list(spec.hidden_dims)`` to
-    ``policy_meta.json`` and ``json.dump`` raises ``TypeError: Object of type
-    int64 is not JSON serializable``, so a run configured that way trains to
-    completion and then loses the whole run at the save.
-
-    The container is checked before its elements, since a field that is not a
-    sequence of widths has no elements to name: a bare ``int`` or ``None`` is
-    not iterable, a ``str`` iterates into characters, and a one-shot iterator is
-    worse than either - a generator is consumed by the first network built, so
-    the actor gets the requested architecture and every later critic silently
-    gets none (measured: 452 parameters for the first, 28 for the second).
-
-    Args:
-        spec: The spec to check.
-        context: Caller identity for the message prefix - the backend's
-            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
-            problem names the backend that refused the value.
-
-    Returns:
-        One problem per unusable width (named by index), or a single problem
-        when ``hidden_dims`` is not a sequence of widths at all; empty when
-        every width can be honored.
-    """
+    """Report ``hidden_dims``: a sequence of counts, each width named by index."""
     widths = getattr(spec, "hidden_dims", ())
     if isinstance(widths, str) or not isinstance(widths, Sequence):
         return [f"{context}: hidden_dims must be a sequence of positive int layer widths, got {widths!r}"]
@@ -1924,105 +397,13 @@ def network_width_problems(spec: TrainSpec, *, context: str) -> list[str]:
 
 
 def rl_checkpoint_interval_problems(spec: TrainSpec, *, context: str) -> list[str]:
-    """Return checkpoint-cadence problems for an RL :class:`RLTrainSpec`.
-
-    ``log_interval`` is how often an RL run writes a checkpoint. Its name and
-    its :class:`RLTrainSpec` entry both said "iterations between progress logs",
-    but no RL module emits a log line at all - the field is read in exactly one
-    expression, the one that decides whether an intermediate checkpoint is
-    written, and all three backends share it::
-
-        if spec.log_interval and (it % spec.log_interval == 0 or it == num_iters - 1):
-            ckpt_dir = self.save_checkpoint(spec.output_dir, iteration=it + 1)
-
-    So it is the same *kind* of value as
-    :attr:`~strands_robots.training.base.TrainSpec.save_freq` - a periodic
-    checkpoint cadence consumed as a modulus - and it reached that modulus with
-    no domain at all, while the supervised field beside it on the same spec has
-    one. Measured on the inherited loop over a 20-iteration run, against the
-    ``[1, 6, 11, 16, 20]`` an ``int`` cadence of 5 writes:
-
-    ====================  ==============  ====================================
-    ``log_interval``      Verdict         Outcome
-    ====================  ==============  ====================================
-    ``5`` (a control)     accepted        5 checkpoints, at 1, 6, 11, 16, 20
-    ``True``             **accepted**     20 checkpoints - one every iteration
-    ``2.5``              **accepted**     5, at 1, 6, 11, 16, 20 - the schedule
-                                          of ``5``, not of ``2.5``
-    ``0.3``              **accepted**     2, at 1 and 20
-    ``nan``              **accepted**     1, at 20 - the *disabled* mode
-    ``inf``              **accepted**     2, at 1 and 20
-    ``"5"``              **accepted**     ``TypeError`` out of ``train()``
-    ``0``                 accepted        1, at 20 - the documented disable
-    ``-5``                accepted        5, at 1, 6, 11, 16, 20
-    ====================  ==============  ====================================
-
-    The bold rows are why this is a gate. ``nan`` is the worst of them: it
-    satisfies the truthiness guard, never satisfies the modulus, and so silently
-    becomes the disabled mode - a long run that asked to checkpoint every 5
-    iterations keeps only the final one, under ``status="success"``. For RL the
-    intermediate checkpoints are not a convenience: return is non-monotonic in
-    training, so the deployable policy is often an earlier one, and a run that
-    kept only its last iteration cannot be recovered without training again.
-    ``True`` is the opposite failure at the same seam (a modulus of one, a full
-    checkpoint every iteration), ``2.5`` is indistinguishable from the ``5`` a
-    caller who wanted twice as many checkpoints did not write, and ``"5"``
-    raises out of the training loop *after* ``setup`` has built the env, the
-    networks and the optimizers - from a lifecycle whose whole contract is to
-    report a failure as :class:`~strands_robots.training.base.TrainResult`, and
-    past a :meth:`~strands_robots.training.base.Trainer.validate` documented to
-    return every problem a run has.
-
-    Only the *type* is graded, exactly as for :func:`checkpoint_cadence_problems`,
-    and the two disabling spellings are first-class: ``0`` disables periodic
-    saving and leaves the end-of-run fallback in
-    :meth:`~strands_robots.training.rl.base_algo.BaseRLAlgo.train` to write the
-    single final checkpoint, a configuration that loop's own contract tests
-    already pin. A negative is accepted for the same
-    no-floor reason and is *not* the disabled mode here - unlike lerobot's
-    ``save_freq > 0`` test, this loop's guard is bare truthiness, so ``-5`` is
-    the cadence of its magnitude (measured above). Which spelling disables is
-    therefore the loop's own business; the domain's business is that the value
-    is a whole number of iterations.
-
-    Args:
-        spec: The spec to check.
-        context: Caller identity for the message prefix - the backend's
-            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
-            problem names the backend that refused the value.
-
-    Returns:
-        A single problem when ``log_interval`` is not a whole number of
-        iterations; empty otherwise.
-    """
+    """Report ``log_interval``: a cadence in iterations."""
     error = step_cadence_error(getattr(spec, "log_interval", 0), "log_interval", context)
     return [] if error is None else [error]
 
 
 def _half_open_unit_interval_error(value: Any, param: str, context: str) -> str | None:
-    """Error text when *value* is not a real number in the half-open range (0, 1].
-
-    Sibling of :func:`_closed_unit_interval_error`, and the two differ in exactly
-    one decision: whether zero is inside the interval. Numeric-ness, ``bool``
-    rejection, finiteness and the float64 range are delegated to the shared
-    :func:`~strands_robots.utils.finite_number_error` domain by both, so those
-    refusals read identically to every other numeric field's.
-
-    Zero is **outside** this interval because it is a degenerate spelling rather
-    than a reading: the one consumer is a Polyak update, ``tp.mul_(1 -
-    x).add_(x * p)``, which at zero leaves the target parameters at their
-    initialization for the whole run. The upper endpoint is inside, because at
-    one the same expression is the hard update ``tp = p`` that TD3-family
-    algorithms take deliberately.
-
-    Args:
-        value: The caller-supplied value.
-        param: Field name for the message.
-        context: Caller label the message is prefixed with.
-
-    Returns:
-        The error text, or None when *value* is a real number in (0, 1].
-    """
+    """Error text when *value* is not a real number in ``(0, 1]``; else ``None``."""
     error = finite_number_error(value, param, context)
     if error is not None:
         return error
@@ -2032,70 +413,6 @@ def _half_open_unit_interval_error(value: Any, param: str, context: str) -> str 
 
 
 def polyak_coefficient_problems(spec: TrainSpec, *, context: str) -> list[str]:
-    """Return Polyak-coefficient problems for an off-policy RL :class:`TrainSpec`.
-
-    ``tau`` is the rate at which a target network tracks its online network. The
-    two off-policy backends spend it in one expression each, per mirrored critic
-    pair::
-
-        tp.mul_(1.0 - spec.tau).add_(spec.tau * p)
-
-    so the field does not merely tune the update - it decides whether a separate
-    target network exists at all, and a target network is the mechanism that
-    makes an off-policy critic's bootstrap target stationary enough to regress
-    onto.
-
-    This interval was the *precedent* the two on-policy interval gates were
-    written against - :func:`discount_factor_problems` and
-    :func:`gae_lambda_problems` both cite "the sibling FastSAC preflight already
-    bounds its own interval coefficient this way (``tau`` must be in ``(0, 1]``)"
-    as the shape they generalize - while the check they cited was a bare local
-    comparison, ``if not 0.0 < spec.tau <= 1.0``, duplicated verbatim in both
-    backends. A bare comparison against the interval bounds cannot carry the
-    domain, and it left two holes the generalization had already closed:
-
-    * ``True`` is a silent ``tau`` of **one**, because ``bool`` is an ``int``
-      subclass. That is the maximum of the interval, so the Polyak average
-      degenerates to ``tp.mul_(0.0).add_(p)`` - the target network becomes a
-      copy of the online network on every update, which is the same thing as
-      having no target network. Measured on a 60-timestep FastSAC run,
-      ``validate()`` returning ``[]`` and the run reporting success: the largest
-      online-to-target parameter gap in the exported checkpoint was ``0.0``
-      exactly against the default ``tau``'s ``9.9e-04``, and the checkpoint was
-      byte-identical to a run that asked for ``tau=1.0``. So a flag landed as a
-      request to switch off target networks, and nothing in the run said so.
-    * A numeric **string**, ``None`` or a list raises ``TypeError: '<' not
-      supported between instances of 'float' and 'str'`` out of the comparison
-      itself - from a
-      :meth:`~strands_robots.training.base.Trainer.validate` documented to
-      *return* its problems, which is the contract every other field on this
-      spec is now checked against.
-
-    ``nan`` and the two infinities were already refused, by an accident of
-    Python's chained comparison rather than by a finiteness test: every
-    comparison against ``nan`` is False and ``inf`` is above the upper bound, so
-    the bare test happened to answer them. They stay refused here, on the
-    shared domain, with the reason naming finiteness rather than the interval.
-
-    Both endpoints keep the reading the bare test gave them, so no value that
-    worked becomes an error: ``1.0`` is accepted as the deliberate hard update,
-    and ``0.0`` is refused because it freezes the target network at its
-    initialization for the whole run - see
-    :func:`_half_open_unit_interval_error`, which owns that one decision and is
-    what makes this interval half-open where the on-policy pair's is closed.
-
-    Only a backend that maintains a target network may call this: like
-    :func:`gae_lambda_problems`, and unlike :func:`learning_rate_problems`, a
-    backend that does not read the field MUST NOT report on it - PPO has no
-    target network and never reads ``tau``.
-
-    Args:
-        spec: The spec to check.
-        context: Caller identity for the message prefix - the backend's
-            :attr:`~strands_robots.training.base.Trainer.provider_name`.
-
-    Returns:
-        A single-element list when ``tau`` cannot be honored; empty otherwise.
-    """
+    """Report ``tau``: a half-open unit - a zero target update never moves."""
     error = _half_open_unit_interval_error(getattr(spec, "tau", 0.005), "tau", context)
     return [error] if error is not None else []

--- a/strands_robots/training/base.py
+++ b/strands_robots/training/base.py
@@ -1,44 +1,30 @@
-"""Trainer abstraction - post-tune ANY policy provider natively.
+"""Trainer abstraction - post-tune any policy provider natively.
 
-The :class:`Trainer` ABC is the training-side peer of
-:class:`~strands_robots.policies.base.Policy` (inference). Where ``Policy``
-hides *how a model produces actions*, ``Trainer`` hides *how a model is
-post-tuned* - and those pipelines genuinely differ per provider:
+:class:`Trainer` is the training-side peer of
+:class:`~strands_robots.policies.base.Policy`: where ``Policy`` hides how a
+model produces actions, ``Trainer`` hides how a model is post-tuned. The
+pipelines differ per provider:
 
-* **LeRobot** - build a ``TrainPipelineConfig`` and call
-  ``lerobot.scripts.lerobot_train.train(cfg)`` in-process. HF-native checkpoints.
-* **GR00T N1.7** - build a ``FinetuneConfig`` -> ``Config`` and call
-  ``gr00t.experiment.experiment.run(config)``; ``tune_llm/visual/projector/
-  diffusion`` knobs + a modality-config ``.py``.
-* **Cosmos3** - build the SFT ``Config`` via ``load_experiment_from_toml`` and
-  call ``cosmos_framework.scripts.train.launch(config, args)``; with an explicit
-  **DCP checkpoint conversion** prepare step and a **DCP -> safetensors** export
-  step. 8xH100 floor.
+* **LeRobot** - build a ``TrainPipelineConfig``, call
+  ``lerobot.scripts.lerobot_train.train(cfg)``. HF-native checkpoints.
+* **GR00T N1.7** - build a ``FinetuneConfig`` -> ``Config``, call
+  ``gr00t.experiment.experiment.run(config)``.
+* **Cosmos3** - build the SFT ``Config`` via ``load_experiment_from_toml``,
+  call ``cosmos_framework.scripts.train.launch(config, args)``, with a DCP
+  checkpoint conversion prepare step and a DCP -> safetensors export step.
+* **SageMaker** - submit the same spec as one managed AWS training job.
 
-Those three are **local** backends: they run in-process (imported and called as
-libraries, no subprocess) and multi-GPU goes through torch's programmatic
-``elastic_launch``. A provider may instead be pure **transport**:
+The first three are *local*: they run in-process and multi-GPU goes through
+torch's programmatic ``elastic_launch``. SageMaker is pure *transport*: it
+imports no training library and its run outlives the submitting process, which
+is what decides each shape's :meth:`Trainer.train` return contract.
 
-* **SageMaker** - submit the same spec as one managed AWS training job whose
-  container image packages one of the local paths, so this provider imports no
-  training library and the run outlives the submitting process.
-
-Which shape a provider is decides its :meth:`Trainer.train` return contract - a
-local run always finishes inside the call, a submitted one need not.
-
-All of them nonetheless converge on:
-
-1. the same **dataset format** - LeRobotDataset v3 (what
-   :class:`~strands_robots.dataset_recorder.DatasetRecorder` already writes), and
-2. the same **lifecycle** - ``validate -> prepare -> train -> export``.
-
-A ``Trainer`` is selected by the SAME provider name as its ``Policy``
-(``groot`` / ``lerobot_local`` / ``cosmos3``), so a single registry identity
-owns both the inference class and the training class. Adding a new policy =
-add a ``Policy`` + a ``Trainer`` under one provider entry.
-
-See :class:`~strands_robots.training.mock.MockTrainer` for the canonical
-no-dependency reference implementation.
+All of them converge on one dataset format - LeRobotDataset v3, what
+:class:`~strands_robots.dataset_recorder.DatasetRecorder` writes - and one
+lifecycle: ``validate -> prepare -> train -> export``. A ``Trainer`` is
+selected by the same provider name as its ``Policy``, so one registry identity
+owns both classes. See :class:`~strands_robots.training.mock.MockTrainer` for
+the no-dependency reference implementation.
 """
 
 from __future__ import annotations
@@ -53,141 +39,73 @@ class TrainSpec:
     """Provider-agnostic post-tuning specification.
 
     Concrete trainers read the fields they support and **ignore the rest** -
-    the same tolerance rule that :meth:`Policy.get_actions` applies to its
-    ``**kwargs``. Backends MUST NOT raise on a field they don't use; new,
-    backend-specific knobs live in :attr:`extra` until >=2 backends share
-    them and they graduate to a first-class field.
+    the same tolerance rule :meth:`Policy.get_actions` applies to its
+    ``**kwargs``. Backends MUST NOT raise on a field they do not use; new
+    backend-specific knobs live in :attr:`extra` until >=2 backends share them.
+    A backend that reads a field MUST preflight it through the matching
+    ``Trainer._*_problems`` gate rather than judge it itself.
 
     Attributes:
-        dataset_root: Path to a LeRobotDataset v3 root (must contain
-            ``meta/info.json``). This is exactly what
-            :class:`~strands_robots.dataset_recorder.DatasetRecorder` /
-            ``Robot.stop_recording`` produce, so the ``record -> train`` loop
-            needs no conversion layer. When :attr:`dataset_repo_id` is set this
-            is optional and, if given, acts as a local cache root for the Hub
-            dataset (lerobot ``DatasetConfig.root``).
-        dataset_repo_id: Hugging Face Hub dataset id (``org/name``) to train
-            *from the Hub* instead of a local root. Required for
-            :attr:`streaming` of a Hub dataset (the 50-500 GB case that would
-            otherwise have to download in full first). When set, the backend
-            uses it as lerobot's ``DatasetConfig.repo_id`` and leaves
-            ``dataset_root`` as an optional local cache. Mutually sufficient
-            with ``dataset_root`` - supply exactly one as the data source.
-        streaming: Stream frames from the dataset instead of materializing it
-            (lerobot ``DatasetConfig.streaming`` -> ``StreamingLeRobotDataset``).
-            With :attr:`dataset_repo_id` this streams shards from the Hub with no
-            full download (bounded disk); with a local ``dataset_root`` it
-            streams from disk (bounded RAM). LeRobot-only; other backends ignore
-            it (tolerance rule). Mutually exclusive with :attr:`val_episodes` on
-            the lerobot backend: a held-out split sends lerobot down a map-style
-            path that rebuilds both splits as ``LeRobotDataset`` and drops the
-            stream, so asking for both materializes the whole dataset. The
-            backend refuses the pair in :meth:`Trainer.validate` rather than
-            deliver one of the two silently.
-        base_model: HF model id or local checkpoint path to post-tune *from*.
-        output_dir: Directory for checkpoints, logs, and the final artifact.
-        embodiment: Embodiment tag / robot id. Required by GR00T
-            (``--embodiment_tag``); LeRobot infers it from dataset features;
-            optional elsewhere.
-        steps: Total optimizer steps (maps to lerobot ``--steps`` /
-            GR00T ``max_steps`` / Cosmos ``trainer.max_iter``).
+        dataset_root: LeRobotDataset v3 root (contains ``meta/info.json``).
+            Optional when :attr:`dataset_repo_id` is set, where it acts as the
+            local cache root.
+        dataset_repo_id: Hub dataset id (``org/name``) to train from the Hub
+            instead of a local root. Supply exactly one data source.
+        streaming: Stream frames instead of materializing the dataset. A
+            ``bool``. LeRobot-only, and mutually exclusive there with
+            :attr:`val_episodes`: a held-out split rebuilds both splits as
+            map-style datasets and drops the stream.
+        base_model: HF model id or local checkpoint path to post-tune from.
+        output_dir: Directory for checkpoints, logs and the final artifact.
+        embodiment: Embodiment tag / robot id. Required by GR00T; LeRobot
+            infers it from dataset features.
+        steps: Total optimizer steps. A positive ``int``.
         global_batch_size: Batch summed across GPUs before grad accumulation.
-        learning_rate: Optimizer learning rate. ``None`` (default) uses the
-            backend's own default -- the policy training preset for LeRobot
-            (``policy.optimizer_lr``), GR00T's ``FinetuneConfig`` default, or
-            Cosmos's TOML default. An explicit value is honored by every
-            backend (same opt-in shape as :attr:`seed`); LeRobot maps it to
-            ``policy.optimizer_lr`` and rejects it loudly if the policy has no
-            such field. RL trainers (PPO/FastSAC) have no preset to defer to,
-            so :class:`~strands_robots.training.rl.base_algo.RLTrainSpec`
-            overrides this default with a concrete value. An explicit value
-            must be a positive finite number: ``0`` trains for the full run
-            without updating a weight and ``inf`` writes a checkpoint of
-            ``NaN``, neither of which any backend can report, so both are
-            refused by :meth:`Trainer.validate` before a run starts.
-        save_freq: Checkpoint cadence in steps (lerobot ``--save_freq`` /
-            ``cfg.save_freq``, GR00T ``--save_steps``, Cosmos
-            ``checkpoint.save_iter``). A whole number: it is consumed as the
-            modulus of a ``step % save_freq`` test, so ``True`` is a cadence of
-            one that checkpoints every step, a fractional or non-finite value
-            never satisfies the test and silently disables periodic saving, and
-            a string raises out of the comparison inside the training loop -
-            none of which any backend reports, which is why a backend that
-            reads it MUST check it through
-            :meth:`Trainer._checkpoint_cadence_problems` rather than forward it.
-            A non-positive value is a capability rather than an unusable one: it
-            disables periodic saving so only the final checkpoint is written
-            (lerobot's ``should_save_checkpoint``), and the backends' own
-            ``eval_steps`` fallback is written for that case.
-        num_gpus: GPUs on this node. ``>1`` runs the backend under torch's
-            in-process ``elastic_launch`` (the engine behind ``torchrun``).
-            A positive integer; a non-positive, fractional, non-finite or
-            ``bool`` process count cannot be honored - the ``>1`` selector
-            would silently route it to a single-process run, or hand it to
-            ``elastic_launch`` as the worker count - so it is refused by
-            :meth:`Trainer.validate` before a run starts.
-        num_nodes: Nodes for multi-node training (Cosmos HSDP /
-            ``torchrun --nnodes``). Same positive-integer domain as
-            ``num_gpus``, and for the same reason.
-        resume: Resume from the latest checkpoint under ``output_dir`` when
-            one exists.
-        seed: Master seed (best-effort; not all backends expose it).
-        method: Tuning strategy, mapped per-backend:
-            ``"full"`` | ``"lora"`` | ``"expert_only"`` | ``"frozen_backbone"``.
-            ``lora`` and ``expert_only`` are mutually exclusive (both freeze
-            the VLM); a backend MUST reject the combination in
-            :meth:`Trainer.validate`.
-        lora_r / lora_alpha / lora_target_modules: LoRA hyperparameters
-            (used only when ``method == "lora"``). ``lora_target_modules=None``
-            means "use the policy's built-in default targets". ``lora_r`` is the
-            adapter rank and ``lora_alpha`` the numerator of its ``lora_alpha /
-            lora_r`` scaling, so each must be a positive integer or ``None``
-            (keep peft's own default); a backend that reads them MUST check them
-            through :meth:`Trainer._lora_hyperparameter_problems` rather than
-            leave them to peft, which judges only the rank and only once the base
-            model is loaded.
-        tune: Fine-grained component toggles for backends that expose them
-            (GR00T: ``{"llm": bool, "visual": bool, "projector": bool,
-            "diffusion": bool}``). Ignored by backends that don't.
-        val_episodes: Hold out the LAST N episodes as a validation set
-            (deterministic split). A backend MUST make the reserved episodes
-            produce a validation signal, not merely shrink the training set;
-            the lerobot backend maps it onto ``--dataset.eval_split`` plus a
-            non-zero ``--eval_steps`` so an eval loss is logged periodically.
-            Must be a positive integer below the dataset's episode count, or
-            ``None`` to train on every episode. That upper bound is also a SOURCE
-            requirement: the count comes from the dataset's local
-            ``meta/info.json``, so a backend that cannot read one (a Hub source
-            with no populated :attr:`dataset_root`) MUST refuse rather than emit
-            no split - an absent split is indistinguishable from ``None``, and
-            reporting no problem would launch exactly the validation-less run
-            this field exists to avoid. Because the count is converted
-            into a real-valued split fraction whose ceiling lerobot takes, a
-            backend MUST check it with
-            :meth:`Trainer._validation_episodes_problems` rather than compare it
-            itself: a non-positive value produces no split at all, and ``True``
-            / ``2.7`` / ``0.5`` reserve 1 / 3 / 0 episodes respectively. On the
-            lerobot backend this is mutually exclusive with :attr:`streaming`
-            (see that field).
+            A positive ``int``.
+        learning_rate: Optimizer learning rate, or ``None`` for the backend's
+            own default. When given, a positive finite number: ``0`` trains the
+            full run without updating a weight and ``inf`` checkpoints ``NaN``.
+        save_freq: Checkpoint cadence in steps, consumed as the modulus of a
+            ``step % save_freq`` test. A non-negative whole number;
+            non-positive disables periodic saving so only the final checkpoint
+            is written.
+        num_gpus: GPUs on this node. A positive ``int``; ``>1`` runs the
+            backend under torch's in-process ``elastic_launch``.
+        num_nodes: Nodes for multi-node training. Same domain as ``num_gpus``.
+        resume: Resume from the latest checkpoint under ``output_dir``. A
+            ``bool``.
+        seed: Master seed (best-effort). A non-negative ``int`` or ``None``.
+        method: Tuning strategy - ``"full"`` | ``"lora"`` | ``"expert_only"``
+            | ``"frozen_backbone"``. ``lora`` and ``expert_only`` are mutually
+            exclusive (both freeze the VLM).
+        lora_r: LoRA adapter rank. A positive ``int``, or ``None`` for peft's
+            default. Read only when ``method == "lora"``.
+        lora_alpha: Numerator of the ``lora_alpha / lora_r`` scaling. Same
+            domain as ``lora_r``.
+        lora_target_modules: Target modules, or ``None`` for the policy's
+            built-in defaults.
+        tune: Component toggles for backends that expose them (GR00T:
+            ``{"llm", "visual", "projector", "diffusion"} -> bool``).
+        val_episodes: Hold out the last N episodes as a validation set, or
+            ``None`` to train on every episode. A positive ``int`` below the
+            dataset's episode count, which comes from a local
+            ``meta/info.json`` - a backend that cannot read one MUST refuse
+            rather than emit no split. The count becomes a real-valued split
+            fraction whose ceiling lerobot takes. A backend MUST make the
+            reserved episodes produce a validation signal, not merely shrink
+            the training set.
         augmentation: Backend-specific data augmentation (GR00T
             ``color_jitter_params`` / ``random_rotation_angle``; Cosmos
             dataset filter dict).
         fps: Dataset control rate, when a backend needs it explicitly.
-        extra: Raw passthrough. Keys become backend-native flags / overrides
-            (lerobot ``--key=value``; Cosmos Hydra ``key.path=value``). The
-            escape hatch that keeps the ABC stable as backends evolve. A value
-            may be given either as text or as the destination field's own Python
-            type; a backend that assigns into a typed config MUST decode text
-            with the same decoder its ``--key=value`` form uses, so one spec
-            means one run whichever path the backend takes. The lerobot backend
-            reads text through lerobot's own draccus decoder: ``false``/``no``/
-            ``off`` and ``true``/``yes``/``on`` (any case) are booleans, ``0``
-            and ``1`` are not, and text that does not decode to the field's type
-            is refused rather than stored. For example, unfreezing a SmolVLA
-            vision tower takes ``extra={"policy.freeze_vision_encoder": False,
-            "policy.train_expert_only": False}`` - or the same values as
-            ``"false"`` - because both default to ``True`` in that policy's own
-            config.
+        extra: Raw passthrough; keys become backend-native flags or overrides
+            (lerobot ``--key=value``, Cosmos Hydra ``key.path=value``). A value
+            may be given as text or as the destination field's own Python type,
+            and a backend that assigns into a typed config MUST decode text
+            with the same decoder its ``--key=value`` form uses. LeRobot uses
+            draccus: ``false``/``no``/``off`` and ``true``/``yes``/``on`` are
+            booleans in any case, ``0`` and ``1`` are not, and text that does
+            not decode to the field's type is refused.
     """
 
     # --- universal ---
@@ -251,29 +169,26 @@ class Trainer(ABC):
     Lifecycle: :meth:`validate` (pure preflight) -> :meth:`prepare` (optional
     one-time setup) -> :meth:`train` (run + collect verdict) -> :meth:`export`
     (produce a loadable artifact). :meth:`latest_checkpoint` discovers the
-    loadable artifact a run produced; :meth:`status` is an optional best-effort
-    verdict for backends that can poll a still-running job.
+    artifact a run produced; :meth:`status` is an optional best-effort verdict
+    for a still-running job.
 
-    Concrete trainers come in two shapes, and neither reimplements training. A
-    **local** trainer is a thin adapter that **imports the backend package and
-    calls its own training function in-process** (LeRobot ``train(cfg)``, GR00T
-    ``experiment.run(config)``, Cosmos ``train.launch(config, args)``) - it does
-    NOT shell out to a subprocess, and multi-GPU is driven via torch's
-    programmatic ``elastic_launch`` (the engine behind ``torchrun``), still
-    in-process. A **transport** trainer imports no training library at all: it
-    submits the same :class:`TrainSpec` to a managed runner whose image packages
-    a local trainer (``sagemaker`` -> one SageMaker training job). Only the
-    local shape necessarily finishes inside the :meth:`train` call; see that
-    method for the return contract that follows from this.
+    Concrete trainers come in two shapes and neither reimplements training. A
+    **local** trainer imports the backend package and calls its own training
+    function in-process (LeRobot ``train(cfg)``, GR00T
+    ``experiment.run(config)``, Cosmos ``train.launch(config, args)``), with
+    multi-GPU driven by torch's programmatic ``elastic_launch``. A
+    **transport** trainer imports no training library: it submits the same
+    :class:`TrainSpec` to a managed runner whose image packages a local trainer.
+    Only the local shape necessarily finishes inside the :meth:`train` call.
 
-    The field-scoped shared domains below (:meth:`_seed_problems` and its
-    siblings) are each obliged of "a backend that reads the field", and a
-    backend reads a field by any means: naming it (``spec.seed``) or forwarding
-    it through a table (``getattr(spec, field)`` over a tuple of field names,
-    which is how a provider that passes a spec on serializes every field
-    without naming any). The second form is a read for this rule exactly as the
-    first is - what obliges the gate is that the value reaches the run, not the
-    syntax that fetched it.
+    The ``_*_problems`` methods are the shared field-scoped preflights. Each
+    forwards to the matching gate in
+    :mod:`strands_robots.training._validate` (imported inside the method to
+    keep the ``base -> _validate`` import one-way at runtime) and each is
+    obliged only of a backend that *reads* the field - by naming it
+    (``spec.seed``) or by forwarding it through a table
+    (``getattr(spec, field)``). What obliges the gate is that the value reaches
+    the run, not the syntax that fetched it.
     """
 
     @property
@@ -283,906 +198,246 @@ class Trainer(ABC):
 
     @abstractmethod
     def validate(self, spec: TrainSpec) -> list[str]:
-        """Pure, side-effect-free preflight.
+        """Return the problems that make *spec* unlaunchable; empty when it is.
 
-        Return a list of human-readable problems; an empty list means the spec
-        is launchable. Implementations SHOULD check: dataset_root has
-        ``meta/info.json``; :attr:`TrainSpec.method` is supported and not a
-        contradictory combination (``lora`` + ``expert_only``); any
-        backend-required input is present (e.g. a DCP base for Cosmos); and
-        rough hardware feasibility against :attr:`hardware_floor`.
-
-        MUST NOT touch the filesystem beyond read-only stat / config reads,
-        spawn processes, or allocate GPUs - it powers a ``plan`` advisor that
-        runs *before* anything expensive starts.
+        A pure preflight: it MUST NOT touch the filesystem beyond read-only
+        stat / config reads, spawn processes, or allocate GPUs, because it
+        powers a ``plan`` advisor that runs before anything expensive starts.
+        Implementations SHOULD check that ``dataset_root`` has
+        ``meta/info.json``, that :attr:`TrainSpec.method` is supported and not
+        a contradictory combination, that any backend-required input is
+        present, and rough feasibility against :meth:`hardware_floor`.
         """
 
     def _security_problems(self, spec: TrainSpec) -> list[str]:
-        """Input-safety preflight shared by every backend (defense-in-depth).
+        """Preflight every agent-supplied value for input safety.
 
-        Returns problems for any agent-supplied value that would be unsafe to
-        feed into the backend's config (path traversal / protected directories,
-        a leading ``-`` that a backend's argv-parity helper would read as a
-        flag, or an ``extra`` key that would set an arbitrary config attribute /
-        Hydra override). Concrete :meth:`validate` implementations MUST call
-        this first so untrusted ``TrainSpec`` input is checked before any config
-        is built. (Training itself is in-process now - no subprocess argv - but
-        the ``extra`` escape hatch and path fields still reach backend internals,
-        so the gate remains.)
-
-        Imported lazily here (not at module top) to break the
-        ``base ↔ _validate`` cyclic import that CodeQL flagged: ``_validate``
-        references :class:`TrainSpec` only under ``TYPE_CHECKING``, so the
-        runtime cycle is closed by deferring this import until first call.
+        Path traversal and protected directories, a leading ``-`` a backend's
+        argv-parity helper would read as a flag, and an ``extra`` key that
+        would set an arbitrary config attribute or Hydra override. Concrete
+        :meth:`validate` implementations MUST call this first, before any
+        config is built.
         """
         from strands_robots.training._validate import validate_train_inputs
 
         return validate_train_inputs(spec)
 
     def _run_size_problems(self, spec: TrainSpec) -> list[str]:
-        """Run-size preflight shared by every backend that consumes it.
-
-        Returns problems for :attr:`TrainSpec.steps` /
-        :attr:`TrainSpec.global_batch_size` - the two factors of how much
-        training the spec asks for - against the one shared positive-count
-        domain. A :meth:`validate` implementation that reads either field MUST
-        call this instead of comparing the value itself: a local ``<= 0`` test
-        admits a ``bool`` as a silent run of one step, admits a fractional or
-        non-finite value that then raises inside the backend's ``range()``
-        after the dataset and model are already loaded, and raises out of the
-        comparison itself for a non-numeric value - from a method documented to
-        *return* problems.
-
-        A backend that drives training from other fields (the RL trainers, on
-        ``total_timesteps`` / ``batch_size``) MUST NOT call this: per
-        :class:`TrainSpec`, a backend ignores the fields it does not support,
-        so reporting on one it never reads would be a false rejection.
-
-        Imported lazily for the same reason as :meth:`_security_problems` - to
-        keep the ``base -> _validate`` import one-way at runtime.
-        """
+        """Preflight ``steps`` and ``global_batch_size``, each a positive ``int``."""
         from strands_robots.training._validate import run_size_problems
 
         return run_size_problems(spec, context=self.provider_name)
 
     def _rl_run_size_problems(self, spec: TrainSpec) -> list[str]:
-        """Run-size preflight shared by every RL backend, the peer of the above.
+        """Preflight ``total_timesteps`` and ``rollout_steps``, each a positive ``int``.
 
-        Returns problems for :attr:`RLTrainSpec.total_timesteps` /
-        :attr:`RLTrainSpec.rollout_steps` - the two caller-supplied factors of
-        the training-loop bound every RL backend derives,
-        ``max(1, total_timesteps // (rollout_steps * num_envs))`` iterated as
-        ``range(...)`` - against the same shared positive-count domain
-        :meth:`_run_size_problems` uses for the supervised pair.
-
-        This exists as a second gate rather than as part of that one because the
-        two field sets are disjoint: per :class:`TrainSpec` a backend ignores the
-        fields it does not support, so an RL trainer must not be refused for a
-        ``steps`` it never reads, and a supervised backend must not be refused
-        for a ``total_timesteps`` it never reads. The *domain* is shared; only the
-        fields differ.
-
-        A :meth:`validate` implementation that sizes its loop from either field
-        MUST call this instead of comparing the value itself. The local ``<= 0``
-        test is weaker here than for the supervised pair, because the bound is
-        derived: the ``max(1, ...)`` clamp reads ``True``, a fraction below one
-        iteration, ``nan`` and ``inf`` as a **single iteration** and the run then
-        reports success and writes a checkpoint, so the run the caller asked for
-        is simply not the one that happened. See
-        :func:`~strands_robots.training._validate.rl_run_size_problems` for the
-        measured table.
-
-        Imported lazily for the same reason as :meth:`_security_problems` - to
-        keep the ``base -> _validate`` import one-way at runtime.
+        ``num_envs`` is graded by the caller that reads it: which counts are
+        usable differs per backend, while being a count at all does not.
         """
         from strands_robots.training._validate import rl_run_size_problems
 
         return rl_run_size_problems(spec, context=self.provider_name)
 
     def _rl_replay_problems(self, spec: TrainSpec) -> list[str]:
-        """Replay-loop count preflight for the off-policy (SAC / TD3) backends.
+        """Preflight ``buffer_size``, ``batch_size`` and ``gradient_steps``.
 
-        Returns problems for :attr:`RLTrainSpec.buffer_size` /
-        :attr:`RLTrainSpec.batch_size` / :attr:`RLTrainSpec.gradient_steps` - the
-        three caller-supplied counts of an off-policy replay loop (the buffer
-        capacity, the transitions sampled per gradient step, and the updates per
-        iteration) - against the same shared positive-count domain the run-size
-        and launch-topology gates use.
-
-        A :meth:`validate` that reads any of the three MUST call this instead of
-        comparing the value itself. Each is consumed directly as a count (a
-        tensor capacity, a sample size, a ``range()`` bound), so a local
-        ``<= 0`` test is weaker: it reads ``True`` as a degenerate one-slot
-        buffer / batch of one (a run that learns nothing and reports success),
-        lets a fraction or non-finite value raise deep inside ``setup`` or the
-        update loop, and raises ``TypeError`` itself on a string or ``None``. See
-        :func:`~strands_robots.training._validate.rl_replay_problems` for the
-        measured table.
-
-        Only the off-policy backends (FastSAC and FastTD3) read these fields;
-        PPO sizes its minibatches from ``num_mini_batches`` and never reads
-        them, so it must not report on them.
-
-        Imported lazily for the same reason as :meth:`_security_problems` - to
-        keep the ``base -> _validate`` import one-way at runtime.
+        Each a positive ``int``. A zero ``gradient_steps`` takes zero gradient
+        updates for the whole run and still reports success with a checkpoint.
         """
         from strands_robots.training._validate import rl_replay_problems
 
         return rl_replay_problems(spec, context=self.provider_name)
 
     def _learning_rate_problems(self, spec: TrainSpec) -> list[str]:
-        """Learning-rate preflight shared by EVERY backend.
-
-        Returns a problem when :attr:`TrainSpec.learning_rate` is supplied and
-        is not a usable positive finite number, against the one shared
-        continuous domain. Unlike :meth:`_run_size_problems` there is no
-        backend that may skip this: the supervised backends assign the value to
-        their config's optimizer field and the RL trainers pass it to
-        ``torch.optim.Adam``, so every concrete :meth:`validate` MUST call it.
-
-        Checking it here rather than leaving it to the optimizer matters
-        because the silent ends of the domain never reach an exception: ``0``
-        does the full run and updates nothing, and ``inf`` writes a checkpoint
-        of ``NaN`` - both under a successful result. The values the optimizer
-        *does* reject only reach it after the dataset and model are loaded,
-        which is what this preflight exists to precede.
-
-        Imported lazily for the same reason as :meth:`_security_problems` - to
-        keep the ``base -> _validate`` import one-way at runtime.
-        """
+        """Preflight ``learning_rate`` when supplied: a positive finite number."""
         from strands_robots.training._validate import learning_rate_problems
 
         return learning_rate_problems(spec, context=self.provider_name)
 
     def _launch_topology_problems(self, spec: TrainSpec) -> list[str]:
-        """Launch-topology preflight shared by every backend that consumes it.
-
-        Returns problems for :attr:`TrainSpec.num_gpus` /
-        :attr:`TrainSpec.num_nodes` - the two process counts a distributed
-        launch is sized from - against the same shared positive-count domain
-        :meth:`_run_size_problems` uses. A :meth:`validate` implementation that
-        reads either field MUST call this instead of comparing the value
-        itself: the ``> 1`` test that selects the multi-process launch path
-        reads ``0``, a negative, ``nan`` and ``True`` as "not more than one" and
-        silently runs on a single process, passes ``2.7`` and ``inf`` through to
-        ``elastic_launch`` (which accepts them), and raises ``TypeError`` for a
-        string or ``None`` - from a method documented to *return* problems.
-
-        A backend that launches from neither field MUST NOT call this: per
-        :class:`TrainSpec`, a backend ignores the fields it does not support, so
-        reporting on one it never reads would be a false rejection. That is why
-        this is a separate gate from :meth:`_learning_rate_problems`, which
-        every backend does call.
-
-        Imported lazily for the same reason as :meth:`_security_problems` - to
-        keep the ``base -> _validate`` import one-way at runtime.
-        """
+        """Preflight ``num_gpus`` and ``num_nodes``, each a positive ``int``."""
         from strands_robots.training._validate import launch_topology_problems
 
         return launch_topology_problems(spec, context=self.provider_name)
 
     def _seed_problems(self, spec: TrainSpec) -> list[str]:
-        """Reproducibility-seed preflight shared by every backend that reads it.
-
-        Returns a problem when :attr:`TrainSpec.seed` is supplied and is not a
-        usable non-negative integer, against the one shared non-negative-count
-        domain. A :meth:`validate` implementation that reads the field MUST call
-        this rather than pass the value straight to its applier: the appliers do
-        not agree about it. ``torch.manual_seed`` takes the value modulo
-        ``2**64``, so a negative seed silently becomes a large positive one and
-        collides with a seed a caller could legitimately have named, while
-        lerobot's ``set_seed`` reseeds Python's ``random`` and only then hands
-        the value to NumPy, which refuses a negative - leaving the process RNG
-        reseeded by a call that failed.
-
-        A backend that does not read the field MUST NOT call this: per
-        :class:`TrainSpec`, a backend ignores the fields it does not support, so
-        reporting on one it never reads would be a false rejection. That is why
-        this is a separate gate from :meth:`_learning_rate_problems`, which
-        every backend does call.
-
-        Imported lazily for the same reason as :meth:`_security_problems` - to
-        keep the ``base -> _validate`` import one-way at runtime.
-        """
+        """Preflight ``seed`` when supplied: a non-negative ``int``."""
         from strands_robots.training._validate import seed_problems
 
         return seed_problems(spec, context=self.provider_name)
 
     def _checkpoint_cadence_problems(self, spec: TrainSpec) -> list[str]:
-        """Checkpoint-cadence preflight shared by every backend that reads it.
-
-        Returns a problem when :attr:`TrainSpec.save_freq` is not a whole number
-        of steps, against the one shared step-cadence domain the
-        ``lerobot_train`` tool holds the same field to. A :meth:`validate`
-        implementation that reads the field MUST call this rather than forward
-        the value: every destination requires a genuine ``int`` and none of them
-        says so. LeRobot in-process hands it straight to lerobot's
-        ``should_save_checkpoint`` (``save_freq > 0 and step % save_freq == 0``),
-        where ``True`` is a modulus of one and checkpoints every step while a
-        fractional or non-finite cadence silently becomes the *disabled* mode
-        and a string raises ``TypeError`` from inside the training loop; the
-        argv, Hydra and hyperparameter routes each fail differently, or not at
-        all, after the run has started. Only the type is graded - a non-positive
-        cadence is the documented "disable periodic saving" mode.
-
-        A backend that does not read the field MUST NOT call this: per
-        :class:`TrainSpec`, a backend ignores the fields it does not support, so
-        reporting on one it never reads would be a false rejection. That is why
-        this is a separate gate from :meth:`_learning_rate_problems`, which
-        every backend does call.
-
-        Imported lazily for the same reason as :meth:`_security_problems` - to
-        keep the ``base -> _validate`` import one-way at runtime.
-        """
+        """Preflight ``save_freq``: a non-negative whole number of steps."""
         from strands_robots.training._validate import checkpoint_cadence_problems
 
         return checkpoint_cadence_problems(spec, context=self.provider_name)
 
     def _rl_checkpoint_interval_problems(self, spec: TrainSpec) -> list[str]:
-        """Checkpoint-cadence preflight for the RL loop, on its own field.
-
-        Returns a problem when :attr:`RLTrainSpec.log_interval` is not a whole
-        number of iterations, against the same shared step-cadence domain
-        :meth:`_checkpoint_cadence_problems` holds ``save_freq`` to. A
-        :meth:`validate` implementation whose loop paces ``save_checkpoint`` on
-        ``it % log_interval`` MUST call this: the field is the RL run's
-        checkpoint cadence, and the modulus judges it no more than lerobot's
-        does. ``nan`` satisfies the truthiness guard and never the modulus, so a
-        run that asked to checkpoint every few iterations silently keeps only
-        its final one and still reports ``status="success"`` - the reading that
-        matters most for RL, where return is non-monotonic and the deployable
-        policy is often an earlier checkpoint. ``True`` is a cadence of one, a
-        fraction is a silently different cadence, and a string raises
-        ``TypeError`` out of the loop after ``setup`` has built the env, the
-        networks and the optimizers. Only the type is graded: ``0`` is the
-        documented "no intermediate checkpoints" mode.
-
-        Scoped like :meth:`_network_width_problems` rather than like
-        :meth:`_gae_lambda_problems`: all three RL backends run the same loop
-        over the same field, so there is no RL backend for which reporting on it
-        would be a false rejection. A supervised backend does not read it and
-        MUST NOT report on it - it has ``save_freq`` for the same question.
-
-        Imported lazily for the same reason as :meth:`_security_problems` - to
-        keep the ``base -> _validate`` import one-way at runtime.
-
-        Args:
-            spec: The spec to preflight.
-
-        Returns:
-            A single problem when the cadence cannot be honored; empty
-            otherwise.
-        """
+        """Preflight ``log_interval``: a non-negative whole number of iterations."""
         from strands_robots.training._validate import rl_checkpoint_interval_problems
 
         return rl_checkpoint_interval_problems(spec, context=self.provider_name)
 
     def _validation_episodes_problems(self, spec: TrainSpec) -> list[str]:
-        """Held-out-validation preflight shared by every backend that reads it.
+        """Preflight ``val_episodes`` when supplied: a positive ``int``.
 
-        Returns a problem when :attr:`TrainSpec.val_episodes` is supplied and is
-        not a usable positive integer, against the same shared positive-count
-        domain :meth:`_run_size_problems` uses. A :meth:`validate`
-        implementation that reads the field MUST call this instead of comparing
-        the value itself, because the count is converted into a real-valued
-        split fraction and the comparison is wrong at both ends: a non-positive
-        value produces no split and no evaluation cadence at all - the run
-        trains on the whole dataset and records no validation loss, with nothing
-        reported - while ``True`` reserves one episode, ``2.7`` reserves three,
-        and ``0.5`` emits an evaluation cadence over a held-out set of zero
-        episodes. A non-numeric value raises out of the comparison from a method
-        documented to *return* problems.
-
-        The dataset-dependent upper bound (``val_episodes`` must leave training
-        data behind) stays with the backend, which is the side that reads
-        ``total_episodes`` from the dataset metadata.
-
-        A backend that does not read the field MUST NOT call this: per
-        :class:`TrainSpec`, a backend ignores the fields it does not support, so
-        reporting on one it never reads would be a false rejection. That is why
-        this is a separate gate from :meth:`_learning_rate_problems`, which
-        every backend does call.
-
-        Imported lazily for the same reason as :meth:`_security_problems` - to
-        keep the ``base -> _validate`` import one-way at runtime.
+        The count becomes a real-valued split fraction whose ceiling lerobot
+        takes, so a backend MUST NOT compare it itself.
         """
         from strands_robots.training._validate import validation_episodes_problems
 
         return validation_episodes_problems(spec, context=self.provider_name)
 
     def _resume_problems(self, spec: TrainSpec) -> list[str]:
-        """Resume-posture preflight shared by every backend that reads it.
-
-        Returns a problem when :attr:`TrainSpec.resume` is not a boolean,
-        against the one shared :func:`~strands_robots.utils.boolean_flag_error`
-        domain. A :meth:`validate` implementation whose backend reads the field
-        - by name or by forwarding it through a table - MUST call this ahead of
-        that read, because the field selects a *posture* and every reader tests
-        it by truthiness: a truthy spelling of off (``"false"``) resumes, and on
-        LeRobot a resume replaces the spec-built config with the checkpoint's,
-        so the run size and cadence the caller set never reach the run.
-
-        A backend that does not read the field MUST NOT call this, for the same
-        reason :meth:`_validation_episodes_problems` gives.
-
-        Imported lazily for the same reason as :meth:`_security_problems` - to
-        keep the ``base -> _validate`` import one-way at runtime.
-        """
+        """Preflight ``resume``: a ``bool``."""
         from strands_robots.training._validate import resume_problems
 
         return resume_problems(spec, context=self.provider_name)
 
     def _streaming_problems(self, spec: TrainSpec) -> list[str]:
-        """Streaming-posture preflight shared by every backend that reads it.
+        """Preflight ``streaming``: a ``bool``.
 
-        The peer of :meth:`_resume_problems` for :attr:`TrainSpec.streaming`,
-        kept separate because the two fields have different readers. A backend
-        whose ``validate`` branches on the field itself (LeRobot refuses
-        ``streaming`` beside ``val_episodes``) MUST consult this first and read
-        the field only when it reports nothing, so a misread posture is refused
-        by the flag's own name rather than by the option it selected.
-
-        Imported lazily for the same reason as :meth:`_security_problems` - to
-        keep the ``base -> _validate`` import one-way at runtime.
+        A backend whose ``validate`` branches on the field MUST consult this
+        first and read the field only when it reports nothing, so a misread
+        posture is refused by the flag's own name.
         """
         from strands_robots.training._validate import streaming_problems
 
         return streaming_problems(spec, context=self.provider_name)
 
     def _lora_hyperparameter_problems(self, spec: TrainSpec) -> list[str]:
-        """LoRA adapter preflight shared by every backend that reads it.
+        """Preflight ``lora_r`` and ``lora_alpha``, each a positive ``int`` or ``None``.
 
-        Returns a problem per supplied-and-unusable :attr:`TrainSpec.lora_r` /
-        :attr:`TrainSpec.lora_alpha`, against the same shared positive-count
-        domain :meth:`_run_size_problems` uses. A :meth:`validate`
-        implementation that reads either field MUST call this instead of leaving
-        the values to peft, because peft only judges one of them: it refuses a
-        non-positive ``lora_r`` from inside ``get_peft_model``, after the base
-        model is already loaded, while ``lora_alpha`` is a bare numerator that
-        nothing compares - ``lora_alpha=0`` trains an adapter whose scaling is
-        ``0.0`` and which therefore cannot change the model's output, and a
-        negative value applies the negation of what it learned.
-
-        A backend that does not read the fields MUST NOT call this: per
-        :class:`TrainSpec`, a backend ignores the fields it does not support, so
-        reporting on ones it never reads would be a false rejection. That is why
-        this is a separate gate from :meth:`_learning_rate_problems`, which every
-        backend does call.
-
-        Imported lazily for the same reason as :meth:`_security_problems` - to
-        keep the ``base -> _validate`` import one-way at runtime.
+        peft judges only the rank, and only once the base model is loaded.
         """
         from strands_robots.training._validate import lora_hyperparameter_problems
 
         return lora_hyperparameter_problems(spec, context=self.provider_name)
 
     def _discount_factor_problems(self, spec: TrainSpec) -> list[str]:
-        """Discount-factor preflight shared by every RL backend.
-
-        Returns a problem when :attr:`RLTrainSpec.gamma` is not a real number in
-        the closed interval ``[0, 1]``. A :meth:`validate` implementation that
-        discounts a return with the field MUST call this instead of leaving the
-        value to the arithmetic that consumes it, because that arithmetic never
-        judges it: ``gamma > 1`` makes the discounted return diverge in the
-        rollout horizon and the run still reports success and writes a
-        checkpoint, ``gamma < 0`` alternates the sign of each future reward so
-        the trace stops accumulating return at all, and a non-finite value
-        surfaces only once the update samples the action distribution - as a
-        torch constraint error naming neither the field nor the run, after the
-        env, the networks and a full rollout have been built.
-
-        Both interval endpoints are inside the domain (``gamma=1`` is the
-        undiscounted episodic return, ``gamma=0`` a myopic agent), so the check
-        is a closed interval rather than a positivity test - and it rejects
-        ``bool``, which a bare comparison against the bounds accepts as a silent
-        ``gamma`` of one.
-
-        Every RL backend reads the field, so unlike
-        :meth:`_lora_hyperparameter_problems` there is no backend for which
-        reporting on it would be a false rejection.
-
-        Imported lazily for the same reason as :meth:`_security_problems` - to
-        keep the ``base -> _validate`` import one-way at runtime.
-        """
+        """Preflight ``gamma``: a real in ``[0, 1]``. Every RL backend reads it."""
         from strands_robots.training._validate import discount_factor_problems
 
         return discount_factor_problems(spec, context=self.provider_name)
 
     def _gae_lambda_problems(self, spec: TrainSpec) -> list[str]:
-        """GAE-lambda preflight shared by every backend that estimates a trace.
+        """Preflight ``lam``: a real in ``[0, 1]``, for a backend that estimates a trace.
 
-        Returns a problem when :attr:`RLTrainSpec.lam` is not a real number in
-        the closed interval ``[0, 1]``. A :meth:`validate` implementation that
-        decays an advantage trace with the field MUST call this **in addition
-        to** :meth:`_discount_factor_problems`, because the two fields are one
-        contract: the trace decays by the product ``gamma * lam``, so bounding
-        ``gamma`` alone leaves the divergence that gate exists to refuse
-        reachable through the other factor - a ``gamma`` of ``0.99`` with a
-        ``lam`` of ``1.5`` decays by ``1.485`` and the largest advantage grows
-        without bound in the rollout horizon, under a successful run that writes
-        a checkpoint.
-
-        Both interval endpoints are inside the domain (``lam=1`` is the
-        Monte-Carlo advantage, ``lam=0`` the one-step TD advantage), so the check
-        is a closed interval rather than a positivity test - and it rejects
-        ``bool``, which a bare comparison against the bounds accepts as a silent
-        ``lam`` of one, i.e. a different estimator from the requested one.
-
-        Only the on-policy backend estimates an advantage trace, so unlike
-        :meth:`_discount_factor_problems` a backend that does not read the field
-        MUST NOT call this: per :class:`TrainSpec` a backend ignores the fields
-        it does not support, so reporting on one it never reads would be a false
-        rejection.
-
-        Imported lazily for the same reason as :meth:`_security_problems` - to
-        keep the ``base -> _validate`` import one-way at runtime.
+        The trace decays by the product ``gamma * lam``, so bounding one factor
+        does not bound the trace.
         """
         from strands_robots.training._validate import gae_lambda_problems
 
         return gae_lambda_problems(spec, context=self.provider_name)
 
     def _optimization_epochs_problems(self, spec: TrainSpec) -> list[str]:
-        """Optimization-epoch preflight for a backend with an epoch loop.
+        """Preflight ``num_learning_epochs``: a positive ``int``.
 
-        Returns a problem when :attr:`RLTrainSpec.num_learning_epochs` is not a
-        positive integer. A :meth:`validate` implementation whose update makes
-        ``num_learning_epochs`` passes over each rollout batch MUST call this,
-        because the field is the loop bound of the whole optimizer step: a
-        non-positive value takes no gradient step at all, and the run still
-        collects its rollouts, writes a checkpoint and reports success with
-        losses of ``0.0`` (the update averages through ``max(1, n_updates)``).
-        ``True`` is likewise a silent single epoch, and a non-integer raises a
-        bare ``TypeError`` out of ``range()`` after the environment and the
-        networks have been built.
-
-        Only a backend that loops over a rollout batch reads the field - an
-        off-policy backend optimizes per gradient step from a replay buffer - so
-        like :meth:`_gae_lambda_problems`, and unlike
-        :meth:`_discount_factor_problems`, a backend that does not read it MUST
-        NOT call this: per :class:`TrainSpec` a backend ignores the fields it
-        does not support, so reporting on one it never reads would be a false
-        rejection.
-
-        Imported lazily for the same reason as :meth:`_security_problems` - to
-        keep the ``base -> _validate`` import one-way at runtime.
+        It is the ``range()`` bound enclosing every ``optimizer.step()``, so a
+        non-positive value takes no gradient step while the run reports success
+        and writes an untrained checkpoint.
         """
         from strands_robots.training._validate import optimization_epochs_problems
 
         return optimization_epochs_problems(spec, context=self.provider_name)
 
     def _temperature_learning_rate_problems(self, spec: TrainSpec) -> list[str]:
-        """Entropy-temperature learning-rate preflight, for backends that tune one.
-
-        Returns a problem when a spec asking for an automatically tuned
-        temperature carries an :attr:`RLTrainSpec.alpha_lr` that is not a positive
-        finite number. A :meth:`validate` implementation that builds a temperature
-        optimizer MUST call this **in addition to**
-        :meth:`_learning_rate_problems`: the two fields are separate learning
-        rates on separate optimizers, so guarding the one that drives the actor
-        and critics leaves the temperature's own rate unchecked. ``alpha_lr=0``
-        freezes the temperature at ``init_alpha`` for the whole run - the
-        requested automatic tuning silently does not happen - and ``alpha_lr=inf``
-        writes a checkpoint holding non-finite parameters, both under a
-        successful result.
-
-        Only the SAC backend tunes a temperature, so unlike
-        :meth:`_learning_rate_problems` a backend that does not read the field
-        MUST NOT call this: per :class:`TrainSpec` a backend ignores the fields it
-        does not support, so reporting on one it never reads would be a false
-        rejection. For the same reason the check is inert unless the spec's
-        ``autotune_alpha`` is set, since that is the only branch that constructs a
-        temperature optimizer.
-
-        Imported lazily for the same reason as :meth:`_security_problems` - to
-        keep the ``base -> _validate`` import one-way at runtime.
-        """
+        """Preflight ``alpha_lr``: a positive finite number, when a temperature is tuned."""
         from strands_robots.training._validate import temperature_learning_rate_problems
 
         return temperature_learning_rate_problems(spec, context=self.provider_name)
 
     def _initial_temperature_problems(self, spec: TrainSpec) -> list[str]:
-        """Entropy-temperature starting-value preflight, for backends that hold one.
+        """Preflight ``init_alpha``: a positive finite number.
 
-        Returns a problem when :attr:`RLTrainSpec.init_alpha` is not a positive
-        finite number. FastSAC stores the temperature's logarithm, so the field
-        reaches ``torch.log`` and only a positive finite value has a finite one.
-        A :meth:`validate` implementation that builds a temperature MUST call
-        this **in addition to** :meth:`_temperature_learning_rate_problems`: the
-        two fields are the temperature's starting value and the rate that moves
-        it, so guarding the rate leaves the value it starts from unchecked -
-        which that gate's own reasoning depends on, since it refuses
-        ``alpha_lr=0`` on the grounds that "the temperature stays at
-        ``init_alpha`` for the whole run".
-
-        ``init_alpha=0`` makes ``log(0) == -inf`` and the temperature exactly
-        zero, so the entropy term is absent from both losses and automatic
-        tuning cannot lift it back - no finite update moves an infinity - while
-        the run reports success and checkpoints the non-finite value. A negative
-        value, ``nan`` or ``inf`` poisons the actor loss instead and raises from
-        inside ``torch.distributions.Normal``, naming that distribution's
-        parameter rather than the field.
-
-        Unlike :meth:`_temperature_learning_rate_problems` this is not scoped to
-        ``autotune_alpha``: that gate guards an optimizer only the tuning branch
-        constructs, while ``init_alpha`` is read on both branches, and with
-        tuning off it is the temperature for the entire run.
-
-        Only a backend that holds an entropy temperature may call this: like
-        :meth:`_gae_lambda_problems`, and unlike :meth:`_learning_rate_problems`,
-        a backend that does not read the field MUST NOT report on it, because
-        per :class:`TrainSpec` a backend ignores the fields it does not support.
-
-        Imported lazily for the same reason as :meth:`_security_problems` - to
-        keep the ``base -> _validate`` import one-way at runtime.
-
-        Args:
-            spec: The spec to preflight.
-
-        Returns:
-            A single-element list when ``init_alpha`` has no finite logarithm;
-            empty when it is usable.
+        The temperature is stored as its logarithm, so a non-positive value has
+        none. Not scoped to ``autotune_alpha`` - the coercion is unconditional.
         """
         from strands_robots.training._validate import initial_temperature_problems
 
         return initial_temperature_problems(spec, context=self.provider_name)
 
     def _target_entropy_problems(self, spec: TrainSpec) -> list[str]:
-        """Target-entropy preflight, for backends that tune a temperature.
+        """Preflight ``target_entropy``: a finite real of either sign, or ``None``.
 
-        Returns a problem when :attr:`RLTrainSpec.target_entropy` is neither the
-        ``None`` sentinel nor a finite real of either sign. It is the third field
-        of FastSAC's temperature block, and a backend that builds that block MUST
-        call this **alongside** :meth:`_initial_temperature_problems` and
-        :meth:`_temperature_learning_rate_problems`: those two guard the
-        temperature's starting value and the rate that moves it, and this one the
-        constant it is moved *toward*, so guarding two of the three leaves the
-        third to the arithmetic that spends it.
-
-        The domain is signed, which is why it is
-        :func:`~strands_robots.utils.finite_number_error` rather than the
-        positive-finite domain its two neighbours read: the field defaults to
-        ``-num_actions``, so every reading of it is a negative entropy in nats and
-        no endpoint is decidable. ``target_entropy=True`` is therefore not merely
-        a flag read as a number but a silent sign flip - a target of ``+1.0`` -
-        and a run that took it reported success while checkpointing a different
-        temperature. ``nan`` poisons ``alpha``, which scales the entropy term of
-        both the critic target and the actor loss, and the next rollout raises
-        from inside ``torch.distributions.Normal`` about ``nan`` policy means; a
-        list or a dict raises ``TypeError`` out of the ``float()`` coercion in
-        ``setup``.
-
-        ``None`` is exempt rather than refused: unlike ``init_alpha`` and
-        ``alpha_lr`` this field is annotated ``float | None``, and ``None`` is the
-        documented request for the ``-num_actions`` heuristic.
-
-        Like :meth:`_initial_temperature_problems` this is not scoped to
-        ``autotune_alpha``: the coercion in ``setup`` is unconditional, so a
-        non-real value raises on either branch.
-
-        Only a backend that optimizes a temperature against a target entropy may
-        call this: like :meth:`_gae_lambda_problems`, and unlike
-        :meth:`_learning_rate_problems`, a backend that does not read the field
-        MUST NOT report on it, because per :class:`TrainSpec` a backend ignores
-        the fields it does not support.
-
-        Imported lazily for the same reason as :meth:`_security_problems` - to
-        keep the ``base -> _validate`` import one-way at runtime.
-
-        Args:
-            spec: The spec to preflight.
-
-        Returns:
-            A single-element list when ``target_entropy`` cannot be honored;
-            empty when it can.
+        The domain is signed because the field defaults to ``-num_actions``, so
+        no endpoint is decidable and ``True`` is a sign flip rather than merely
+        a flag read as a number. ``None`` requests that heuristic default. A
+        backend that builds FastSAC's temperature block MUST call this
+        alongside :meth:`_initial_temperature_problems` and
+        :meth:`_temperature_learning_rate_problems`: those guard the starting
+        value and the rate that moves it, this one the constant it moves
+        toward.
         """
         from strands_robots.training._validate import target_entropy_problems
 
         return target_entropy_problems(spec, context=self.provider_name)
 
     def _polyak_coefficient_problems(self, spec: TrainSpec) -> list[str]:
-        """Polyak-coefficient preflight, for a backend that keeps a target network.
+        """Preflight ``tau``: a real in ``(0, 1]``.
 
-        Returns a problem when :attr:`RLTrainSpec.tau` is not a real number in
-        ``(0, 1]``. It is the rate at which a target network tracks its online
-        network, spent in one expression per mirrored critic pair,
-        ``tp.mul_(1.0 - spec.tau).add_(spec.tau * p)``, so it decides whether a
-        separate target network exists at all rather than merely how fast it
-        moves.
-
-        The interval is the one the two on-policy interval gates cite as their
-        precedent - :meth:`_discount_factor_problems` and
-        :meth:`_gae_lambda_problems` both generalize "``tau`` must be in
-        ``(0, 1]``" - and it is half-open where theirs is closed because zero is
-        a degenerate spelling here: it freezes the target parameters at their
-        initialization for the whole run. The upper endpoint stays inside, being
-        the deliberate hard update ``tp = p``.
-
-        The two backends each carried a bare local interval comparison against
-        those bounds instead, which admitted ``True`` as a silent ``tau`` of one -
-        a target network that is a copy of the online network, measured as an
-        exactly zero online-to-target gap in the exported checkpoint of a run
-        that reported success - and raised ``TypeError`` out of the comparison
-        itself on a numeric string, ``None`` or a list, from a :meth:`validate`
-        documented to *return* its problems.
-
-        Only a backend that maintains a target network may call this: like
-        :meth:`_gae_lambda_problems`, and unlike :meth:`_learning_rate_problems`,
-        a backend that does not read the field MUST NOT report on it, because
-        per :class:`TrainSpec` a backend ignores the fields it does not support.
-        PPO has no target network and never reads ``tau``.
-
-        Imported lazily for the same reason as :meth:`_security_problems` - to
-        keep the ``base -> _validate`` import one-way at runtime.
-
-        Args:
-            spec: The spec to preflight.
-
-        Returns:
-            A single-element list when ``tau`` cannot be honored; empty when it
-            can.
+        A zero coefficient never moves the target networks, so the TD target is
+        the untrained initialisation for the whole run.
         """
         from strands_robots.training._validate import polyak_coefficient_problems
 
         return polyak_coefficient_problems(spec, context=self.provider_name)
 
     def _spec_device_problems(self, spec: TrainSpec) -> list[str]:
-        """Device preflight for a backend that places its tensors from the spec.
-
-        Returns a problem when :attr:`RLTrainSpec.device` is not a device string
-        torch can parse. Distinct from
-        :meth:`~strands_robots.training.lerobot.LerobotTrainer._device_problems`,
-        which grades that trainer's ``device`` *constructor* knob: this one grades
-        the field on the spec, which is where the from-scratch RL backends carry
-        it. Both consult one domain,
-        :func:`~strands_robots.utils.torch_device_error`.
-
-        Imported lazily for the same reason as :meth:`_security_problems` - to
-        keep the ``base -> _validate`` import one-way at runtime.
-
-        Args:
-            spec: The spec to preflight.
-
-        Returns:
-            A single-element list when ``device`` cannot be honored; empty when
-            it can or when it is unstated.
-        """
+        """Preflight ``device``: one torch can place tensors on, when stated."""
         from strands_robots.training._validate import torch_device_problems
 
         return torch_device_problems(spec, context=self.provider_name)
 
     def _gradient_clip_problems(self, spec: TrainSpec) -> list[str]:
-        """Gradient-clip preflight for a backend that clips before it steps.
-
-        Returns a problem when :attr:`RLTrainSpec.max_grad_norm` is not a
-        positive real number. Positive infinity is inside the domain: it is the
-        field's only spelling of "do not clip", and ``clip_grad_norm_`` honors
-        it by leaving every gradient untouched.
-
-        Zero and negative values are not degenerate spellings of that, which is
-        why this is a positivity test rather than a non-negative one. Zero
-        scales every gradient to zero, so the optimizer steps with no
-        information and the run writes a checkpoint bit-identical to a
-        never-trained one; a negative bound negates the scaling ratio, so the
-        update becomes gradient *ascent* on the loss. Both report success.
-
-        Only a backend that clips may call this: like
-        :meth:`_gae_lambda_problems`, and unlike
-        :meth:`_learning_rate_problems`, a backend that does not read the field
-        MUST NOT report on it, because per :class:`TrainSpec` a backend ignores
-        the fields it does not support.
-
-        Imported lazily for the same reason as :meth:`_security_problems` - to
-        keep the module import graph one-way.
-
-        Args:
-            spec: The spec to preflight.
-
-        Returns:
-            A single-element list when the field cannot be honored; empty
-            otherwise.
-        """
+        """Preflight ``max_grad_norm``: a positive real, ``inf`` meaning do not clip."""
         from strands_robots.training._validate import gradient_clip_problems
 
         return gradient_clip_problems(spec, context=self.provider_name)
 
     def _loss_weight_problems(self, spec: TrainSpec) -> list[str]:
-        """Loss-weight preflight for a backend that composes a weighted objective.
+        """Preflight ``value_loss_coef`` and ``entropy_coef``, each a finite real.
 
-        Returns a problem per weight when :attr:`RLTrainSpec.value_loss_coef` or
-        :attr:`RLTrainSpec.entropy_coef` is not a finite real number. Both are
-        multiplied into the loss the update descends, and the multiplication
-        judges nothing: a ``nan`` weight makes the loss ``nan``, the optimizer
-        writes ``nan`` into every parameter, and the next rollout raises from
-        inside ``torch`` naming neither field nor value - after the env, the
-        networks and a full rollout have been built.
-
-        The floor is deliberately *not* tested. Zero and negative are inside the
-        domain for both: ``entropy_coef`` ships defaulting to ``0.0``, a negative
-        entropy weight is a determinism penalty, and ``value_loss_coef=0`` stops
-        training the critic. That is what distinguishes this from
-        :meth:`_gradient_clip_problems`, whose endpoint is settled by
-        ``clip_grad_norm_`` and which therefore tests positivity. A ``bool`` is
-        refused here, because it reads as a flag and lands as a coefficient of
-        one - turning the entropy bonus on at full weight where the field's
-        default is off.
-
-        Only a backend that composes this objective may call this: like
-        :meth:`_gradient_clip_problems`, and unlike
-        :meth:`_learning_rate_problems`, a backend that does not read the fields
-        MUST NOT report on them, because per :class:`TrainSpec` a backend ignores
-        the fields it does not support.
-
-        Imported lazily for the same reason as :meth:`_security_problems` - to
-        keep the module import graph one-way.
-
-        Args:
-            spec: The spec to preflight.
-
-        Returns:
-            One problem per weight that cannot be honored; empty when both can.
+        Zero and negative are real configurations for both, so only the domain
+        is bounded, not the floor.
         """
         from strands_robots.training._validate import loss_weight_problems
 
         return loss_weight_problems(spec, context=self.provider_name)
 
     def _clip_range_problems(self, spec: TrainSpec) -> list[str]:
-        """Trust-region preflight for a backend that clips a policy ratio.
+        """Preflight ``clip_param``: a positive real, ``inf`` meaning do not clip.
 
-        Returns a problem when :attr:`RLTrainSpec.clip_param` is not a positive
-        real number. It is the half-width of the trust region the on-policy
-        surrogate is clipped to, read twice per mini-batch - once for the policy
-        ratio and once for the value loss - and ``torch.clamp`` judges it not at
-        all, so every unusable value below produced a finite, successful,
-        deployable run whose objective was not the configured one. A ``nan``
-        half-width is the sharpest: both clipped terms become ``nan``, the
-        gradient of ``torch.max`` flows to the *unclipped* branch because every
-        comparison against ``nan`` is false, and the resulting checkpoint is
-        bit-identical to an unclipped run while every reported loss is ``nan`` -
-        the trust region silently gone with no signal a caller can act on. A
-        negative half-width inverts the clamp bounds so they return a constant,
-        a ``bool`` is a silent half-width of one, and a string, ``None`` or a
-        list raises ``TypeError`` mid-update.
-
-        Positive infinity is inside the domain: it is the field's only spelling
-        of *do not clip*, and ``clamp(ratio, -inf, inf)`` honors it by returning
-        the ratio unchanged. That is the same endpoint, for the same reason, as
-        the sibling bound :meth:`_gradient_clip_problems`, so the two share one
-        domain helper rather than carrying a copy each.
-
-        Only a backend that clips a policy ratio may call this: like
-        :meth:`_gradient_clip_problems`, and unlike
-        :meth:`_learning_rate_problems`, a backend that does not read the field
-        MUST NOT report on it, because per :class:`TrainSpec` a backend ignores
-        the fields it does not support.
-
-        Imported lazily for the same reason as :meth:`_security_problems` - to
-        keep the module import graph one-way.
-
-        Args:
-            spec: The spec to preflight.
-
-        Returns:
-            A single-element list when ``clip_param`` cannot be honored; empty
-            otherwise.
+        It is the half-width of the trust region and also clips the value loss.
         """
         from strands_robots.training._validate import clip_range_problems
 
         return clip_range_problems(spec, context=self.provider_name)
 
     def _policy_delay_problems(self, spec: TrainSpec) -> list[str]:
-        """Policy-delay preflight for a backend that delays its actor updates.
+        """Preflight ``policy_delay``: a positive ``int``.
 
-        Returns a problem when :attr:`RLTrainSpec.policy_delay` is not a
-        positive integer. A :meth:`validate` implementation whose update gates
-        the actor / target step on ``update_count % policy_delay == 0`` MUST
-        call this, because the modulus judges nothing and its silent reading is
-        the worst one: a value the test can never satisfy (``nan``, since
-        ``n % nan`` is ``nan`` and compares unequal to everything) trains the
-        critics for the whole run while the deployable actor never takes a
-        gradient step - the run reports success and checkpoints an untrained
-        policy. ``True`` is a silent delay of one, a fraction a silently
-        different cadence, ``0`` a ``ZeroDivisionError`` and a string a
-        ``TypeError`` - each from inside the update loop, after the env, the
-        networks, the optimizers and the replay buffer are built.
-
-        ``1`` is inside the domain: a delay of one is TD3 with the delay
-        disabled, a configuration rather than a defect.
-
-        Only a backend that delays its policy may call this: like
-        :meth:`_gae_lambda_problems`, and unlike
-        :meth:`_learning_rate_problems`, a backend that does not read the field
-        MUST NOT report on it, because per :class:`TrainSpec` a backend ignores
-        the fields it does not support.
-
-        Imported lazily for the same reason as :meth:`_security_problems` - to
-        keep the module import graph one-way.
-
-        Args:
-            spec: The spec to preflight.
-
-        Returns:
-            A single-element list when ``policy_delay`` cannot be honored;
-            empty otherwise.
+        It is the modulus of an ``update_count % policy_delay`` test, so a
+        value that never satisfies it trains the critics while the deployable
+        actor never takes a gradient step.
         """
         from strands_robots.training._validate import policy_delay_problems
 
         return policy_delay_problems(spec, context=self.provider_name)
 
     def _td3_noise_problems(self, spec: TrainSpec) -> list[str]:
-        """Noise-scale preflight for a backend built on a deterministic actor.
+        """Preflight the three TD3 noise scalars, each a positive finite number.
 
-        Returns a problem per unusable :attr:`RLTrainSpec.exploration_noise_std`
-        / :attr:`RLTrainSpec.target_noise_std` /
-        :attr:`RLTrainSpec.target_noise_clip` - the three scalars of TD3's two
-        noise mechanisms: the exploration noise that is a deterministic
-        policy's only exploration once the random warmup ends, and the target
-        policy smoothing that keeps the critic from exploiting its own sharp
-        errors. A :meth:`validate` implementation that reads any of the three
-        MUST call this, because the multiplications that consume them judge
-        nothing: zero silently removes the mechanism (a collection that never
-        explores; plain clipped double-Q reported as the smoothed algorithm), a
-        negative scale is silently the identical distribution (Gaussian noise
-        is symmetric) while a negative clip inverts the clamp into a constant
-        bias, and a non-finite value poisons the actions or the TD target under
-        a run that keeps stepping. Positive infinity has no "disable" reading
-        here, unlike the clip bounds of :meth:`_gradient_clip_problems` - an
-        infinite std is a coin-flip between the action bounds, not a large
-        noise - so the domain is the plain positive-finite one.
-
-        Only a backend that explores and smooths this way may call this: like
-        :meth:`_gae_lambda_problems`, and unlike
-        :meth:`_learning_rate_problems`, a backend that does not read the
-        fields MUST NOT report on them, because per :class:`TrainSpec` a
-        backend ignores the fields it does not support.
-
-        Imported lazily for the same reason as :meth:`_security_problems` - to
-        keep the module import graph one-way.
-
-        Args:
-            spec: The spec to preflight.
-
-        Returns:
-            One problem per noise scalar that cannot be honored; empty when all
-            three can.
+        ``exploration_noise_std``, ``target_noise_std`` and
+        ``target_noise_clip``. Gaussian noise is symmetric, so a negative scale
+        is the identical distribution and zero removes the mechanism.
         """
         from strands_robots.training._validate import td3_noise_problems
 
         return td3_noise_problems(spec, context=self.provider_name)
 
     def _network_width_problems(self, spec: TrainSpec) -> list[str]:
-        """Hidden-layer-width preflight for a from-scratch RL backend.
-
-        Returns a problem per unusable width in
-        :attr:`RLTrainSpec.hidden_dims`, named by index. A :meth:`validate`
-        implementation that builds its networks from the field MUST call this,
-        because the loop that expands it judges nothing and neither does
-        ``nn.Linear``: a width of zero is a legal layer whose activation is
-        empty, so the layer after it emits its bias alone and the network's
-        output stops depending on the observation at all. The run still
-        collects, still trains its critics against that constant, still returns
-        ``status="success"``, and still exports a deployable checkpoint - one
-        whose actor commands a single fixed action in every state. The empty
-        sequence is a genuine linear policy and stays accepted, so the domain
-        is per element rather than on the length.
-
-        Scoped like :meth:`_learning_rate_problems` rather than like
-        :meth:`_gae_lambda_problems`: every from-scratch RL backend builds its
-        actor and critics from this field, so there is no RL backend for which
-        reporting on it would be a false rejection. A supervised backend, which
-        fine-tunes a pretrained policy whose architecture comes from the
-        checkpoint rather than from the spec, does not read it and must not
-        report on it.
-
-        Imported lazily for the same reason as :meth:`_security_problems` - to
-        keep the module import graph one-way.
-
-        Args:
-            spec: The spec to preflight.
-
-        Returns:
-            One problem per width that cannot be honored, or a single problem
-            when the field is not a sequence of widths; empty when it is usable.
-        """
+        """Preflight ``hidden_dims``: a sequence of positive ``int`` layer widths."""
         from strands_robots.training._validate import network_width_problems
 
         return network_width_problems(spec, context=self.provider_name)
@@ -1190,9 +445,8 @@ class Trainer(ABC):
     def prepare(self, spec: TrainSpec) -> None:
         """Optional one-time setup before :meth:`train`. Default no-op.
 
-        Overridden by backends that need it: Cosmos converts the base
-        checkpoint to PyTorch DCP; GR00T registers a modality-config ``.py``.
-        LeRobot needs nothing here.
+        Cosmos converts the base checkpoint to PyTorch DCP; GR00T registers a
+        modality-config ``.py``; LeRobot needs nothing here.
         """
         return None
 
@@ -1200,39 +454,29 @@ class Trainer(ABC):
     def train(self, spec: TrainSpec) -> TrainResult:
         """Run the backend's training and return the result of that run.
 
-        Responsible for: building the backend's typed config from the
-        :class:`TrainSpec`, wiring resume, selecting single- vs multi-GPU
-        (``elastic_launch`` for ``num_gpus > 1``), invoking the backend's own
-        training function, and surfacing the checkpoint dir + metrics verdict.
+        Builds the backend's typed config from *spec*, wires resume, selects
+        single- vs multi-GPU (``elastic_launch`` for ``num_gpus > 1``), invokes
+        the backend's own training function and surfaces the checkpoint dir plus
+        the metrics verdict. Every implementation MUST call :meth:`validate`
+        first and fail closed.
 
-        A **local** trainer runs the training in-process, so the call is
-        **synchronous**: it blocks until the run finishes (or raises) and
-        returns a terminal ``TrainResult`` (``success``/``error``) with
-        ``metrics`` already populated, and there is no detached job to poll. A
-        **transport** trainer submits a run that outlives this process, so its
-        result MAY be non-terminal: ``running`` with a ``job_id`` that
-        :meth:`status` polls, and no ``checkpoint_dir`` yet.
-
-        A caller therefore has to branch on all three
-        :attr:`TrainResult.status` values rather than read "not ``error``" as
-        finished: a completed-run report rendered for a ``running`` result names
-        an artifact that does not exist yet.
-        Every implementation MUST call :meth:`validate` first and fail closed.
+        A *local* trainer blocks until the run finishes and returns a terminal
+        :class:`TrainResult` with ``metrics`` populated. A *transport* trainer
+        MAY return ``running`` with a ``job_id`` that :meth:`status` polls and
+        no ``checkpoint_dir`` yet, so a caller must branch on all three
+        ``status`` values rather than read "not ``error``" as finished.
         """
 
     def status(self, job_id: str) -> TrainResult:
-        """Optional "RUNNING != learning" verdict for a job still in flight.
+        """Return a "RUNNING != learning" verdict for a job still in flight.
 
-        Two kinds of job reach here: one launched OUT of band (e.g. a long
-        cosmos run started under an external launcher) that a caller wants to
-        poll by id, and one a **transport** :meth:`train` submitted and handed
-        back as ``running`` because it outlives the submitting process. A local
-        trainer produces neither - its ``train`` already returned the full
-        ``metrics`` verdict - so most backends track no job at all and inherit
-        this default, which returns an informative ``error``. Backends that DO
-        override either read the runner's own job API (``sagemaker`` ->
-        ``DescribeTrainingJob``) or parse their training logs for
-        ``latest_step`` / ``latest_loss`` / a ``learning`` boolean.
+        Two kinds of job reach here: one launched out of band that a caller
+        polls by id, and one a *transport* :meth:`train` handed back as
+        ``running`` because it outlives the submitting process. A local trainer
+        produces neither, so
+        most backends inherit this default, which returns an informative
+        ``error``. Backends that override read the runner's own job API
+        (``sagemaker`` -> ``DescribeTrainingJob``) or parse their training logs.
         """
         return TrainResult(
             status="error",
@@ -1244,36 +488,29 @@ class Trainer(ABC):
         )
 
     def export(self, spec: TrainSpec, checkpoint_dir: str) -> str:
-        """Produce a loadable artifact from a checkpoint.
+        """Produce a loadable artifact from *checkpoint_dir* and return its path.
 
-        Default returns ``checkpoint_dir`` unchanged - correct for HF-native
-        backends (LeRobot, GR00T) whose checkpoints are directly loadable by
-        ``create_policy(checkpoint_dir)``. Cosmos overrides to convert DCP ->
-        safetensors. The returned path MUST be something ``create_policy``
-        accepts.
+        The default returns ``checkpoint_dir`` unchanged, which is correct for
+        HF-native backends whose checkpoints ``create_policy`` loads directly;
+        Cosmos overrides to convert DCP -> safetensors. The returned path MUST
+        be something ``create_policy`` accepts.
         """
         return checkpoint_dir
 
     def latest_checkpoint(self, output_dir: str) -> str | None:
         """Return the newest loadable checkpoint directory under ``output_dir``.
 
-        A loadable directory is one that ``export``/``create_policy`` can consume
-        (for HF-native backends, the saved model dir). Returns ``None`` when no
-        checkpoint exists yet, or when the backend writes no discoverable
-        checkpoint tree. Powers the ``export`` action (which needs a checkpoint
-        to convert) and resume logic.
-
-        Default returns ``None`` (no discovery). Backends that write a
-        predictable checkpoint layout override this. Pure / read-only (stat only).
+        ``None`` when no checkpoint exists yet or the backend writes no
+        discoverable tree, which is the default. Read-only (stat only).
         """
         return None
 
     @property
     def hardware_floor(self) -> dict[str, Any]:
-        """Advisory minimum hardware, for the ``plan`` advisor.
+        """Return the advisory minimum hardware for the ``plan`` advisor.
 
-        Keys: ``min_gpus`` (int), ``min_vram_gb`` (int),
-        ``multinode`` (bool). Defaults to a single 24 GB GPU; backends with a
-        higher floor (e.g. Cosmos: 8x80 GB) override.
+        Keys ``min_gpus`` (int), ``min_vram_gb`` (int), ``multinode`` (bool).
+        Defaults to a single 24 GB GPU; a backend with a higher floor (Cosmos:
+        8x80 GB) overrides.
         """
         return {"min_gpus": 1, "min_vram_gb": 24, "multinode": False}

--- a/strands_robots/training/rl/base_algo.py
+++ b/strands_robots/training/rl/base_algo.py
@@ -60,9 +60,13 @@ class RLTrainSpec(TrainSpec):
             policy update (the on-policy batch horizon, holosoma ``num_steps``).
         num_envs: Parallel environments. ``1`` for the MuJoCo single-env
             backend; vectorized backends raise it.
-        actor_obs_keys / critic_obs_keys: Documentation of the observation
-            contract (the env enforces it); kept on the spec so a plan/advisor
-            can echo it without constructing the env.
+        actor_obs_keys: Ordered observation keys the actor sees, as
+            :class:`~strands_robots.training.rl.env.SimEnv` enforces them. Kept
+            on the spec so a plan advisor can echo the observation contract
+            without constructing the env.
+        critic_obs_keys: Privileged simulation-only keys appended to the critic
+            observation (asymmetric actor-critic), defaulting to
+            ``actor_obs_keys``. Same source of truth as that field.
         gamma: Discount factor.
         lam: GAE-lambda.
         clip_param: PPO clip range (also clips the value loss).

--- a/tests/training/test_spec_fields_are_documented.py
+++ b/tests/training/test_spec_fields_are_documented.py
@@ -1,0 +1,103 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Every training spec field is named by the surface that governs it.
+
+An agent populates :class:`~strands_robots.training.base.TrainSpec` (or its RL
+subclass) field by field from the class docstring, and a backend that reads a
+field preflights it through the matching ``Trainer._*_problems`` gate. Both
+surfaces are prose, so both can silently stop naming a field the code still
+reads - an undocumented field is one an agent cannot populate, and a gate that
+does not name the field it grades sends a refused caller to the wrong knob.
+
+This scans the docstrings against the dataclass fields and the ``_validate``
+gates, so a field added without an ``Attributes`` entry, or a gate whose
+docstring no longer names its field, fails here.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+import re
+
+import pytest
+
+from strands_robots.training.base import Trainer, TrainSpec
+from strands_robots.training.rl.base_algo import RLTrainSpec
+
+# ``Attributes:`` entries are indented one level past the section header, so a
+# field entry is the only thing that opens at that depth.
+_ATTRIBUTE = re.compile(r"^\s{4}(\w+):", re.MULTILINE)
+
+# The field(s) each shared preflight grades. A gate MUST name every field it
+# reports on, because the message a caller gets names that field.
+_GATE_FIELDS: dict[str, tuple[str, ...]] = {
+    "_run_size_problems": ("steps", "global_batch_size"),
+    "_rl_run_size_problems": ("total_timesteps", "rollout_steps"),
+    "_rl_replay_problems": ("buffer_size", "batch_size", "gradient_steps"),
+    "_learning_rate_problems": ("learning_rate",),
+    "_launch_topology_problems": ("num_gpus", "num_nodes"),
+    "_seed_problems": ("seed",),
+    "_checkpoint_cadence_problems": ("save_freq",),
+    "_rl_checkpoint_interval_problems": ("log_interval",),
+    "_validation_episodes_problems": ("val_episodes",),
+    "_resume_problems": ("resume",),
+    "_streaming_problems": ("streaming",),
+    "_lora_hyperparameter_problems": ("lora_r", "lora_alpha"),
+    "_discount_factor_problems": ("gamma",),
+    "_gae_lambda_problems": ("lam",),
+    "_optimization_epochs_problems": ("num_learning_epochs",),
+    "_temperature_learning_rate_problems": ("alpha_lr",),
+    "_initial_temperature_problems": ("init_alpha",),
+    "_target_entropy_problems": ("target_entropy",),
+    "_polyak_coefficient_problems": ("tau",),
+    "_spec_device_problems": ("device",),
+    "_gradient_clip_problems": ("max_grad_norm",),
+    "_loss_weight_problems": ("value_loss_coef", "entropy_coef"),
+    "_clip_range_problems": ("clip_param",),
+    "_policy_delay_problems": ("policy_delay",),
+    "_td3_noise_problems": ("exploration_noise_std", "target_noise_std", "target_noise_clip"),
+    "_network_width_problems": ("hidden_dims",),
+}
+
+
+def _documented_attributes(cls: type) -> set[str]:
+    """Field names the class's own ``Attributes:`` section names."""
+    doc = inspect.cleandoc(cls.__doc__ or "")
+    _, _, attributes = doc.partition("Attributes:")
+    return set(_ATTRIBUTE.findall(attributes))
+
+
+@pytest.mark.parametrize("cls", [TrainSpec, RLTrainSpec], ids=lambda c: c.__name__)
+def test_every_spec_field_has_an_attributes_entry(cls: type) -> None:
+    """A field an agent must populate is named where the agent reads."""
+    documented = _documented_attributes(cls)
+    for base in cls.__mro__[1:]:
+        if dataclasses.is_dataclass(base):
+            documented |= _documented_attributes(base)
+    declared = {f.name for f in dataclasses.fields(cls) if not f.name.startswith("_")}
+    assert not declared - documented, (
+        f"{cls.__name__} declares {sorted(declared - documented)} but its docstring "
+        "names no Attributes entry for them, so an agent reading the class cannot "
+        "learn the field exists or what it accepts."
+    )
+
+
+@pytest.mark.parametrize("gate, fields", sorted(_GATE_FIELDS.items()))
+def test_every_gate_names_the_fields_it_grades(gate: str, fields: tuple[str, ...]) -> None:
+    """The refusal names a field, so the docstring must name it too."""
+    doc = inspect.getdoc(getattr(Trainer, gate)) or ""
+    unnamed = [name for name in fields if name not in doc]
+    assert not unnamed, (
+        f"Trainer.{gate} reports on {unnamed} but its docstring never names them, "
+        "so a caller refused by that gate cannot find the knob from the method it came from."
+    )
+
+
+def test_the_gate_table_covers_every_shared_preflight() -> None:
+    """A new gate joins the table instead of shipping unscanned."""
+    graded = {name for name in vars(Trainer) if name.endswith("_problems") and name not in ("_security_problems",)}
+    assert graded == set(_GATE_FIELDS), (
+        f"gates not in the table: {sorted(graded - set(_GATE_FIELDS))}; "
+        f"table entries that are not gates: {sorted(set(_GATE_FIELDS) - graded)}"
+    )


### PR DESCRIPTION
`training/base.py` and `training/_validate.py` were **82%** and **85%** docstring. A reader looking for a field's domain had to read the history of the check to find it: a 158-line module docstring enumerating the shared validation gates as ordinals ("the eleventh", "the twelfth" ...), 27 `Trainer._*_problems` forwarders carrying 20-48 lines of narration over a two-line lazy-import body, and the same `Args:`/`Returns:` block restated 27 times.

Both files now say what each surface accepts. **No code changed.**

![composition of the training core before and after](https://raw.githubusercontent.com/cagataycali/robots/assets/training-prose-diet-34424124715/training_prose_diet.png)

## Census

| | LOC | docstring | comment | **code** |
|---|---|---|---|---|
| `training/_validate.py` before | 2,101 | 1,801 (85%) | 22 | **278** |
| `training/_validate.py` after | **418** | 124 (29%) | 16 | **278** |
| `training/base.py` before | 1,279 | 1,059 (82%) | 4 | **216** |
| `training/base.py` after | **516** | 296 (57%) | 4 | **216** |
| `strands_robots/training/` before | 11,194 | 5,242 (46%) | 784 | **5,168** |
| `strands_robots/training/` after | **8,752** | 2,806 (32%) | 778 | **5,168** |

Diff: **+483 / -2,798**, net **-2,315 LOC**. Code lines are identical in every row. 56 of the 60 members of the two files carried more than 15 docstring lines; now none do (2,477 -> 243 lines over the same members, right-hand panel).

<details><summary>census script, re-runnable</summary>

```python
import ast, sys, pathlib
def census(paths):
    loc = doc = com = 0
    for p in paths:
        lines = p.read_text().splitlines()
        loc += len(lines)
        com += sum(1 for ln in lines if ln.lstrip().startswith("#"))
        for n in ast.walk(ast.parse("\n".join(lines))):
            if isinstance(n, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
                if ast.get_docstring(n, clean=False) is not None:
                    b = n.body[0]
                    doc += b.end_lineno - b.lineno + 1
    return loc, doc, com
for arg in sys.argv[1:]:
    t = pathlib.Path(arg)
    loc, doc, com = census(sorted(t.rglob("*.py")) if t.is_dir() else [t])
    print(f"{arg} loc={loc} doc={doc} ({doc*100//loc}%) comment={com} code={loc-doc-com}")
```
</details>

## What the prose became

| deleted | kept, stated once |
|---|---|
| ordinal narration of the gate list ("the fifteenth, on the *optimization* axis") | the six shared domains - count, cadence, rate, weight, clip bound, unit interval - in `_validate`'s module docstring, each pointing at the builder that enforces it |
| "Imported lazily for the same reason as `_security_problems`" x 26 | the lazy-import rule, once, on `Trainer` |
| "per `TrainSpec` a backend ignores the fields it does not support, so reporting on one it never reads would be a false rejection" x 14 | the reads-the-field scoping rule, once, on `Trainer` |
| measured tables of a past 60-step run inside a gate docstring | the consequence in one clause: "the `range()` bound enclosing every `optimizer.step()`, so a non-positive value takes no gradient step while the run reports success" |
| `Args: spec: The spec to check. context: Caller identity for the message prefix ...` x 27 | the uniform `(spec, *, context) -> list[str]` contract, once |
| `TrainSpec` field history (which backend asked, what a previous version did) | each field's domain: `> 0`, `a non-negative whole number`, `a positive finite number`, `one of {...}` |

Hardware- and library-level facts stay: the `extra` argv interpolation formats, the leading-`-` injection vector, `numbers.Real` having no guaranteed `__float__`, draccus's boolean spellings.

## The public surface is unchanged

`TrainSpec` / `RLTrainSpec` / `TrainResult` fields + types + defaults, every `Trainer` member signature, every `_validate` export signature and the trainer provider list, dumped from both trees and diffed: **708 lines, byte-identical** (`md5 9e2c21ab22c056892df5a3bf59307df7` both sides). Stripping docstrings from each file and diffing the remainder is likewise empty, in both files.

## The new guard, and the two gaps it found

Prose that carries an API contract can silently stop naming a field the code still reads. `tests/training/test_spec_fields_are_documented.py` (29 cells) pins the two things this prose is *for*: every `TrainSpec` / `RLTrainSpec` field has its own `Attributes` entry, and every shared gate names the field it reports on.

On `main` it is **2 failed / 27 passed**: five fields were not individually addressable, because two combined entries covered them - `lora_r / lora_alpha / lora_target_modules:` on `TrainSpec` and `actor_obs_keys / critic_obs_keys:` on `RLTrainSpec`. Both are now one entry per field, and `actor_obs_keys` / `critic_obs_keys` gained a real description (the `SimEnv` observation contract) instead of "documentation of the observation contract".

| mutation | cells |
|---|---|
| the guard is removed | no tests ran |
| `TrainSpec` drops the `streaming` entry | 2 (the subclass inherits the field and the docstring) |
| `_polyak_coefficient_problems` stops naming `tau` | 1 |
| `RLTrainSpec` keeps one combined entry for the two obs-key fields | 1 |
| a new shared gate ships without a table entry | 1 |
| restored | 29 passed |

## Gate

`ruff check` + `ruff format --check` clean over `strands_robots tests` (1,941 files); `mypy` clean (1,940 source files); full `pytest tests/` **52,329 passed / 304 skipped / 0 failed** (30m21s) on `b91f49f4d`, then rebased onto `0c1ce3a3f` with `tests/training` re-run green (5,247 passed).

## Deliberately not in this PR

`utils.py`'s `*_error()` refusal builders stay. They are still what makes two backends refuse a value with the same sentence, and the suite asserts those sentences today - replacing them with a raising `check()` is a behaviour change to every call site plus a test-suite migration, not a prose edit. For the same reason `AGENTS.md` rule 11 is untouched: it describes code that still ships. The other packages' docstring share is unchanged; this PR is the training core.
