### PR TITLE
fix(drivers/g1): rt/lowstate.motor_state is a reading, and the humanoid takes it

### DIFF
--- a/changelog.d/3394-g1-reads-motor-state.md
+++ b/changelog.d/3394-g1-reads-motor-state.md
@@ -1,0 +1,24 @@
+### Fixed: the G1 driver reads `rt/lowstate.motor_state`, so its 29 PD-controlled joints are observed
+
+`G1Driver._on_lowstate` decoded `rt/lowstate` into the IMU and the hardware
+layout id and never touched `motor_state`, the array the robot's 29 joints
+report `q` / `dq` / `tau_est` / `temperature` through. The driver therefore
+published PD targets on `rt/lowcmd` under gains up to `_SDK_KP` while observing
+no joint at all: `send_action` could not check a target against the measured
+pose, and `_ControlLoop._call_policy` handed a policy an observation of
+`{mode_machine, fsm_id, battery, imu}`, so no proprioceptive policy - which is
+every locomotion and whole-body controller - could run on the humanoid.
+
+The twin `Go2Driver._on_lowstate` already read the same array the same way, per
+`GO2_JOINT_INDEX`, and published it on its `sensors` verb, so one SDK family
+answered a joint read on the quadruped and not on the humanoid.
+
+The G1 now reads it over `_G1_JOINT_INDEX` and exposes `joints` on the
+`sensors` verb and in the control loop's policy observation. The decode itself
+moves to `decode_motor_state` in `drivers/base.py` and both drivers call it, so
+the Go2's private copy is deleted rather than duplicated - the same
+one-owner shape the shared telemetry coercers took. The shared decoder keeps
+the family's rule that a default is not a reading: a field the frame does not
+carry reads `None` rather than `0.0`, which on a joint would be a plausible
+pose, and a `motor_state` that is absent, bytes-like, or answers no slot reads
+`None` rather than an empty record.

--- a/strands_robots/drivers/base.py
+++ b/strands_robots/drivers/base.py
@@ -57,7 +57,7 @@ import inspect
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Callable
+    from collections.abc import AsyncGenerator, Callable, Mapping
 
     from strands.types.tools import ToolSpec, ToolUse
 
@@ -516,3 +516,63 @@ def _telemetry_list[T: (float, int)](value: Any, coerce: Callable[[Any], T | Non
             return None
         out.append(coerced)
     return out
+
+
+def decode_motor_state(motors: Any, index: Mapping[str, int]) -> dict[str, dict[str, Any]] | None:
+    """Decode a Unitree ``LowState_.motor_state`` array into per-joint readings.
+
+    Both Unitree drivers subscribe ``rt/lowstate`` and both are handed the same
+    fixed-length ``motor_state`` array, addressed by wire slot: the G1's
+    ``unitree_hg`` layout declares 35 slots of which
+    :data:`~strands_robots.drivers.g1._G1_JOINT_INDEX` names 29, and the Go2's
+    ``unitree_go`` layout is read through
+    :data:`~strands_robots.drivers.go2.GO2_JOINT_INDEX`'s 12. The array is the
+    only proprioception either robot publishes, so a driver that does not read
+    it commands PD targets it cannot check against a measured pose.
+
+    One decoder rather than one per driver, for the reason the vector readers
+    are written once: two copies of a coercion rule drift into disagreeing
+    about which values are readings, and the copy that never gets audited is
+    the one still manufacturing numbers.
+
+    Every field is read through ``getattr(motor, name, None)`` and coerced by
+    :func:`telemetry_float` / :func:`telemetry_int`, so a name a firmware
+    revision drops lands ``None`` in the record rather than a typed default. A
+    zero here is not a harmless placeholder: ``q=0.0`` is a valid reading of a
+    joint at its zero position, so a defaulted read of a renamed field
+    publishes a plausible pose - and on the G1 that pose is what a proprioceptive
+    policy is handed at 500 Hz.
+
+    A slot the array cannot answer is skipped rather than defaulted, so a
+    firmware carrying fewer slots than the index names costs those joints and
+    not the rest of the frame.
+
+    Args:
+        motors: The ``motor_state`` field, already defaulted to ``None`` by the
+            caller's ``getattr``.
+        index: Joint name to wire slot, as the driver's own index table
+            declares it.
+
+    Returns:
+        A mapping of joint name to a ``{"q", "dq", "tau_est", "temperature"}``
+        record for every slot the array answered, or ``None`` when the field is
+        absent, bytes-like (a buffer indexes to integers, which carry none of
+        these names and would read as a full-width record of ``None``), or
+        answered no slot at all. ``None`` says the array was not read, which is
+        a different fact from a robot reporting no joints.
+    """
+    if motors is None or isinstance(motors, _BYTES_LIKE):
+        return None
+    joints: dict[str, dict[str, Any]] = {}
+    for name, slot in index.items():
+        try:
+            motor = motors[slot]
+        except (IndexError, KeyError, TypeError):
+            continue
+        joints[name] = {
+            "q": telemetry_float(getattr(motor, "q", None)),
+            "dq": telemetry_float(getattr(motor, "dq", None)),
+            "tau_est": telemetry_float(getattr(motor, "tau_est", None)),
+            "temperature": telemetry_int(getattr(motor, "temperature", None)),
+        }
+    return joints or None

--- a/strands_robots/drivers/g1.py
+++ b/strands_robots/drivers/g1.py
@@ -50,6 +50,7 @@ from collections.abc import AsyncGenerator, Callable
 from typing import TYPE_CHECKING, Any, cast
 
 from strands_robots.drivers.base import (
+    decode_motor_state,
     telemetry_float,
     telemetry_float_list,
     telemetry_int,
@@ -328,6 +329,7 @@ class G1Driver:
         # tiny critical section around dict swap; readers snapshot.
         self._cache_lock = threading.Lock()
         self._imu: dict[str, Any] | None = None
+        self._joints: dict[str, Any] | None = None
         self._battery: dict[str, Any] | None = None
         self._lidar_state: dict[str, Any] | None = None
         self._lidar_summary: dict[str, Any] | None = None
@@ -469,7 +471,7 @@ class G1Driver:
                             "action": {
                                 "type": "string",
                                 "description": (
-                                    "sensors: return the latest cached IMU/battery/lidar; "
+                                    "sensors: return the latest cached IMU/joints/battery/lidar; "
                                     "status: report connection and FSM; "
                                     "stop: halt any running control loop - it publishes a zero-torque "
                                     "frame on exit - and report whether it joined"
@@ -514,6 +516,7 @@ class G1Driver:
                     {
                         "json": {
                             "imu": self._snapshot("_imu"),
+                            "joints": self._snapshot("_joints"),
                             "battery": self._snapshot("_battery"),
                             "lidar_state": self._snapshot("_lidar_state"),
                             "lidar_summary": self._snapshot("_lidar_summary"),
@@ -1349,7 +1352,7 @@ class G1Driver:
         ]
 
     def _on_lowstate(self, msg: Any) -> None:
-        """Decode ``rt/lowstate`` into :attr:`_imu` and :attr:`_mode_machine`.
+        """Decode ``rt/lowstate`` into :attr:`_imu`, :attr:`_joints` and :attr:`_mode_machine`.
 
         ``LowState_.mode_machine`` is the uint8 hardware-layout id the firmware
         wants echoed on every ``LowCmd_``.  It is **not** the high-level FSM
@@ -1382,6 +1385,17 @@ class G1Driver:
         raising past the dict and abandoning a frame that carried three good
         readings.
 
+        ``motor_state`` is the array this robot's 29 PD-controlled joints
+        report through, and it is read by the same shared decoder the twin
+        driver uses -
+        :func:`~strands_robots.drivers.base.decode_motor_state` over
+        :data:`_G1_JOINT_INDEX` - so both Unitree peers publish one ``joints``
+        shape. It is the only proprioception the G1 publishes: without it
+        :meth:`send_action` writes ``motor_cmd[i].q`` under gains up to
+        :data:`_SDK_KP` against joints the driver cannot observe, and
+        :meth:`_ControlLoop._call_policy` hands a policy an observation with no
+        measured pose in it.
+
         ``mode_machine`` is read the same way, through
         :func:`~strands_robots.drivers.base.telemetry_int`.  It is a reading
         like any other and it is the one this method sends back out: the
@@ -1410,6 +1424,9 @@ class G1Driver:
                     "quaternion": telemetry_float_list(getattr(imu, "quaternion", None)),
                     "t": time.time(),
                 }
+            joints = decode_motor_state(getattr(msg, "motor_state", None), _G1_JOINT_INDEX)
+            if joints is not None:
+                self._joints = joints
             mode_machine = telemetry_int(getattr(msg, "mode_machine", None))
             if mode_machine is not None:
                 self._mode_machine = mode_machine
@@ -2191,6 +2208,7 @@ class _ControlLoop:
             "fsm_id": self._driver._fsm_id,
             "battery": self._driver._battery,
             "imu": self._driver._imu,
+            "joints": self._driver._joints,
         }
         step = getattr(self._policy, "step", None)
         if callable(step):

--- a/strands_robots/drivers/go2.py
+++ b/strands_robots/drivers/go2.py
@@ -74,6 +74,7 @@ from collections.abc import AsyncGenerator, Callable
 from typing import TYPE_CHECKING, Any, cast
 
 from strands_robots.drivers.base import (
+    decode_motor_state,
     telemetry_float,
     telemetry_float_list,
     telemetry_int,
@@ -1272,20 +1273,8 @@ class Go2Driver:
                 "current": telemetry_float(getattr(bms, "current", None)),
                 "cycle": telemetry_int(getattr(bms, "cycle", None)),
             }
-        motors = getattr(msg, "motor_state", None)
-        if motors is not None:
-            joints: dict[str, Any] = {}
-            for name, slot in GO2_JOINT_INDEX.items():
-                try:
-                    motor = motors[slot]
-                except (IndexError, KeyError, TypeError):
-                    continue
-                joints[name] = {
-                    "q": telemetry_float(getattr(motor, "q", None)),
-                    "dq": telemetry_float(getattr(motor, "dq", None)),
-                    "tau_est": telemetry_float(getattr(motor, "tau_est", None)),
-                    "temperature": telemetry_int(getattr(motor, "temperature", None)),
-                }
+        joints = decode_motor_state(getattr(msg, "motor_state", None), GO2_JOINT_INDEX)
+        if joints is not None:
             self._joints = joints
 
     def _on_sportmode(self, msg: Any) -> None:

--- a/tests/drivers/test_g1_control_loop.py
+++ b/tests/drivers/test_g1_control_loop.py
@@ -174,6 +174,7 @@ def _fake_driver(
             "_fsm_id",
             "_battery",
             "_imu",
+            "_joints",
             "_pubs",
             "_check_motion_gates",
             "_loop",
@@ -197,6 +198,7 @@ def _fake_driver(
     driver._motion_switcher_lock = _threading.Lock()
     driver._battery = {"pct": 80.0}
     driver._imu = {"rpy": [0.0, 0.0, 0.0]}
+    driver._joints = {"left_hip_pitch": {"q": 0.0, "dq": 0.0, "tau_est": 0.0, "temperature": 30}}
     driver._pubs = publisher if publisher is not None else _RecordingPublisher()
     driver._check_motion_gates = MagicMock(return_value=gate_result)
     driver._loop = None
@@ -616,6 +618,7 @@ class TestCleanupJoinsLoopBeforeClosingPubs:
         driver._fsm_id = 500
         driver._battery = {"pct": 80.0}
         driver._imu = {"rpy": [0.0, 0.0, 0.0]}
+        driver._joints = {"left_hip_pitch": {"q": 0.0, "dq": 0.0, "tau_est": 0.0, "temperature": 30}}
         return driver
 
     def test_cleanup_stops_running_loop_first(self) -> None:
@@ -690,6 +693,7 @@ def _admission_driver() -> Any:
     driver._fsm_id = 500
     driver._battery = {"pct": 80.0}
     driver._imu = {"rpy": [0.0, 0.0, 0.0]}
+    driver._joints = {"left_hip_pitch": {"q": 0.0, "dq": 0.0, "tau_est": 0.0, "temperature": 30}}
     # Mirrors _fake_driver: a live stamp plus a refresher that keeps stamping
     # is the healthy wire, which is the case an admission test is about.
     driver._refresh_fsm_id = MagicMock(  # type: ignore[method-assign]
@@ -816,6 +820,7 @@ class TestRunPolicyValidatesBudgets:
         driver._fsm_id = 500
         driver._battery = {"pct": 80.0}
         driver._imu = {"rpy": [0.0, 0.0, 0.0]}
+        driver._joints = {"left_hip_pitch": {"q": 0.0, "dq": 0.0, "tau_est": 0.0, "temperature": 30}}
         return driver
 
     def test_duration_nan_refused(self) -> None:

--- a/tests/drivers/test_g1_control_loop_terminal_observability.py
+++ b/tests/drivers/test_g1_control_loop_terminal_observability.py
@@ -164,6 +164,7 @@ def _fake_driver(monkeypatch: pytest.MonkeyPatch, *, fsm_id: int = 500) -> G1Dri
     driver._mode_machine = 4
     driver._battery = {"pct": 90.0}
     driver._imu = {"quaternion": (1.0, 0.0, 0.0, 0.0)}
+    driver._joints = {"left_hip_pitch": {"q": 0.0, "dq": 0.0, "tau_est": 0.0, "temperature": 30}}
     driver._loop = None
     driver._last_task_snapshot = None
     driver._task_admission = threading.Lock()

--- a/tests/drivers/test_unitree_lowcmd_fields_are_finite.py
+++ b/tests/drivers/test_unitree_lowcmd_fields_are_finite.py
@@ -317,6 +317,7 @@ def _fake_driver(publisher: _RecordingPublisher) -> Any:
             "_fsm_id",
             "_battery",
             "_imu",
+            "_joints",
             "_pubs",
             "_check_motion_gates",
             "_loop",
@@ -335,6 +336,7 @@ def _fake_driver(publisher: _RecordingPublisher) -> Any:
     driver._motion_switcher_lock = threading.Lock()
     driver._battery = {"pct": 80.0}
     driver._imu = {"rpy": [0.0, 0.0, 0.0]}
+    driver._joints = {"left_hip_pitch": {"q": 0.0, "dq": 0.0, "tau_est": 0.0, "temperature": 30}}
     driver._pubs = publisher
     driver._check_motion_gates = MagicMock(return_value=None)
     driver._loop = None

--- a/tests/drivers/test_unitree_motor_state_is_read_by_both_twins.py
+++ b/tests/drivers/test_unitree_motor_state_is_read_by_both_twins.py
@@ -1,0 +1,292 @@
+"""``rt/lowstate.motor_state`` is a reading, and both Unitree twins take it.
+
+The G1 is a 29-DoF humanoid whose driver publishes PD targets on ``rt/lowcmd``
+under gains up to :data:`~strands_robots.drivers.g1._SDK_KP` at the control
+loop's rate. ``LowState_.motor_state`` is the only proprioception the robot
+sends back, so a driver that does not read it commands every one of those
+joints without ever observing one: nothing can check a target against the
+measured pose, and a policy driven by
+:meth:`~strands_robots.drivers.g1._ControlLoop._call_policy` is handed an
+observation with no joint in it at all.
+
+The twin driver already read the same array the same way -
+:meth:`~strands_robots.drivers.go2.Go2Driver._on_lowstate` decoded
+``motor_state[slot]`` per :data:`~strands_robots.drivers.go2.GO2_JOINT_INDEX`
+into ``_joints`` and published it on the ``sensors`` verb - so one SDK family
+answered a joint read on the quadruped and not on the humanoid.
+
+These cells pin the reading on both drivers, that they share one decoder
+(:func:`~strands_robots.drivers.base.decode_motor_state`) rather than a copy
+each, and that the decoder distinguishes a field the frame does not carry from
+a joint at zero.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import pathlib
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from strands_robots.drivers import g1 as g1_module
+from strands_robots.drivers import go2 as go2_module
+from strands_robots.drivers.base import decode_motor_state
+from strands_robots.drivers.g1 import _G1_JOINT_INDEX, G1Driver, _ControlLoop
+from strands_robots.drivers.go2 import GO2_JOINT_INDEX, Go2Driver
+
+#: The record every joint reports, on either robot.
+_JOINT_FIELDS = frozenset({"q", "dq", "tau_est", "temperature"})
+
+#: ``unitree_hg``'s ``LowState_`` declares 35 motor slots; the G1 names 29.
+_HG_MOTOR_SLOTS = 35
+
+
+def _motor(slot: int, **overrides: Any) -> SimpleNamespace:
+    """One ``MotorState_``, its readings derived from its slot so they differ."""
+    fields: dict[str, Any] = {
+        "q": 0.1 * slot,
+        "dq": 0.01 * slot,
+        "tau_est": 1.0 * slot,
+        "temperature": 30 + slot,
+    }
+    fields.update(overrides)
+    return SimpleNamespace(**fields)
+
+
+def _lowstate(slots: int = _HG_MOTOR_SLOTS, **overrides: Any) -> SimpleNamespace:
+    """A ``LowState_`` carrying a full motor array, an IMU and a layout id."""
+    return SimpleNamespace(
+        motor_state=[_motor(i, **overrides) for i in range(slots)],
+        imu_state=SimpleNamespace(rpy=[0.0, 0.0, 0.0]),
+        mode_machine=4,
+    )
+
+
+def _g1() -> G1Driver:
+    return G1Driver(tool_name="g1", port="192.168.1.172")
+
+
+def _go2() -> Go2Driver:
+    return Go2Driver(tool_name="go2", port="192.168.1.100")
+
+
+class TestTheG1ReadsItsJoints:
+    """The read the humanoid was missing."""
+
+    def test_lowstate_populates_every_named_joint(self) -> None:
+        driver = _g1()
+        assert driver._joints is None, "a driver that has not heard lowstate reports no joints"
+
+        driver._on_lowstate(_lowstate())
+
+        assert driver._joints is not None
+        assert set(driver._joints) == set(_G1_JOINT_INDEX), "every named joint is read"
+        assert len(driver._joints) == 29
+
+    def test_each_joint_carries_the_full_record(self) -> None:
+        driver = _g1()
+        driver._on_lowstate(_lowstate())
+        assert driver._joints is not None
+        for name, record in driver._joints.items():
+            assert set(record) == _JOINT_FIELDS, f"{name} reports a partial record"
+
+    def test_a_joint_reads_its_own_wire_slot(self) -> None:
+        """Slot-for-slot: the humanoid's index table addresses the array."""
+        driver = _g1()
+        driver._on_lowstate(_lowstate())
+        assert driver._joints is not None
+        for name, slot in _G1_JOINT_INDEX.items():
+            assert driver._joints[name] == {
+                "q": pytest.approx(0.1 * slot),
+                "dq": pytest.approx(0.01 * slot),
+                "tau_est": pytest.approx(1.0 * slot),
+                "temperature": 30 + slot,
+            }
+
+    def test_the_reserved_slots_are_not_reported(self) -> None:
+        """35 slots arrive; the 29 the robot actuates are the ones read."""
+        driver = _g1()
+        driver._on_lowstate(_lowstate())
+        assert driver._joints is not None
+        assert max(_G1_JOINT_INDEX.values()) == 28
+        assert len(driver._joints) < _HG_MOTOR_SLOTS
+
+    def test_the_imu_and_layout_id_still_decode(self) -> None:
+        """The new read shares a callback with the two it did not replace."""
+        driver = _g1()
+        driver._on_lowstate(_lowstate())
+        assert driver._imu is not None
+        assert driver._imu["rpy"] == [0.0, 0.0, 0.0]
+        assert driver._mode_machine == 4
+
+
+class TestTheJointsReachTheirConsumers:
+    """A reading nothing exposes is not yet an answer to anything."""
+
+    def test_the_sensors_verb_publishes_joints(self) -> None:
+        driver = _g1()
+        driver._on_lowstate(_lowstate())
+
+        async def _read() -> dict[str, Any]:
+            async for result in driver.stream({"toolUseId": "t", "name": "g1", "input": {"action": "sensors"}}, {}):
+                return dict(result)
+            raise AssertionError("the sensors verb yielded no result")
+
+        result = asyncio.run(_read())
+
+        assert result["status"] == "success"
+        payload = result["content"][0]["json"]
+        assert set(payload["joints"]) == set(_G1_JOINT_INDEX)
+
+    def test_the_sensors_verb_is_declared_to_return_them(self) -> None:
+        """The verb's own description names what it hands back."""
+        described = _g1().tool_spec["inputSchema"]["json"]["properties"]["action"]["description"]
+        assert "joints" in described
+
+    def test_the_policy_observation_carries_the_measured_pose(self) -> None:
+        """The whole point of the read: a proprioceptive policy can run."""
+        driver = _g1()
+        driver._on_lowstate(_lowstate())
+
+        seen: list[dict[str, Any]] = []
+
+        def recording_policy(obs: dict[str, Any]) -> dict[str, float]:
+            seen.append(obs)
+            return {}
+
+        loop = _ControlLoop.__new__(_ControlLoop)
+        loop._driver = driver
+        loop._policy = recording_policy
+
+        loop._call_policy()
+
+        assert len(seen) == 1
+        joints = seen[0]["joints"]
+        assert joints is not None
+        assert len(joints) == 29
+        for record in joints.values():
+            assert set(record) == _JOINT_FIELDS
+
+    def test_the_snapshot_does_not_hand_out_the_live_cache(self) -> None:
+        driver = _g1()
+        driver._on_lowstate(_lowstate())
+        snapshot = driver._snapshot("_joints")
+        assert snapshot is not None
+        snapshot["left_knee"] = "clobbered"
+        assert driver._joints is not None
+        assert driver._joints["left_knee"] != "clobbered"
+
+
+class TestOneDecoderForBothTwins:
+    """The decode is shared, so the two drivers cannot drift apart on it."""
+
+    def test_both_drivers_call_the_shared_decoder(self) -> None:
+        for module in (g1_module, go2_module):
+            assert module.decode_motor_state is decode_motor_state, (
+                f"{module.__name__} must route through the one owner in drivers.base"
+            )
+
+    def test_the_go2_still_reads_its_twelve_joints(self) -> None:
+        driver = _go2()
+        driver._on_lowstate(
+            SimpleNamespace(
+                motor_state=[_motor(i) for i in range(20)],
+                imu_state=SimpleNamespace(rpy=[0.0, 0.0, 0.0]),
+                bms_state=SimpleNamespace(soc=88.0),
+            )
+        )
+        assert driver._joints is not None
+        assert set(driver._joints) == set(GO2_JOINT_INDEX)
+        assert len(driver._joints) == 12
+
+    def test_both_peers_report_one_joint_shape(self) -> None:
+        """A fleet consumer reading one SDK family sees one record shape."""
+        g1_driver = _g1()
+        g1_driver._on_lowstate(_lowstate())
+        go2_driver = _go2()
+        go2_driver._on_lowstate(
+            SimpleNamespace(motor_state=[_motor(i) for i in range(20)]),
+        )
+        assert g1_driver._joints is not None
+        assert go2_driver._joints is not None
+
+        g1_shapes = {frozenset(r) for r in g1_driver._joints.values()}
+        go2_shapes = {frozenset(r) for r in go2_driver._joints.values()}
+        assert g1_shapes == go2_shapes == {_JOINT_FIELDS}
+
+    def test_neither_twin_keeps_a_private_motor_decode(self) -> None:
+        """Neither Unitree module names a motor-record field itself.
+
+        ``tau_est`` is a name only a ``MotorState_`` record carries, so either
+        twin reading it outside the shared decoder has grown a second copy of
+        this decode - which is how they came to disagree about whether the
+        array was read at all. Scoped to the two ``rt/lowstate`` subscribers:
+        :data:`~strands_robots.drivers.booster.MOTOR_STATE_FIELDS` decodes a
+        different layout (parallel per-field vectors, not per-joint records)
+        and already derives its own read from one table.
+        """
+        offenders: list[str] = []
+        for module in (g1_module, go2_module):
+            path = pathlib.Path(inspect.getfile(module))
+            for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+                if isinstance(node, ast.Constant) and node.value == "tau_est":
+                    offenders.append(f"{path.name}:{node.lineno}")
+        assert offenders == [], f"a private motor decode reappeared: {offenders}"
+
+    def test_each_twin_reaches_the_decoder_exactly_once(self) -> None:
+        """One call site per driver: the read is not duplicated inside one."""
+        for module in (g1_module, go2_module):
+            source = inspect.getsource(module)
+            calls = source.count("decode_motor_state(getattr(msg,")
+            assert calls == 1, f"{module.__name__} decodes motor_state {calls} times"
+
+
+class TestADefaultIsNotAReading:
+    """``0.0`` is a valid pose; a field the frame lacks must not read as one."""
+
+    def test_an_absent_field_reads_none_not_zero(self) -> None:
+        """A renamed IDL field is silence, not a joint parked at its zero."""
+        motors = [SimpleNamespace(dq=0.5, tau_est=1.0, temperature=30) for _ in range(_HG_MOTOR_SLOTS)]
+        decoded = decode_motor_state(motors, _G1_JOINT_INDEX)
+        assert decoded is not None
+        assert decoded["left_knee"]["q"] is None, "an unread position is not the zero position"
+        assert decoded["left_knee"]["dq"] == pytest.approx(0.5), "the readable fields survive"
+
+    def test_one_bad_field_does_not_discard_the_others(self) -> None:
+        motors = [_motor(i, q=object()) for i in range(_HG_MOTOR_SLOTS)]
+        decoded = decode_motor_state(motors, _G1_JOINT_INDEX)
+        assert decoded is not None
+        record = decoded["left_knee"]
+        assert record["q"] is None
+        assert record["temperature"] == 33, "the frame's other readings are kept"
+
+    def test_an_absent_array_leaves_the_cache_unread(self) -> None:
+        assert decode_motor_state(None, _G1_JOINT_INDEX) is None
+
+    def test_a_buffer_is_not_a_motor_array(self) -> None:
+        """A bytes-like array indexes to integers, which carry no readings."""
+        for buffer in (b"\x01\x02", bytearray(b"\x01\x02"), memoryview(b"\x01\x02"), "0.1"):
+            assert decode_motor_state(buffer, _G1_JOINT_INDEX) is None, buffer
+
+    def test_an_array_answering_no_slot_is_not_a_reading(self) -> None:
+        """Zero joints decoded says the array was unreadable, not jointless."""
+        assert decode_motor_state([], _G1_JOINT_INDEX) is None
+
+    def test_a_short_array_costs_only_the_slots_it_lacks(self) -> None:
+        """A firmware carrying fewer slots keeps the joints it does carry."""
+        decoded = decode_motor_state([_motor(i) for i in range(5)], _G1_JOINT_INDEX)
+        assert decoded is not None
+        assert set(decoded) == {name for name, slot in _G1_JOINT_INDEX.items() if slot < 5}
+        assert decoded["left_hip_pitch"]["q"] == pytest.approx(0.0)
+
+    def test_a_lowstate_without_motors_leaves_the_previous_reading(self) -> None:
+        """A frame missing the array does not erase the pose already read."""
+        driver = _g1()
+        driver._on_lowstate(_lowstate())
+        first = dict(driver._joints or {})
+        driver._on_lowstate(SimpleNamespace(imu_state=SimpleNamespace(rpy=[0.0, 0.0, 0.0])))
+        assert driver._joints == first


### PR DESCRIPTION
`G1Driver._on_lowstate` decoded `rt/lowstate` into the IMU and the hardware layout id, and never touched `motor_state` - the array the robot's 29 joints report `q` / `dq` / `tau_est` / `temperature` through. `grep -c motor_state strands_robots/drivers/g1.py` was **0**. The twin `Go2Driver._on_lowstate` already read the same array the same way per `GO2_JOINT_INDEX` and published it on its `sensors` verb, so one SDK family answered a joint read on the quadruped and not on the humanoid.

![before/after](https://raw.githubusercontent.com/cagataycali/robots/assets-g1-motor-state/g1_motor_state.png)

A MuJoCo G1 (headless EGL) squats and raises its left arm; the 29 measured joint states are packed into a `unitree_hg` `LowState_` per frame and fed to each driver. Bottom left is what the driver published before: nothing, for all 150 frames, while the robot reported every joint. Top trace is after - the dashed published line lies exactly on the measurement (max error **0.0 rad** over 29 joints x 150 frames).

| | before | after |
|---|---|---|
| `joints` on the `sensors` verb | absent | present |
| frames carrying a reading | 0 / 150 | 150 / 150 |
| keys in the policy observation | 4 | 5 |
| joints in the policy observation | 0 | 29 |

## Why it matters

`send_action` writes `motor_cmd[i].q` under gains up to `_SDK_KP` (kp 40-100), so the driver commanded 29 PD-controlled joints while observing none of them: no target could be checked against the measured pose. `_ControlLoop._call_policy` handed a policy `{mode_machine, fsm_id, battery, imu}`, so no proprioceptive policy - which is every locomotion and whole-body controller - could run on the robot at all.

## Change

The decode moves to `decode_motor_state` in `drivers/base.py` and **both** drivers call it, so the Go2's private copy is deleted rather than duplicated - the one-owner shape the shared telemetry coercers already took. The shared decoder keeps the family's rule that a default is not a reading: a field the frame does not carry reads `None` rather than `0.0`, which on a joint would be a plausible pose; and a `motor_state` that is absent, bytes-like (a buffer indexes to integers, which carry none of these names), or answers no slot reads `None` rather than an empty record. A slot the array lacks is skipped, so a shorter firmware costs those joints and not the frame.

`joints` reaches the `sensors` verb and the control loop's policy observation. No new verb.

| | statements | note |
|---|---|---|
| `drivers/base.py` | +10 | the one decoder |
| `drivers/g1.py` | +4 | the read plus two exposures |
| `drivers/go2.py` | **-6** | its private loop deleted |
| **net** | **+8** | +67 raw lines, the bulk being the decoder's docstring |

## Tests

`tests/drivers/test_unitree_motor_state_is_read_by_both_twins.py`, 21 cells. With only the new `drivers/base.py` helper copied into a pristine tree and both drivers left untouched: **13 failed / 8 passed** (the 8 that pass are the pure-decoder cells). After: 21 passed. Each mutation of the fix, measured:

| mutation | cells |
|---|---|
| the G1 read removed entirely (the defect as filed) | 10 |
| the Go2 keeps a private decode instead of sharing | 3 |
| a slot the array lacks defaults instead of skipping | 2 |
| `joints` not handed to the policy observation | 1 |
| `joints` not published on the `sensors` verb | 1 |
| typed defaults in the decoder (`q` reads `0.0`) | 1 |
| the bytes-like guard dropped | 1 |
| an array answering no slot reads as a reading | 1 |

A package-scoped guard pins that neither Unitree module names a motor-record field itself, so a second private copy cannot come back. `booster.py` is deliberately out of that scope: `MOTOR_STATE_FIELDS` decodes a different layout (parallel per-field vectors, not per-joint records) and already derives its read from one table.

Four existing `__new__`/`MagicMock(spec=[...])` fixtures hand-list the driver's cache roster; `_joints` joins it beside `_imu` in each.

Full suite `52293 passed / 304 skipped / 0 failed` (30m31s), `ruff check` + `format --check` clean, `mypy` clean over 1892 files.

## Not in this PR

Seeding uncommanded joints in `_build_lowcmd_from_action` from the new reading (LeRobot's `unitree_g1` does this, and it is now possible here - but it changes what gets commanded, which belongs in its own PR). Hand joints on `rt/dex3/...` and the reserved slots 29-34. The mesh state topic reaches joints through `joint_read_source`, which resolves to `None` for **both** native Unitree drivers (neither exposes a `bus.sync_read` nor a `get_observation`), so the mesh publishes no `joints` section for either peer - unchanged here, and a separate question from whether the driver reads its own wire.