### PR TITLE
ci(pr-and-push): the required check evaluates the merge commit, not the branch head

### DIFF
--- a/.github/workflows/pr-and-push.yml
+++ b/.github/workflows/pr-and-push.yml
@@ -2,8 +2,8 @@ name: Pull Request and Push Action
 
 on:
   # No 'types' override: the default (opened, synchronize, reopened) is exactly
-  # the set that can change 'pull_request.head.sha', which is the ref handed to
-  # the reusable workflow below. Subscribing to an event that cannot change it -
+  # the set that can change 'pull_request.head.sha', which is what moves the
+  # refs/pull/<n>/merge commit handed to the reusable workflow below. Subscribing to an event that cannot change it -
   # this workflow was also started by ready_for_review, review_requested and
   # review_request_removed - cannot produce a new verdict, and because the
   # concurrency group below cancels in progress, it discards the in-flight run of
@@ -55,4 +55,13 @@ jobs:
     permissions:
       contents: read
     with:
-      ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      # The tree the one required check evaluates. On a 'pull_request' event this is
+      # the merge commit GitHub keeps at refs/pull/<n>/merge (head + base tip), not
+      # the head sha: the head is a tree that will never exist on 'main', and a
+      # branch that forked before a fix landed on 'main' is red on it while the
+      # tree its merge would produce is green (#2796). The grader that went red
+      # dismissed the approval to clear, on a branch that needed no change. The
+      # sibling gates that DO read the head (merge-base-overlap) say why in place;
+      # this one wants the tree that merges, which is what lockfile-parity checks
+      # out for the same reason. On a push there is no merge commit: 'github.sha'.
+      ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}

--- a/changelog.d/2796-required-check-tests-the-merge-commit.md
+++ b/changelog.d/2796-required-check-tests-the-merge-commit.md
@@ -1,0 +1,12 @@
+### Fixed: the required check evaluates the tree that would merge, not the branch head
+
+`call-test-lint / Test and Lint` was handed `pull_request.head.sha`, a tree that
+never exists on `main`. A branch that forked before a grader fix landed on `main`
+was therefore red on its own head while the merge it proposed was green, and the
+only way to clear the red re-ran the check and dismissed the approval on a branch
+that needed no change (#2796, measured on #2789 and again on #3236). The reusable
+workflow now checks out `refs/pull/<n>/merge` on a pull request, the same commit
+`lockfile-parity` reads for the same reason, and `github.sha` on a push, where no
+merge commit exists. `merge-base-overlap` keeps reading the head on purpose: its
+merge base against the merge commit would be the base tip and the check would pass
+vacuously, which its own comment already says.


### PR DESCRIPTION
## What

`call-test-lint / Test and Lint` is handed `refs/pull/<n>/merge` on a pull request instead of `pull_request.head.sha`; on a push it stays `github.sha`.

## Why

The head is a tree that never exists on `main`. A branch that forked before a grader fix landed on `main` is red on its own head while the tree its merge would produce is green, and the only way to clear the red re-ran the check and dismissed the approval on a branch that needed no change. Measured on #2789 (job `98279418594` resolved the reusable workflow from `refs/pull/2789/merge` and then checked out the head) and again after #3236 landed. `lockfile-parity` already checks out the merge commit for this reason; `merge-base-overlap` keeps the head deliberately and says why in place (its merge base against the merge commit would be the base tip).

## Tests

The eight modules that read `pr-and-push.yml` / `test-lint.yml` (trigger types, both concurrency groups, action sha pins, merge-gate viewer scope, job bounds, changelog gate, merge-base overlap) pass unchanged: 354 passed. None pinned which tree the check evaluates, which is the gap #2796 names.

Closes #2796