### PR TITLE
fix(policies/lerobot_local): the RTC prefix names the actions the robot has not executed yet

### DIFF
--- a/changelog.d/3402-rtc-prefix-is-the-unexecuted-chunk.md
+++ b/changelog.d/3402-rtc-prefix-is-the-unexecuted-chunk.md
@@ -1,0 +1,32 @@
+### Fixed: the RTC prefix names the actions the robot has not executed yet
+
+LeRobot fixes what `prev_chunk_left_over` means in
+`ActionQueue.get_left_over()`, which its inference loop snapshots immediately
+before denoising: `original_queue[last_index:]`, the previous chunk from the
+observation tick to its end. Row 0 is therefore the action applied on the tick
+right after the observation, and row *i* the action applied on the tick the new
+chunk's row *i* lands on. That index alignment is the mechanism -
+`RTCProcessor.denoise_step` builds
+`get_prefix_weights(inference_delay, execution_horizon, T)`, which pins weight
+1.0 across `[0, inference_delay)` (the steps that elapse *during* inference) and
+blends `[inference_delay, execution_horizon)` toward the prefix.
+
+`LerobotLocalPolicy` cut the prefix at emit time instead, keeping the chunk tail
+past the execution horizon. Which part of a chunk becomes the next prefix is not
+knowable then: it depends on how far the consumer has drained the chunk when the
+next observation is captured, and that count only arrives with the next
+inference (`set_rtc_observed_delay`). On the synchronous path the guess happens
+to be right, because the chunk is fully drained before the re-query. On the
+async rollout path the runner fires the prefetch when the chunk is half drained,
+so the prefix was shifted forward by exactly `observed_delay` steps on every
+seam: the denoiser froze the new chunk onto actions the robot would not reach
+for another `observed_delay` ticks, and blended the seam against actions the
+runner discards at the swap and never executes.
+
+The policy now keeps the chunk as the consumer received it - LeRobot's
+`original_queue` - and derives the prefix at the next inference from the overlap
+the runtime reports, which is that queue's `last_index` seen from the other end.
+Measured on the real async pipeline with `execution_horizon=10` and a 50-step
+chunk: the prefix opened on the action 5 ticks ahead of the one being executed,
+and lerobot's own weight schedule hard-froze all five of those rows. The
+synchronous path, where nothing is pending during inference, is unchanged.

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -652,6 +652,26 @@ RTC policies (it cannot stretch the interval and break blending). For non-RTC
 policies `execution_horizon == actions_per_step` and the consumer still takes
 `max(action_horizon, actions_per_step)` so the trained chunk is never truncated.
 
+### What the prefix contains: `prev_chunk_left_over`
+
+The prefix is the previous chunk **from the observation tick to its end** - the
+same span LeRobot's `ActionQueue.get_left_over()` returns
+(`original_queue[last_index:]`). Row 0 is the action applied on the tick right
+after the observation, and row *i* the action applied on the tick the new chunk's
+row *i* lands on. LeRobot's denoiser depends on that index alignment: it builds
+`get_prefix_weights(inference_delay, execution_horizon, T)`, pinning weight 1.0
+across `[0, inference_delay)` - the steps that elapse *during* inference - and
+blending `[inference_delay, execution_horizon)` toward the prefix.
+
+The provider therefore keeps each chunk as the consumer received it and cuts the
+prefix at the next query, from the overlap the runtime reports
+(`set_rtc_observed_delay`). Under `async_rtc=True` the runner fires the prefetch
+mid-chunk, so the prefix opens on the action still pending at that moment; under
+`async_rtc=False` the chunk has drained and it opens past the execution horizon.
+Cutting the prefix when the chunk is produced cannot express the async case: how
+far the consumer has drained the chunk is not known until its next observation is
+captured.
+
 ### Relative-action policies: prefix re-anchoring
 
 Some flow-matching checkpoints (pi0 / pi0.5 / pi0-FAST trained with a

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -582,12 +582,21 @@ class LerobotLocalPolicy(Policy):
             if error:
                 raise ValueError(error)
         self._rtc_max_guidance_weight = rtc_max_guidance_weight
+        # The previous chunk as it was handed to the consumer - LeRobot's
+        # ``ActionQueue.original_queue``. The prefix the denoiser receives is a
+        # SLICE of this taken at the next inference, once the number of steps the
+        # consumer still has pending is known; see _rtc_unexecuted_prefix.
         self._rtc_prev_chunk: torch.Tensor | None = None
-        # Absolute-coordinate copy of the leftover tail, populated ONLY for
+        # Absolute-coordinate copy of that chunk, populated ONLY for
         # relative-action flow policies so the next chunk can re-express it
         # against the current robot state (see _predict_with_rtc). Stays None
         # for absolute-action policies, whose frame does not move.
         self._rtc_prev_chunk_abs: torch.Tensor | None = None
+        # Actions the consumer was expected to execute from that chunk before
+        # re-querying (its execution horizon). With the overlap reported at the
+        # next inference this is LeRobot's ``ActionQueue.last_index``: the
+        # consumption index the prefix is sliced from.
+        self._rtc_prev_chunk_horizon: int = 0
         # Lazily-resolved (once) preprocessor steps + helper used to re-anchor a
         # relative-action RTC prefix to LeRobot parity. All stay None unless an
         # enabled RelativeActionsProcessorStep is present in the pipeline.
@@ -740,6 +749,7 @@ class LerobotLocalPolicy(Policy):
         # Clear RTC state
         self._rtc_prev_chunk = None
         self._rtc_prev_chunk_abs = None
+        self._rtc_prev_chunk_horizon = 0
         self._rtc_action_queue.clear()
         self._rtc_latency_history.clear()
         self._rtc_last_inference_time = 0.0
@@ -1965,6 +1975,65 @@ class LerobotLocalPolicy(Policy):
         )
         self._rtc_reanchor_degraded_warned = True
 
+    def _rtc_unexecuted_prefix(self, inference_delay: int) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+        """The previous chunk from the observation tick on - the RTC prefix.
+
+        LeRobot fixes what ``prev_chunk_left_over`` means in
+        ``ActionQueue.get_left_over()``, which its inference loop snapshots
+        immediately before denoising::
+
+            idx_before = queue.get_action_index()
+            prev_actions = queue.get_left_over()    # original_queue[last_index:]
+
+        ``original_queue`` is the previous chunk with its own inference delay
+        already dropped - exactly what :meth:`_predict_with_rtc` hands its
+        consumer and stores in ``_rtc_prev_chunk`` - and ``last_index`` is how
+        much of it the robot has executed. Row 0 of the result is therefore the
+        action applied on the tick right after the observation, and row *i* the
+        action applied on the tick the new chunk's row *i* lands on. That index
+        alignment is the mechanism: ``RTCProcessor.denoise_step`` builds
+        ``get_prefix_weights(inference_delay, execution_horizon, T)``, pinning
+        weight 1.0 across ``[0, inference_delay)`` - the steps that elapse
+        *during* this inference - and blending ``[inference_delay,
+        execution_horizon)`` toward the prefix.
+
+        ``inference_delay`` supplies the consumption index, because the two are
+        the same number seen from either end: the runtime reports the steps of
+        the current chunk still pending (``set_rtc_observed_delay``), so the
+        consumer has executed ``horizon - delay`` of the ``horizon`` actions it
+        was handed. Cutting there is what keeps the frozen region pinned to the
+        actions the robot really executes while this inference runs; a prefix cut
+        past the horizon named rows the robot would not reach for another
+        ``delay`` ticks, so the denoiser froze the new chunk onto actions that
+        were never applied - and on the async path that is every seam.
+
+        Args:
+            inference_delay: Control steps that elapse during this inference -
+                equivalently, actions of the previous chunk still pending when
+                its observation was captured.
+
+        Returns:
+            ``(prefix, absolute_prefix)`` cut at the same index, either element
+            ``None`` when it is unavailable: no previous chunk yet (first
+            inference of an episode), a chunk the consumer has fully drained, or
+            an absolute copy that was never populated (absolute-action policies,
+            which need no re-anchoring).
+        """
+        chunk = self._rtc_prev_chunk
+        if chunk is None or chunk.shape[0] == 0:
+            return None, None
+        # A delay past the horizon is only reachable on the wall-clock fallback
+        # (the counted path never exceeds the chunk it handed out): the estimate
+        # claims more steps elapse than the consumer had actions for, so it has
+        # stalled on the chunk's last action. The prefix cannot describe ticks
+        # from before the chunk began, so anchor at its first row rather than
+        # indexing off its front.
+        start = max(0, self._rtc_prev_chunk_horizon - max(0, inference_delay))
+        if start >= chunk.shape[0]:
+            return None, None
+        absolute = self._rtc_prev_chunk_abs
+        return chunk[start:], None if absolute is None else absolute[start:]
+
     def _predict_with_rtc(self, batch: dict[str, Any]) -> torch.Tensor:
         """Run inference using predict_action_chunk with RTC kwargs.
 
@@ -2038,23 +2107,26 @@ class LerobotLocalPolicy(Policy):
         # On the first chunk prev_chunk_left_over is None and lerobot returns
         # early, so the value is harmless there.
         rtc_kwargs: dict[str, Any] = {"inference_delay": inference_delay}
-        # Relative-action policies: re-express the leftover tail against the
-        # CURRENT robot state instead of carrying a stale-frame prefix. The
-        # leftover is kept in absolute coordinates (_rtc_prev_chunk_abs);
-        # LeRobot's reanchor helper subtracts the live cached state and
-        # re-normalizes so the model receives a correctly anchored prefix.
-        # Absolute-action policies fall through to the verbatim leftover.
-        prev_chunk = self._rtc_prev_chunk
+        # Cut the previous chunk at the action the consumer has reached, so the
+        # prefix describes the ticks this inference overlaps (see
+        # _rtc_unexecuted_prefix).
+        prev_chunk, prev_chunk_abs = self._rtc_unexecuted_prefix(inference_delay)
+        # Relative-action policies: re-express that prefix against the CURRENT
+        # robot state instead of carrying a stale-frame one. The prefix's
+        # absolute coordinates come from the same slice; LeRobot's reanchor
+        # helper subtracts the live cached state and re-normalizes so the model
+        # receives a correctly anchored prefix. Absolute-action policies fall
+        # through to the verbatim prefix.
         if (
             self._rtc_relative_step is not None
             and self._rtc_reanchor_fn is not None
-            and self._rtc_prev_chunk_abs is not None
-            and self._rtc_prev_chunk_abs.numel() > 0
+            and prev_chunk_abs is not None
+            and prev_chunk_abs.numel() > 0
         ):
             current_state = self._rtc_relative_step.get_cached_state()
             if current_state is not None:
                 prev_chunk = self._rtc_reanchor_fn(
-                    prev_actions_absolute=self._rtc_prev_chunk_abs,
+                    prev_actions_absolute=prev_chunk_abs,
                     current_state=current_state,
                     relative_step=self._rtc_relative_step,
                     normalizer_step=self._rtc_normalizer_step,
@@ -2092,41 +2164,38 @@ class LerobotLocalPolicy(Policy):
         if action_chunk.dim() == 3 and action_chunk.shape[0] == 1:
             action_chunk = action_chunk.squeeze(0)
 
-        # Store leftover for next RTC call (unconsumed portion of this chunk).
-        # The consumer executes ``execution_horizon`` actions before re-querying
-        # (see Policy.execution_horizon / resolve_chunk_length), so the tail past
-        # that point - shifted by the steps already burned during inference - is
-        # what carries into the next chunk as ``prev_chunk_left_over``. Keying
-        # this on the full trained chunk (actions_per_step) emptied the tail
-        # whenever the chunk was consumed whole, so cross-chunk blending never
-        # engaged.
-        exec_horizon = self._rtc_execution_horizon or self.actions_per_step
-        steps_to_consume = min(inference_delay + max(1, int(exec_horizon)), action_chunk.shape[0])
-        if steps_to_consume < action_chunk.shape[0]:
-            leftover_model = action_chunk[steps_to_consume:].detach()
-            self._rtc_prev_chunk = leftover_model
-            # For relative-action policies, also stash the leftover in absolute
-            # robot coordinates so the NEXT call can re-anchor it against the new
-            # state. None for absolute-action policies (no frame shift to undo).
-            self._rtc_prev_chunk_abs = self._absolute_rtc_leftover(leftover_model)
-        else:
-            self._rtc_prev_chunk = None
-            self._rtc_prev_chunk_abs = None
-
         # Skip delay steps - they correspond to time spent during inference
         usable_start = min(inference_delay, action_chunk.shape[0] - 1)
         usable_actions = action_chunk[usable_start:]
+
+        # Keep the chunk exactly as the consumer receives it, which is LeRobot's
+        # ``ActionQueue.original_queue`` (``original_actions[delay:]``, set by
+        # ``_replace_actions_queue``). Which part of it becomes the next prefix
+        # is NOT knowable here: it depends on how far the consumer has drained
+        # this chunk when the next observation is captured, and that count only
+        # arrives with that inference (set_rtc_observed_delay). Pre-slicing it
+        # here to the tail past the execution horizon was that guess, and it was
+        # wrong by the overlap on every async seam - see
+        # _rtc_unexecuted_prefix.
+        self._rtc_prev_chunk = usable_actions.detach()
+        # For relative-action policies, also stash the chunk in absolute robot
+        # coordinates so the NEXT call can re-anchor the prefix it cuts from it
+        # against the new state. None for absolute-action policies (no frame
+        # shift to undo). The conversion is element-wise per action, so slicing
+        # it later matches slicing the model-space copy.
+        self._rtc_prev_chunk_abs = self._absolute_rtc_leftover(self._rtc_prev_chunk)
+        self._rtc_prev_chunk_horizon = max(1, int(self._rtc_execution_horizon or self.actions_per_step))
 
         # Log RTC details at debug level - throttled to once every 2s regardless of Hz
         _now = time.monotonic()
         if _now - self._rtc_last_log_time >= 2.0:
             self._rtc_last_log_time = _now
             logger.debug(
-                "RTC: chunk=%s, delay=%d, usable_start=%d, leftover=%s, avg_latency=%.3fs",
+                "RTC: chunk=%s, delay=%d, usable_start=%d, prefix=%s, avg_latency=%.3fs",
                 action_chunk.shape,
                 inference_delay,
                 usable_start,
-                self._rtc_prev_chunk.shape if self._rtc_prev_chunk is not None else None,
+                None if prev_chunk is None else tuple(prev_chunk.shape),
                 sum(self._rtc_latency_history) / len(self._rtc_latency_history),
             )
 

--- a/tests/policies/lerobot_local/test_policy.py
+++ b/tests/policies/lerobot_local/test_policy.py
@@ -1685,15 +1685,16 @@ class TestRTCInference:
         assert policy._rtc_prev_chunk is not None
         assert policy._rtc_prev_chunk.dim() == 2
 
-    def test_predict_with_rtc_leftover_keyed_on_execution_horizon(self):
-        """Leftover is the chunk tail past execution_horizon, not actions_per_step.
+    def test_predict_with_rtc_prefix_keyed_on_execution_horizon(self):
+        """The prefix is keyed on execution_horizon, not actions_per_step.
 
         Regression: when the consumer drained the FULL trained chunk
-        (actions_per_step == chunk length) the old bookkeeping set steps_to_consume
-        to the whole chunk, so ``_rtc_prev_chunk`` was always ``None`` and the
-        cross-chunk blend never received a previous-chunk tail. With the
-        execution-horizon contract the consumer re-queries every
-        execution_horizon steps, so the tail past that point must carry over.
+        (actions_per_step == chunk length) the old bookkeeping consumed the whole
+        chunk, so no prefix was ever carried and the cross-chunk blend never
+        received one. With the execution-horizon contract the consumer re-queries
+        every execution_horizon steps, so the chunk past that point must carry
+        over. ``prev_chunk_left_over`` is what the model actually receives, so
+        assert it there rather than on the policy's bookkeeping.
         """
         policy = _make_policy()
         policy._rtc_enabled = True
@@ -1705,11 +1706,15 @@ class TestRTCInference:
         mock_policy.predict_action_chunk.return_value = torch.randn(1, 20, 6)
         policy._policy = mock_policy
 
+        # Two zero-overlap queries: the consumer drained its execution horizon
+        # and re-queried with nothing pending.
+        policy.set_rtc_observed_delay(0)
+        policy._predict_with_rtc({})
+        policy.set_rtc_observed_delay(0)
         policy._predict_with_rtc({})
 
-        # delay ~= 0 on the first call -> leftover starts at execution_horizon.
-        assert policy._rtc_prev_chunk is not None
-        assert policy._rtc_prev_chunk.shape == (10, 6)
+        prefix = mock_policy.predict_action_chunk.call_args.kwargs["prev_chunk_left_over"]
+        assert prefix.shape == (10, 6)
 
     def test_execution_horizon_prefers_rtc_over_actions_per_step(self):
         """execution_horizon is the RTC horizon while RTC is active."""

--- a/tests/policies/lerobot_local/test_rtc_prefix_is_the_unexecuted_chunk.py
+++ b/tests/policies/lerobot_local/test_rtc_prefix_is_the_unexecuted_chunk.py
@@ -1,0 +1,247 @@
+"""The RTC prefix describes the actions the robot has not executed yet.
+
+LeRobot's Real-Time Chunking contract for ``prev_chunk_left_over`` is fixed by
+``ActionQueue.get_left_over()``, which the inference loop snapshots immediately
+before it starts denoising::
+
+    idx_before = queue.get_action_index()
+    prev_actions = queue.get_left_over()      # original_queue[last_index:]
+
+``original_queue`` is the previous chunk with its own inference delay already
+dropped - exactly what a strands RTC policy hands its consumer - and
+``last_index`` is how much of it the robot has executed. So row 0 of the prefix
+is the action the robot executes on the tick right after the observation, and
+row *i* is the action it executes on the tick the new chunk's row *i* would land
+on. That index alignment is the whole mechanism: ``RTCProcessor.denoise_step``
+builds ``get_prefix_weights(inference_delay, execution_horizon, T)``, which
+pins weight 1.0 on ``[0, inference_delay)`` - the steps that elapse *during*
+inference - and blends ``[inference_delay, execution_horizon)`` toward the
+prefix. A prefix that starts anywhere else freezes the new chunk onto actions
+the robot is not executing.
+
+These cells drive the real async pipeline (``_ChunkPipeline``) so the runner's
+own prefetch arithmetic - not a restatement of it - decides the observation tick
+and the delay, and then assert which rows of the previous chunk arrive.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from strands_robots.policies.base import resolve_chunk_length
+from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy
+from strands_robots.simulation.policy_runner import _ChunkPipeline
+
+_ACTION_DIM = 1
+_CHUNK_LEN = 50
+_HORIZON = 10
+
+
+def _arange_chunk() -> torch.Tensor:
+    """A ``(1, 50, 1)`` chunk whose row *j* carries the value ``j``.
+
+    Every row is its own index, so an assertion on a prefix value names the row
+    of the previous chunk that arrived without any bookkeeping in the test.
+    """
+    return torch.arange(_CHUNK_LEN, dtype=torch.float32).reshape(1, _CHUNK_LEN, _ACTION_DIM)
+
+
+def _rtc_policy() -> LerobotLocalPolicy:
+    """An RTC-active policy whose model returns the arange chunk on every call."""
+    with patch.object(LerobotLocalPolicy, "_load_model"):
+        policy = LerobotLocalPolicy(pretrained_name_or_path="test/model")
+    policy._rtc_enabled = True
+    policy._rtc_execution_horizon = _HORIZON
+    policy.actions_per_step = _CHUNK_LEN
+    stub = MagicMock()
+    stub.predict_action_chunk.side_effect = lambda batch, **kwargs: _arange_chunk()
+    policy._policy = stub
+    return policy
+
+
+def _run_async_rollout(policy: LerobotLocalPolicy, ticks: int) -> tuple[list[float], list[dict], list[int]]:
+    """Drive ``ticks`` control steps of the async-RTC pipeline over ``policy``.
+
+    Returns the action values the consumer actually executed in order, the kwargs
+    of every ``predict_action_chunk`` call, and the tick each of those calls'
+    observation was captured on - so a prefix can be compared against the
+    execution it claims to describe. The pipeline captures a prefetch
+    observation on the consuming thread immediately before it submits the
+    inference, so the length of the executed list at that moment IS the
+    observation tick.
+    """
+    calls: list[dict] = []
+    observation_ticks: list[int] = []
+    stub = policy._policy
+    assert stub is not None, "_rtc_policy installs the stub model"
+
+    def query_chunk(observation: dict, observed_delay: int) -> list[dict]:
+        policy.set_rtc_observed_delay(observed_delay)
+        chunk = policy._predict_with_rtc({})
+        calls.append(dict(stub.predict_action_chunk.call_args.kwargs))
+        actions = [{"joint": float(row[0])} for row in chunk]
+        return actions[: resolve_chunk_length(policy, 1)]
+
+    executed: list[float] = []
+
+    def observe() -> dict:
+        observation_ticks.append(len(executed))
+        return {}
+
+    with _ChunkPipeline(query_chunk, observe, async_rtc=True, rtc_inference_timeout_s=10.0) as chunks:
+        for _observation, action in chunks:
+            executed.append(action["joint"])
+            if len(executed) >= ticks:
+                break
+    return executed, calls, observation_ticks
+
+
+def test_prefix_row_zero_is_the_action_executed_right_after_the_observation():
+    """The async prefix starts at the consumer's next action, not past the horizon.
+
+    The runner fires the prefetch when the current chunk is half drained, so at
+    the observation tick five of the ten handed-out actions are still pending.
+    Those five execute *during* inference and are what ``inference_delay=5``
+    tells the denoiser to freeze. Handing back the tail past the execution
+    horizon instead shifted the whole prefix five steps into the future: the
+    denoiser froze the new chunk onto rows the robot would not reach for another
+    five ticks, and the seam RTC exists to smooth was blended against actions
+    that were never executed.
+    """
+    policy = _rtc_policy()
+
+    executed, calls, _ = _run_async_rollout(policy, ticks=2 * _HORIZON)
+
+    assert len(calls) >= 2, "the pipeline should have re-queried at the chunk seam"
+    prefetch = calls[1]
+    assert prefetch["inference_delay"] == _HORIZON // 2
+    prefix = prefetch["prev_chunk_left_over"]
+    # The observation is captured just before the action at index 5 is applied,
+    # so that action is what the prefix must open on.
+    assert prefix[0, 0] == pytest.approx(executed[_HORIZON // 2])
+    # ... and the prefix runs to the end of the previous chunk, which is what
+    # anchors the blended region [inference_delay, execution_horizon).
+    assert prefix.shape == (_CHUNK_LEN - _HORIZON // 2, _ACTION_DIM)
+    assert prefix[:, 0].tolist() == [float(v) for v in range(_HORIZON // 2, _CHUNK_LEN)]
+
+
+def test_prefix_rows_stay_aligned_with_the_ticks_the_new_chunk_lands_on():
+    """Prefix row *i* is the action executed on the new chunk's row *i* tick.
+
+    The frozen region is an index-wise comparison inside the denoiser, so the
+    guarantee has to hold per row, not just at row 0: for every step that
+    elapses during inference, the prefix row and the action the consumer really
+    applies on that tick must be the same.
+    """
+    policy = _rtc_policy()
+
+    executed, calls, _ = _run_async_rollout(policy, ticks=2 * _HORIZON)
+
+    delay = calls[1]["inference_delay"]
+    prefix = calls[1]["prev_chunk_left_over"]
+    during_inference = executed[_HORIZON - delay : _HORIZON]
+    assert prefix[:delay, 0].tolist() == pytest.approx(during_inference)
+
+
+def test_a_fully_drained_chunk_carries_the_tail_past_the_horizon():
+    """With no overlap the prefix is the undrained tail - unchanged behaviour.
+
+    The synchronous path pauses the world during inference and re-queries only
+    once the handed-out chunk has drained, so nothing is pending at the
+    observation tick and ``observed_delay`` is 0. The prefix is then the
+    continuation the previous chunk would have run past the execution horizon,
+    which is what the consumer's next actions are blended against.
+    """
+    policy = _rtc_policy()
+
+    policy.set_rtc_observed_delay(0)
+    policy._predict_with_rtc({})
+    policy.set_rtc_observed_delay(0)
+    policy._predict_with_rtc({})
+
+    prefix = policy._policy.predict_action_chunk.call_args.kwargs["prev_chunk_left_over"]
+    assert prefix[0, 0] == pytest.approx(float(_HORIZON))
+    assert prefix.shape == (_CHUNK_LEN - _HORIZON, _ACTION_DIM)
+
+
+def test_an_overlap_longer_than_the_horizon_anchors_at_the_chunk_start():
+    """A delay past the horizon opens the prefix at the chunk the consumer got.
+
+    Only the wall-clock fallback can report an overlap longer than the
+    handed-out chunk (the counted path never exceeds it): the estimate says more
+    steps elapse during inference than the consumer was given actions for, so it
+    has stalled on the chunk's last action. The prefix cannot describe ticks
+    before the chunk began, so it is clamped to the chunk's first row rather
+    than indexed off its front.
+    """
+    policy = _rtc_policy()
+
+    policy.set_rtc_observed_delay(0)
+    policy._predict_with_rtc({})
+    policy.set_rtc_observed_delay(_HORIZON + 25)
+    policy._predict_with_rtc({})
+
+    prefix = policy._policy.predict_action_chunk.call_args.kwargs["prev_chunk_left_over"]
+    assert prefix[0, 0] == pytest.approx(0.0)
+    assert prefix.shape == (_CHUNK_LEN, _ACTION_DIM)
+
+
+def test_the_absolute_prefix_is_sliced_where_the_model_prefix_is():
+    """A relative-action policy re-anchors the same rows it blends.
+
+    The absolute-coordinate copy of the chunk exists so a relative-action policy
+    can re-express the prefix against the current state. It has to be cut at the
+    same consumption index as the model-space prefix - a copy sliced elsewhere
+    would re-anchor a different span of the chunk than the one being blended,
+    reintroducing the shift this module pins in the coordinate frame instead of
+    the row index.
+    """
+    policy = _rtc_policy()
+    # Element-wise offset, mirroring the real conversion's per-action contract.
+    policy._absolute_rtc_leftover = lambda tail: tail + 100.0  # type: ignore[method-assign]
+    policy._rtc_rebase_resolved = True
+    relative_step = MagicMock()
+    relative_step.get_cached_state.return_value = torch.zeros(_ACTION_DIM)
+    policy._rtc_relative_step = relative_step
+    seen: dict[str, torch.Tensor] = {}
+
+    def reanchor(*, prev_actions_absolute, current_state, relative_step, normalizer_step, policy_device):
+        seen["absolute"] = prev_actions_absolute
+        return prev_actions_absolute
+
+    policy._rtc_reanchor_fn = reanchor
+
+    policy.set_rtc_observed_delay(0)
+    policy._predict_with_rtc({})
+    policy.set_rtc_observed_delay(_HORIZON // 2)
+    policy._predict_with_rtc({})
+
+    model_prefix = policy._policy.predict_action_chunk.call_args.kwargs["prev_chunk_left_over"]
+    assert torch.allclose(seen["absolute"], model_prefix - 100.0 + 100.0)
+    assert seen["absolute"].shape == model_prefix.shape
+    assert seen["absolute"][0, 0] == pytest.approx(float(_HORIZON // 2) + 100.0)
+
+
+def test_every_seam_opens_its_prefix_on_that_seam_own_next_action():
+    """The alignment holds at every re-query, not only the first.
+
+    Each chunk is handed out with its own inference delay already dropped, so the
+    chunk a later seam slices is not the raw model output - it is what the
+    consumer received. Keeping the raw chunk instead is indistinguishable on the
+    first seam (its delay is 0) and wrong on every one after it, so the guarantee
+    has to be checked across several chunks against the tick each observation was
+    actually captured on.
+    """
+    policy = _rtc_policy()
+
+    executed, calls, observation_ticks = _run_async_rollout(policy, ticks=3 * _HORIZON)
+
+    seams = [i for i, call in enumerate(calls) if call.get("prev_chunk_left_over") is not None]
+    assert len(seams) >= 2, f"expected at least two seams, saw calls={len(calls)}"
+    for i in seams:
+        prefix = calls[i]["prev_chunk_left_over"]
+        tick = observation_ticks[i]
+        assert prefix[0, 0] == pytest.approx(executed[tick]), (
+            f"seam {i}: prefix opens on {prefix[0, 0]} but tick {tick} executes {executed[tick]}"
+        )

--- a/tests/policies/lerobot_local/test_rtc_reanchor_degradation_is_reported.py
+++ b/tests/policies/lerobot_local/test_rtc_reanchor_degradation_is_reported.py
@@ -84,9 +84,18 @@ def _model_chunk() -> torch.Tensor:
     return torch.arange(_CHUNK_LEN * _ACTION_DIM, dtype=torch.float32).reshape(1, _CHUNK_LEN, _ACTION_DIM)
 
 
+def _emitted_chunk() -> torch.Tensor:
+    """The chunk as the consumer receives it, which is what the policy keeps.
+
+    With a zero overlap nothing is dropped off the front, so this is the whole
+    chunk - LeRobot's ``ActionQueue.original_queue``.
+    """
+    return _model_chunk().squeeze(0)
+
+
 def _model_leftover() -> torch.Tensor:
     """The tail a consumer does not execute this step: ``chunk[exec_horizon:]``."""
-    return _model_chunk().squeeze(0)[_EXEC_HORIZON:]
+    return _emitted_chunk()[_EXEC_HORIZON:]
 
 
 def _make_rtc_policy(
@@ -214,7 +223,7 @@ class TestTheBenignFallbackStaysSilent:
 
         # The conversion succeeded, so there is a leftover to re-anchor with.
         assert policy._rtc_prev_chunk_abs is not None
-        assert torch.allclose(policy._rtc_prev_chunk_abs, _model_leftover() + state)
+        assert torch.allclose(policy._rtc_prev_chunk_abs, _emitted_chunk() + state)
         assert caplog.records == []
 
 

--- a/tests/policies/lerobot_local/test_rtc_relative_reanchor.py
+++ b/tests/policies/lerobot_local/test_rtc_relative_reanchor.py
@@ -79,9 +79,22 @@ def _model_chunk() -> torch.Tensor:
     return torch.arange(_CHUNK_LEN * _ACTION_DIM, dtype=torch.float32).reshape(1, _CHUNK_LEN, _ACTION_DIM)
 
 
+def _emitted_chunk() -> torch.Tensor:
+    """The chunk as the consumer receives it, which is what the policy keeps.
+
+    With a zero overlap nothing is dropped off the front, so this is the whole
+    chunk - LeRobot's ``ActionQueue.original_queue``.
+    """
+    return _model_chunk().squeeze(0)
+
+
 def _model_leftover() -> torch.Tensor:
-    """The tail of the chunk consumers do NOT execute this step: chunk[exec_horizon:]."""
-    return _model_chunk().squeeze(0)[_EXEC_HORIZON:]
+    """The prefix a zero-overlap re-query blends: chunk[exec_horizon:].
+
+    The consumer executed the first ``exec_horizon`` actions and re-queried with
+    nothing pending, so the prefix opens where its execution stopped.
+    """
+    return _emitted_chunk()[_EXEC_HORIZON:]
 
 
 def _make_rtc_policy(preprocessor: DataProcessorPipeline, postprocessor: DataProcessorPipeline):
@@ -142,9 +155,9 @@ def test_relative_action_rtc_prefix_is_reanchored_to_current_state():
     # First call has no prior chunk to blend.
     assert captured[0] is None
     leftover_model = _model_leftover()
-    assert torch.allclose(policy._rtc_prev_chunk, leftover_model)
-    # Absolute leftover = unnormalize (identity here) + add the current state.
-    assert torch.allclose(policy._rtc_prev_chunk_abs, leftover_model + state1)
+    assert torch.allclose(policy._rtc_prev_chunk, _emitted_chunk())
+    # Absolute copy = unnormalize (identity here) + add the current state.
+    assert torch.allclose(policy._rtc_prev_chunk_abs, _emitted_chunk() + state1)
 
     # State moves: the leftover must be re-expressed against the new frame.
     state2 = torch.tensor([[10.0, 20.0, 30.0, 40.0]])
@@ -173,7 +186,7 @@ def test_absolute_action_policy_carries_leftover_verbatim():
         policy._predict_with_rtc({})
     assert captured[0] is None
     leftover_model = _model_leftover()
-    assert torch.allclose(policy._rtc_prev_chunk, leftover_model)
+    assert torch.allclose(policy._rtc_prev_chunk, _emitted_chunk())
     assert policy._rtc_prev_chunk_abs is None
 
     with torch.inference_mode():
@@ -267,7 +280,7 @@ def test_relative_action_falls_back_when_reanchor_helper_unavailable(make_stub, 
     assert policy._rtc_reanchor_fn is None
     assert policy._rtc_prev_chunk_abs is None
     leftover_model = _model_leftover()
-    assert torch.allclose(policy._rtc_prev_chunk, leftover_model)
+    assert torch.allclose(policy._rtc_prev_chunk, _emitted_chunk())
     assert any("reanchor_relative_rtc_prefix" in record.message for record in caplog.records)
 
     # State moves, but with no helper the leftover is fed back unchanged.


### PR DESCRIPTION
**What:** `LerobotLocalPolicy` derives the RTC prefix at the next inference from the overlap the runtime reports, rather than cutting it at emit time.

**Why:** Which rows become the next prefix depends on how far the consumer drained the chunk — known only at the next inference. The synchronous path drains first, so the guess held; the async path prefetches mid-chunk, so every seam shipped a prefix shifted forward by `observed_delay`. At `inference_delay=5` prefix row 0 was 10.0 where the executed action was 5.0, all five misaligned rows inside lerobot's hard-frozen weight region.

**Tests:** 6 cells driving the real `_ChunkPipeline`; 5 failed / 1 passed on main, the pass being the untouched synchronous path. Full `tests/` 50,763 passed.