### PR TITLE
fix(drivers/booster): read_mode passes GetMode its out-parameter

### DIFF
--- a/changelog.d/3400-booster-read-mode-out-parameter.md
+++ b/changelog.d/3400-booster-read-mode-out-parameter.md
@@ -1,0 +1,3 @@
+### Fixed: the Booster T1 driver reads its mode through the vendor's out-parameter
+
+`BoosterDriver.read_mode` called `B1LocoClient.GetMode()` with no argument, but the vendor binding is `GetMode(get_mode_response) -> int`: the mode lands in the `GetModeResponse` you pass in and the return value is a status code. On a real T1 the call raised `TypeError`, which `read_mode` did not catch, so `get_status` failed on every connected robot. The driver now passes a `GetModeResponse`, reads the mode name from it when the code is 0, and reports `None` for any other code instead of an uninitialised field.

--- a/strands_robots/drivers/booster.py
+++ b/strands_robots/drivers/booster.py
@@ -1016,9 +1016,20 @@ class BoosterDriver:
         if self._client is None:
             return None
         try:
-            response = self._client.GetMode()
+            import booster_robotics_sdk_python as sdk
+        except ImportError:  # pragma: no cover - connect_eagerly already needed it
+            return None
+        # The vendor binding is ``GetMode(get_mode_response) -> int``: the mode
+        # lands in the out-parameter and the return value is a status code, 0
+        # on success. Calling it without the parameter raises ``TypeError``.
+        response = sdk.GetModeResponse()
+        try:
+            code = self._client.GetMode(response)
         except (RuntimeError, OSError) as exc:
             logger.debug("%s: GetMode failed: %s", self._tool_name, exc)
+            return None
+        if code != 0:
+            logger.debug("%s: GetMode returned code %s", self._tool_name, code)
             return None
         mode = getattr(response, "mode", None)
         return getattr(mode, "name", None) if mode is not None else None

--- a/tests/drivers/test_booster_driver.py
+++ b/tests/drivers/test_booster_driver.py
@@ -132,6 +132,7 @@ class _FakeLocoClient:
     def __init__(self) -> None:
         self.calls: list[tuple[str, tuple[Any, ...]]] = []
         self.refuse: set[str] = set()
+        self.mode_code = 0
 
     def _record(self, name: str, *args: Any) -> None:
         if name in self.refuse:
@@ -156,9 +157,12 @@ class _FakeLocoClient:
     def ChangeMode(self, mode: Any) -> None:  # noqa: N802
         self._record("ChangeMode", mode)
 
-    def GetMode(self) -> Any:  # noqa: N802
-        self._record("GetMode")
-        return type("Response", (), {"mode": type("Mode", (), {"name": "kCustom"})()})()
+    def GetMode(self, get_mode_response: Any) -> int:  # noqa: N802
+        """The vendor's signature: fill the out-parameter, return a status code."""
+        self._record("GetMode", get_mode_response)
+        if self.mode_code == 0:
+            get_mode_response.mode = type("Mode", (), {"name": "kCustom"})()
+        return self.mode_code
 
 
 class _FakeChannel:
@@ -201,12 +205,19 @@ class _FakeRobotMode:
     kSoccer = 4
 
 
+class _FakeGetModeResponse:
+    """``GetModeResponse``: an empty out-parameter ``GetMode`` fills in."""
+
+    mode: Any = None
+
+
 class _FakeSdk:
     """The module surface the driver reaches for, and nothing more."""
 
     LowCmd = _FakeLowCmd
     LowCmdType = _FakeLowCmdType
     RobotMode = _FakeRobotMode
+    GetModeResponse = _FakeGetModeResponse
 
     def __init__(self) -> None:
         self.client = _FakeLocoClient()
@@ -577,6 +588,18 @@ class TestTheReadSurface:
         assert payload["upper_body_enabled"] is True
         assert payload["frame_width"] == _WIDTH
         assert payload["mode"] == "kCustom"
+
+    def test_read_mode_passes_the_vendor_out_parameter_and_reads_it_back(self, sdk: _FakeSdk) -> None:
+        """``B1LocoClient.GetMode(get_mode_response) -> int`` fills its argument."""
+        driver = _live_driver(sdk)
+        assert driver.read_mode() == "kCustom"
+        (args,) = [args for name, args in sdk.client.calls if name == "GetMode"]
+        assert isinstance(args[0], _FakeGetModeResponse)
+
+    def test_a_nonzero_get_mode_code_is_no_reading(self, sdk: _FakeSdk) -> None:
+        """The out-parameter is uninitialised when the code is not 0 (vendor docs)."""
+        sdk.client.mode_code = 100
+        assert _live_driver(sdk).read_mode() is None
 
     def test_the_agent_verbs_are_read_only_plus_a_stop(self, sdk: _FakeSdk) -> None:
         """A model must not be able to choose a motion verb on a 1.2 m biped."""


### PR DESCRIPTION
**What**

`BoosterDriver.read_mode` now calls the vendor binding the way it is declared, `GetMode(get_mode_response) -> int`, and reads the mode from the filled `GetModeResponse` when the code is 0.

**Why**

`booster_robotics_sdk_python` binds `B1LocoClient::GetMode(GetModeResponse&)`: one required out-parameter, an integer status back. The driver called `self._client.GetMode()` with no argument, so on a real T1 every `read_mode` raised and `get_status` died with it. With a vendor-faithful double, main fails at:

```
TypeError: _FakeLocoClient.GetMode() missing 1 required positional argument: 'get_mode_response'
strands_robots/drivers/booster.py:1019: TypeError
```

**Tests**

`test_read_mode_passes_the_vendor_out_parameter_and_reads_it_back`, `test_a_nonzero_get_mode_code_is_no_reading`; ruff, mypy clean on touched files.
