### PR TITLE
feat(dashboard): a consent request is built from a refusal's code, never its prose

### DIFF
--- a/changelog.d/3403-dashboard-consent-request.md
+++ b/changelog.d/3403-dashboard-consent-request.md
@@ -1,0 +1,3 @@
+### Added: the dashboard turns a refusal into a consent request by its code, not its wording
+
+`strands_robots.dashboard.consent.classify_refusal` takes a refusal the SDK raised (or its wire shape, or the agent-motion verdict) and returns a `ConsentRequest` naming what the operator can grant: the environment variable comes from `refusal_codes.REFUSAL_GRANTS`, the subject from the refusal itself, and the message is shown, never parsed. A refusal without a code is not continuable and gets no card. Teleop slew refusals carry no code yet, so they are not offered.

--- a/docs/security.md
+++ b/docs/security.md
@@ -176,6 +176,8 @@ except ValidationError as refusal:
 - **Codes are additive.** They were introduced without changing a single refusal message, and new codes may be added for refusals that become continuable later. Switch on the codes you know and fall through to the message for the rest.
 - **Every code you receive is in `REFUSAL_CODES`.** Nothing validates `code` at runtime - it is stored as given - so what backs the closed vocabulary is a static scan over every raise site in the package, reading the code in each spelling a site can use it (a `refusal_codes` attribute, a name imported from it, or the literal string). That means `REFUSAL_GRANTS[refusal.code]` is safe for any code you are handed: a code outside the vocabulary is a defect in this package, not a case for you to handle.
 
+The in-tree consumer of this contract is `strands_robots.dashboard.consent.classify_refusal`, which builds the dashboard's consent card from `code` and `subject` alone and carries the message only for display.
+
 Reference: `strands_robots.refusal_codes`; `strands_robots.mesh.security.SecurityError`; `strands_robots.policies.factory.UntrustedRemoteCodeError`.
 
 ## HuggingFace policy code execution (`trust_remote_code`)

--- a/strands_robots/dashboard/consent.py
+++ b/strands_robots/dashboard/consent.py
@@ -1,0 +1,448 @@
+"""Turn a safety refusal into something a human can answer.
+
+A refusal is recognised by its ``code`` and described by its ``subject`` -- the
+contract :mod:`strands_robots.refusal_codes` states and ``docs/security.md``
+documents. The message travels with the request for the operator to read; it
+decides nothing here, so the SDK may reword any refusal without this module
+noticing. The environment variable a grant writes is read from
+:data:`~strands_robots.refusal_codes.REFUSAL_GRANTS`, never spelled here.
+
+One refusal is the dashboard's own and carries no SDK code: the verdict
+:func:`~strands_robots.dashboard.agent_motion.agent_motion_allowed` returns
+when the agent asks to start motion on real hardware. It is accepted as the
+dict it already is, with the peer name passed alongside, not read back out of
+its sentence.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+from strands_robots import refusal_codes
+from strands_robots.dashboard.agent_motion import MOTION_ENV as _AGENT_MOTION_ENV
+
+#: Same charset the mesh allowlist validator accepts for one ENTRY (``<org>`` or
+#: ``<org>/<repo>``). Validates what would be written to the allowlist, not a sentence.
+_HF_ENTRY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,95}(/[A-Za-z0-9][A-Za-z0-9._-]{0,95})?$")
+#: A provider, policy type or peer name as it may be shown and granted.
+_PROVIDER_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+#: The SDK's own charset for an ENTRY in the host allowlist (security._POLICY_HOST_ENTRY_RE),
+#: copied rather than imported so this module stays free of the mesh at import time.
+_POLICY_HOST_ENTRY_RE = re.compile(r"^[A-Za-z0-9.:/_\-]{1,253}$")
+
+#: The teleop slew bound has no refusal code yet, so it is never classified; it is written
+#: alongside the value bound because the degrees preset is one envelope with two edges.
+_TELEOP_SLEW_ENV = "STRANDS_MESH_INPUT_SLEW_ABS"
+#: Degrees plus a percent gripper: 400 covers a multi-turn wrist with headroom and still
+#: refuses a runaway three orders of magnitude out.
+_TELEOP_DEGREE_VALUE = "400"
+_TELEOP_DEGREE_SLEW = "800"
+
+#: The refusal text can be a whole traceback; keep the evidence bounded.
+_MAX_MESSAGE = 2000
+
+#: The only things an operator can be asked to approve.
+KINDS: tuple[str, ...] = (
+    "trust_remote_code",
+    "hf_repo_allow",
+    "teleop_degree_units",
+    "agent_physical_motion",
+    "policy_type_allow",
+    "policy_host_allow",
+)
+
+#: Which card answers which SDK refusal. Closed on both sides: every code in
+#: :data:`~strands_robots.refusal_codes.REFUSAL_CODES` has a kind here, and the
+#: environment variable for each comes from :data:`~strands_robots.refusal_codes.REFUSAL_GRANTS`.
+_KIND_BY_CODE: dict[str, str] = {
+    refusal_codes.TRUST_REMOTE_CODE_REQUIRED: "trust_remote_code",
+    refusal_codes.HF_REPO_NOT_ALLOWED: "hf_repo_allow",
+    refusal_codes.POLICY_TYPE_NOT_ALLOWED: "policy_type_allow",
+    refusal_codes.POLICY_HOST_NOT_ALLOWED: "policy_host_allow",
+    refusal_codes.TELEOP_VALUE_OUT_OF_RANGE: "teleop_degree_units",
+}
+_CODE_BY_KIND: dict[str, str] = {kind: code for code, kind in _KIND_BY_CODE.items()}
+
+
+def _env_var(kind: str) -> str:
+    """The variable a grant of ``kind`` writes, read from the contract."""
+    if kind == "agent_physical_motion":
+        return _AGENT_MOTION_ENV
+    return refusal_codes.REFUSAL_GRANTS[_CODE_BY_KIND[kind]]
+
+
+def _entries(env: Mapping[str, str], var: str) -> list[str]:
+    return [e.strip() for e in str(env.get(var, "")).split(",") if e.strip()]
+
+
+def _truthy(env: Mapping[str, str], var: str) -> bool:
+    return str(env.get(var, "")).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _host_entry(raw: object, *, strip_url: bool = False) -> str | None:
+    """The allowlist ENTRY that grants ``raw``, or None if nothing safe can be derived.
+
+    The host refusal's subject is either a ``policy_host`` (already an entry) or the whole
+    ``server_address`` the host was taken from; ``strip_url`` reduces the latter to its host.
+    """
+    if not isinstance(raw, str):
+        return None
+    s = raw.strip()
+    if not strip_url:
+        # Already an entry (a policy_host, or a subject the browser sent back): validate, never
+        # rewrite - the approval endpoint rebuilds the request from this string.
+        return s if s and _POLICY_HOST_ENTRY_RE.match(s) else None
+    if "://" in s:
+        s = s.split("://", 1)[1]
+    s = s.split("/", 1)[0]  # path (a CIDR entry never arrives via a refusal, so / cannot be kept)
+    if s.startswith("["):  # bracketed IPv6, with or without a port
+        if "]" not in s:
+            return None
+        s = s[1 : s.index("]")]
+    elif s.count(":") == 1:  # host:port - an IPv6 literal has more, and keeps them
+        s = s.split(":", 1)[0]
+    s = s.strip()
+    if not s or not _POLICY_HOST_ENTRY_RE.match(s):
+        return None
+    return s
+
+
+@dataclass(frozen=True)
+class ConsentRequest:
+    """One thing the operator can approve, with the risk in the SDK's own words."""
+
+    kind: str
+    scope: str  # stable id to persist an approval against
+    title: str
+    risk: str
+    env_var: str
+    subject: str | None = None
+    message: str = ""
+    grants: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def grantable(self) -> bool:
+        """Would approving this actually change the environment?"""
+        return bool(env_patch(self, {}))
+
+    def as_dict(self) -> dict:
+        return {
+            "kind": self.kind,
+            "scope": self.scope,
+            "title": self.title,
+            "risk": self.risk,
+            "env_var": self.env_var,
+            "subject": self.subject,
+            "message": self.message,
+            "grants": list(self.grants),
+            # Computed against an EMPTY env deliberately: the question is "is there a grant here at all",
+            # not "is it already in place on this machine" - which env_patch answers for the live env at
+            # approval time, and which must not disable the button (a refusal from a process started
+            # before the last approval still needs its explanation).
+            "grantable": self.grantable,
+        }
+
+
+def build_request(kind: str, subject: object = None, message: str = "") -> ConsentRequest | None:
+    """Construct a consent request from ``kind`` + ``subject``, validating both."""
+    if kind not in KINDS:
+        return None
+    text = message.strip()[:_MAX_MESSAGE] if isinstance(message, str) else ""
+    name = subject.strip() if isinstance(subject, str) and subject.strip() else None
+    env_var = _env_var(kind)
+
+    if kind == "trust_remote_code":
+        if name is not None and not _PROVIDER_NAME_RE.match(name):
+            name = None
+        shown = name or "this policy provider"
+        return ConsentRequest(
+            kind=kind,
+            scope="trust_remote_code",
+            title=f"Run model code from HuggingFace ({shown})?",
+            risk=(
+                f"{shown} loads the model with trust_remote_code=True: code stored in the "
+                "model repository executes on this machine, with your files and your robots. "
+                "Approve only for organisations you trust."
+            ),
+            env_var=env_var,
+            subject=name,
+            message=text,
+            grants=("run repository code for every policy load from now on",),
+        )
+
+    if kind == "agent_physical_motion":
+        # Subject is the peer that was refused, for the wording only: the grant is MACHINE-wide,
+        # because the gate reads one env var.
+        if name is not None and not _PROVIDER_NAME_RE.match(name):
+            name = None
+        shown = name or "a real robot"
+        return ConsentRequest(
+            kind=kind,
+            scope="agent_physical_motion",
+            title="Let the agent start motion on real robots?",
+            risk=(
+                f"The fleet agent asked to run a task on {shown}, which is real hardware. Approving "
+                "lets it start physical motion on ANY real robot on this mesh from now on - by itself, "
+                "from a chat sentence or a voice command, with no confirmation step and without the "
+                "check that the policy fits the robot that the play button performs. It cannot see your "
+                "room. Stopping is never gated either way, so 'everyone stop' works regardless."
+            ),
+            env_var=env_var,
+            subject=name,
+            message=text,
+            grants=("start tasks on real robots unattended, until you revoke it",),
+        )
+
+    if kind == "teleop_degree_units":
+        # Subject is the joint key the frame was refused for, for the dialog's wording only: the
+        # envelope is a MACHINE-wide setting, so the scope deliberately is not per-joint.
+        shown = f"joint {name}" if name else "this arm"
+        return ConsentRequest(
+            kind=kind,
+            scope="teleop_degree_units",
+            title="Set the teleop envelope to degrees?",
+            risk=(
+                f"The mesh refuses the teleop frame for {shown} because its safety envelope "
+                f"assumes RADIANS (4*pi, about 12.57) and the arm reports DEGREES (a wrist at 170). "
+                f"Approving widens the envelope to {_TELEOP_DEGREE_VALUE} units and the per-joint "
+                f"speed bound to {_TELEOP_DEGREE_SLEW} units/s for every teleop stream on this "
+                "machine - a wider envelope means a single frame may command a longer reach, so a "
+                "faulty leader can ask for a bigger move before the bound stops it. It stays an "
+                "envelope: a runaway three orders of magnitude out is still refused."
+            ),
+            env_var=env_var,
+            subject=name,
+            message=text,
+            grants=(
+                f"{env_var}={_TELEOP_DEGREE_VALUE} (how far one frame may reach)",
+                f"{_TELEOP_SLEW_ENV}={_TELEOP_DEGREE_SLEW} (how fast one joint may be driven)",
+            ),
+        )
+
+    if kind == "policy_host_allow":
+        # Subject is normalised to an ENTRY, not kept as the operator typed it: see _host_entry.
+        host = _host_entry(name)  # validate only: classify_refusal already derived the entry
+        shown = host or "that address"
+        return ConsentRequest(
+            kind=kind,
+            scope=f"policy_host_allow:{host}" if host else "policy_host_allow",
+            title=f"Let policies run on {shown}?",
+            risk=(
+                f"The mesh only talks to policy servers on loopback by default, and {shown} is not "
+                "in the allowlist. Approving sends your robots' camera frames and joint states to "
+                "that host, and lets the actions it returns drive real hardware - so it is trusted "
+                "with what the arms SEE and what they DO. Hostnames are matched literally with no "
+                "DNS resolution, so this trusts whatever that name resolves to at the time; an IP "
+                "literal keeps the boundary under your control."
+            ),
+            env_var=env_var,
+            subject=host,
+            message=text,
+            grants=(f"reach the policy server at {host}" if host else "nothing yet - the host could not be read",),
+        )
+
+    if kind == "policy_type_allow":
+        # One variable, two things the SDK refuses with it (provider and policy_type).
+        if name is not None and not _PROVIDER_NAME_RE.match(name):
+            name = None  # unparseable/hostile: ask, but grant nothing automatically
+        shown = name or "the requested policy"
+        return ConsentRequest(
+            kind=kind,
+            scope=f"policy_type_allow:{name}" if name else "policy_type_allow",
+            title=f"Allow the policy {shown}?",
+            risk=(
+                f"{shown} is not in this machine's policy allowlist, so the mesh refused to build "
+                "it. A policy decides what the arms DO, and approving lets this one be constructed "
+                "and run on real hardware from now on. Exactly this name is added - no wildcard, "
+                "and no other provider."
+            ),
+            env_var=env_var,
+            subject=name,
+            message=text,
+            grants=(f"build and run the policy {name}" if name else "nothing yet - the policy name could not be read",),
+        )
+
+    if name is not None and not _HF_ENTRY_RE.match(name):
+        name = None  # unparseable/hostile: ask, but grant nothing automatically
+    shown = name or "the requested model"
+    return ConsentRequest(
+        kind=kind,
+        scope=f"hf_repo_allow:{name}" if name else "hf_repo_allow",
+        title=f"Allow the model {shown}?",
+        risk=(
+            f"{shown} is not in this machine's HuggingFace allowlist, so the mesh refused "
+            "to load it. Approving adds exactly this repository - no other org, no wildcard."
+        ),
+        env_var=env_var,
+        subject=name,
+        message=text,
+        grants=(f"load {name}" if name else "nothing yet - the repository name could not be read",),
+    )
+
+
+def _agent_motion_request(verdict: Mapping[str, object], subject: object) -> ConsentRequest | None:
+    """The dashboard's own refusal: a gated, physical, not-granted verdict from agent_motion."""
+    if verdict.get("allowed") is not False or not verdict.get("gated") or not verdict.get("physical"):
+        return None
+    reason = verdict.get("reason")
+    return build_request("agent_physical_motion", subject, reason if isinstance(reason, str) else "")
+
+
+def classify_refusal(refusal: object, *, subject: object = None) -> ConsentRequest | None:
+    """Recognise a *continuable* refusal by its code, else ``None``.
+
+    ``refusal`` is an exception carrying ``.code`` and ``.subject``
+    (``SecurityError``, ``UntrustedRemoteCodeError``), or a mapping with ``code`` /
+    ``subject`` / ``message`` keys (the wire shape), or the verdict dict
+    :func:`~strands_robots.dashboard.agent_motion.agent_motion_allowed` returns, in
+    which case ``subject`` names the peer. A refusal with ``code`` ``None`` is not
+    continuable; a code outside :data:`~strands_robots.refusal_codes.REFUSAL_CODES` is
+    left for the message to explain. Prose is never inspected.
+    """
+    if isinstance(refusal, Mapping):
+        if "code" not in refusal and "allowed" in refusal:
+            return _agent_motion_request(refusal, subject)
+        code = refusal.get("code")
+        about = refusal.get("subject")
+        text = refusal.get("message", "")
+    elif isinstance(refusal, BaseException):
+        code = getattr(refusal, "code", None)
+        about = getattr(refusal, "subject", None)
+        text = str(refusal)
+    else:
+        return None  # a bare string has no code, so it has nothing to offer
+
+    if not isinstance(code, str):
+        return None
+    kind = _KIND_BY_CODE.get(code)
+    if kind is None:
+        return None
+    if kind == "policy_host_allow":
+        # The subject is the host, or the whole server_address the host was taken from.
+        about = _host_entry(about, strip_url=True)
+    return build_request(kind, about, text if isinstance(text, str) else "")
+
+
+def env_patch(request: ConsentRequest, env: Mapping[str, str] | None = None) -> dict[str, str]:
+    """The smallest env change that grants ``request``, given the current ``env``."""
+    env = env or {}
+    var = request.env_var
+
+    if request.kind in ("trust_remote_code", "agent_physical_motion"):
+        return {} if _truthy(env, var) else {var: "1"}
+
+    if request.kind == "teleop_degree_units":
+        patch = {}
+        if str(env.get(var, "")).strip() != _TELEOP_DEGREE_VALUE:
+            patch[var] = _TELEOP_DEGREE_VALUE
+        if str(env.get(_TELEOP_SLEW_ENV, "")).strip() != _TELEOP_DEGREE_SLEW:
+            patch[_TELEOP_SLEW_ENV] = _TELEOP_DEGREE_SLEW
+        return patch
+
+    if request.kind == "policy_host_allow":
+        host = _host_entry(request.subject)
+        if not host:
+            return {}
+        current = _entries(env, var)
+        return {} if host in current else {var: ",".join(current + [host])}
+
+    if request.kind == "policy_type_allow":
+        name = request.subject
+        if not name or not _PROVIDER_NAME_RE.match(name):
+            return {}
+        current = _entries(env, var)
+        # No org shortcut here: a policy name has no hierarchy, so nothing broader can cover it.
+        return {} if name in current else {var: ",".join(current + [name])}
+
+    if request.kind == "hf_repo_allow":
+        repo = request.subject
+        if not repo or not _HF_ENTRY_RE.match(repo):
+            return {}
+        current = _entries(env, var)
+        org = repo.split("/", 1)[0]
+        # An existing broader entry (the org, or the repo itself) already covers it.
+        if repo in current or org in current:
+            return {}
+        return {var: ",".join(current + [repo])}
+
+    return {}
+
+
+def granted_state(env: Mapping[str, str] | None = None) -> dict:
+    """What this machine currently grants - every kind, in one place."""
+    env = os.environ if env is None else env
+    value_abs = str(env.get(_env_var("teleop_degree_units"), "")).strip()
+    slew_abs = str(env.get(_TELEOP_SLEW_ENV, "")).strip()
+    return {
+        "kinds": list(KINDS),
+        "trust_remote_code": _truthy(env, _env_var("trust_remote_code")),
+        # Reported as what the environment ACTUALLY holds: a hand-set "on" is in force and must be
+        # visible, or the screen would deny a permission the agent is currently using.
+        "agent_physical_motion": _truthy(env, _env_var("agent_physical_motion")),
+        "hf_repo_allow": _entries(env, _env_var("hf_repo_allow")),
+        # Shown for the same reason the teleop envelope had to be: a grant with no surface cannot
+        # be revoked, while the dialog promises it can.
+        "policy_type_allow": _entries(env, _env_var("policy_type_allow")),
+        # Loopback is allowed by the SDK's own default and is NOT listed: this key answers "what has
+        # this machine been opened up to", and printing localhost as a grant would bury the one entry
+        # that matters among defaults nobody approved.
+        "policy_host_allow": _entries(env, _env_var("policy_host_allow")),
+        "teleop_degree_units": {
+            "granted": bool(value_abs or slew_abs),
+            "value_abs": value_abs or None,
+            "slew_abs": slew_abs or None,
+            # True only when it is exactly the pair this module grants; a hand-tuned wider bound
+            # must not be described to the operator as "the degrees preset".
+            "is_degree_preset": value_abs == _TELEOP_DEGREE_VALUE and slew_abs == _TELEOP_DEGREE_SLEW,
+        },
+    }
+
+
+def revoke_patch(request: ConsentRequest, env: Mapping[str, str] | None = None) -> dict[str, str]:
+    """The env change that takes a grant BACK, given the current ``env``."""
+    env = env or {}
+    var = request.env_var
+
+    if request.kind == "trust_remote_code":
+        return {var: ""} if _truthy(env, var) else {}
+
+    if request.kind == "agent_physical_motion":
+        # Cleared rather than set to "0": an absent line lets a stale 1 from a shell profile win the
+        # next restart, and a revocation that does not hold across a restart is the worst kind.
+        return {var: ""} if str(env.get(var, "")).strip() else {}
+
+    if request.kind == "teleop_degree_units":
+        # Back to the SDK defaults by CLEARING both, not by writing 12.566...:
+        # a number frozen here would silently override a future SDK default.
+        patch = {}
+        if str(env.get(var, "")).strip():
+            patch[var] = ""
+        if str(env.get(_TELEOP_SLEW_ENV, "")).strip():
+            patch[_TELEOP_SLEW_ENV] = ""
+        return patch
+
+    if request.kind in ("policy_host_allow", "policy_type_allow", "hf_repo_allow"):
+        entry = _host_entry(request.subject) if request.kind == "policy_host_allow" else request.subject
+        if not entry:
+            return {}
+        current = _entries(env, var)
+        if entry not in current:
+            # A broader entry the operator added by hand (an org, a CIDR) may still cover it; say
+            # nothing changed rather than narrowing something this module did not write.
+            return {}
+        return {var: ",".join(e for e in current if e != entry)}
+
+    return {}
+
+
+def attach_consent(payload: dict, *sources: object, subject: object = None) -> dict:
+    """Add ``needs_consent`` to an error ``payload`` if any source is continuable."""
+    for source in sources:
+        request = classify_refusal(source, subject=subject)
+        if request is not None:
+            payload["needs_consent"] = request.as_dict()
+            break
+    return payload

--- a/strands_robots/dashboard/consent.py
+++ b/strands_robots/dashboard/consent.py
@@ -26,12 +26,12 @@ from strands_robots.dashboard.agent_motion import MOTION_ENV as _AGENT_MOTION_EN
 
 #: Same charset the mesh allowlist validator accepts for one ENTRY (``<org>`` or
 #: ``<org>/<repo>``). Validates what would be written to the allowlist, not a sentence.
-_HF_ENTRY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,95}(/[A-Za-z0-9][A-Za-z0-9._-]{0,95})?$")
+_HF_ENTRY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,95}(/[A-Za-z0-9][A-Za-z0-9._-]{0,95})?\Z")
 #: A provider, policy type or peer name as it may be shown and granted.
-_PROVIDER_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+_PROVIDER_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}\Z")
 #: The SDK's own charset for an ENTRY in the host allowlist (security._POLICY_HOST_ENTRY_RE),
 #: copied rather than imported so this module stays free of the mesh at import time.
-_POLICY_HOST_ENTRY_RE = re.compile(r"^[A-Za-z0-9.:/_\-]{1,253}$")
+_POLICY_HOST_ENTRY_RE = re.compile(r"^[A-Za-z0-9.:/_\-]{1,253}\Z")
 
 #: The teleop slew bound has no refusal code yet, so it is never classified; it is written
 #: alongside the value bound because the degrees preset is one envelope with two edges.

--- a/tests/test_dashboard_consent.py
+++ b/tests/test_dashboard_consent.py
@@ -1,0 +1,306 @@
+"""A consent request is built from a refusal's code, never from its prose.
+
+Every refusal here is produced the way the dashboard will meet it: raised by
+``validate_command`` / ``validate_input_frame`` / ``_check_trust_remote_code``
+and caught, or arriving as the wire mapping ``{"code", "subject", "message"}``,
+or as the verdict dict ``agent_motion_allowed`` returns. The environment
+variable each card offers is asserted against ``refusal_codes.REFUSAL_GRANTS``,
+so this file cannot pass while the two drift apart.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+import pytest
+
+from strands_robots import refusal_codes
+from strands_robots.dashboard import agent_motion
+from strands_robots.dashboard.consent import (
+    KINDS,
+    ConsentRequest,
+    attach_consent,
+    build_request,
+    classify_refusal,
+    env_patch,
+    granted_state,
+    revoke_patch,
+)
+from strands_robots.mesh.security import ValidationError, validate_command, validate_input_frame
+from strands_robots.policies.factory import UntrustedRemoteCodeError, _check_trust_remote_code
+
+GRANTS = refusal_codes.REFUSAL_GRANTS
+
+
+@pytest.fixture(autouse=True)
+def _no_grants(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Refuse by default: an inherited grant would silence the refusal under test."""
+    for name in (*GRANTS.values(), "STRANDS_MESH_INPUT_SLEW_ABS", agent_motion.MOTION_ENV):
+        monkeypatch.delenv(name, raising=False)
+
+
+def _command(**overrides: Any) -> dict[str, Any]:
+    cmd: dict[str, Any] = {
+        "action": "execute",
+        "instruction": "pick up the cube",
+        "sender": "operator",
+        "policy_provider": "mock",
+    }
+    cmd.update(overrides)
+    return cmd
+
+
+def _refused(fn: Any) -> ValidationError | UntrustedRemoteCodeError:
+    try:
+        result = fn()
+    except (ValidationError, UntrustedRemoteCodeError) as refusal:
+        return refusal
+    raise AssertionError(f"expected a refusal, got {result!r}")
+
+
+def _classified(fn: Any) -> ConsentRequest:
+    request = classify_refusal(_refused(fn))
+    assert request is not None
+    return request
+
+
+# --- each coded refusal reaches the right card ----------------------------------------------
+
+
+def test_an_untrusted_provider_asks_for_trust_remote_code() -> None:
+    req = _classified(lambda: _check_trust_remote_code("lerobot_local"))
+    assert req.kind == "trust_remote_code"
+    assert req.subject == "lerobot_local"
+    assert req.env_var == GRANTS[refusal_codes.TRUST_REMOTE_CODE_REQUIRED]
+    assert "lerobot_local" in req.title
+    assert env_patch(req, {}) == {req.env_var: "1"}
+    assert env_patch(req, {req.env_var: "1"}) == {}
+    assert revoke_patch(req, {req.env_var: "1"}) == {req.env_var: ""}
+
+
+def test_a_repo_outside_the_allowlist_asks_for_exactly_that_repo() -> None:
+    req = _classified(lambda: validate_command(_command(pretrained_name_or_path="sketchy-org/model")))
+    assert req.kind == "hf_repo_allow"
+    assert req.subject == "sketchy-org/model"
+    assert req.env_var == GRANTS[refusal_codes.HF_REPO_NOT_ALLOWED]
+    assert req.scope == "hf_repo_allow:sketchy-org/model"
+    assert env_patch(req, {}) == {req.env_var: "sketchy-org/model"}
+    assert env_patch(req, {req.env_var: "nvidia"}) == {req.env_var: "nvidia,sketchy-org/model"}
+    assert env_patch(req, {req.env_var: "sketchy-org"}) == {}  # the org already covers it
+    assert revoke_patch(req, {req.env_var: "nvidia,sketchy-org/model"}) == {req.env_var: "nvidia"}
+    assert revoke_patch(req, {req.env_var: "sketchy-org"}) == {}  # never narrows what it did not write
+
+
+@pytest.mark.parametrize("field", ["policy_type", "policy_provider"])
+def test_type_and_provider_share_one_card_and_one_variable(field: str) -> None:
+    req = _classified(lambda: validate_command(_command(**{field: "mystery_net"})))
+    assert req.kind == "policy_type_allow"
+    assert req.subject == "mystery_net"
+    assert req.env_var == GRANTS[refusal_codes.POLICY_TYPE_NOT_ALLOWED]
+    assert env_patch(req, {}) == {req.env_var: "mystery_net"}
+    assert env_patch(req, {req.env_var: "mock,mystery_net"}) == {}
+    assert revoke_patch(req, {req.env_var: "mock,mystery_net"}) == {req.env_var: "mock"}
+
+
+def test_a_host_outside_the_allowlist_asks_for_that_host() -> None:
+    req = _classified(lambda: validate_command(_command(policy_host="10.9.9.9")))
+    assert req.kind == "policy_host_allow"
+    assert req.subject == "10.9.9.9"
+    assert req.env_var == GRANTS[refusal_codes.POLICY_HOST_NOT_ALLOWED]
+    assert env_patch(req, {}) == {req.env_var: "10.9.9.9"}
+    assert revoke_patch(req, {req.env_var: "10.9.9.9,10.0.0.7"}) == {req.env_var: "10.0.0.7"}
+
+
+def test_a_server_address_is_reduced_to_the_host_entry_the_allowlist_takes() -> None:
+    """The subject is the whole address; the grant is the host inside it."""
+    req = _classified(lambda: validate_command(_command(server_address="tcp://10.9.9.9:5555")))
+    assert req.kind == "policy_host_allow"
+    assert req.subject == "10.9.9.9"
+    assert env_patch(req, {}) == {GRANTS[refusal_codes.POLICY_HOST_NOT_ALLOWED]: "10.9.9.9"}
+
+
+def test_a_teleop_frame_past_the_envelope_asks_for_the_degrees_preset() -> None:
+    req = _classified(lambda: validate_input_frame({"shoulder.pos": 900.0}))
+    assert req.kind == "teleop_degree_units"
+    assert req.subject == "shoulder.pos"
+    assert req.env_var == GRANTS[refusal_codes.TELEOP_VALUE_OUT_OF_RANGE]
+    assert "shoulder.pos" in req.risk
+    patch = env_patch(req, {})
+    assert patch == {req.env_var: "400", "STRANDS_MESH_INPUT_SLEW_ABS": "800"}
+    assert env_patch(req, patch) == {}
+    assert revoke_patch(req, patch) == {req.env_var: "", "STRANDS_MESH_INPUT_SLEW_ABS": ""}
+
+
+def test_every_code_in_the_contract_has_a_card() -> None:
+    for code in refusal_codes.REFUSAL_CODES:
+        req = classify_refusal(ValidationError("", code=code, subject="x"))
+        assert req is not None, code
+        assert req.kind in KINDS
+        assert req.env_var == GRANTS[code]
+
+
+# --- recognition is by code, not by wording ---------------------------------------------------
+
+
+def test_the_same_code_with_different_prose_gives_the_same_request() -> None:
+    a = classify_refusal(
+        ValidationError("policy_host='10.9.9.9' not in allowlist.", code="POLICY_HOST_NOT_ALLOWED", subject="10.9.9.9")
+    )
+    b = classify_refusal(ValidationError("nope", code="POLICY_HOST_NOT_ALLOWED", subject="10.9.9.9"))
+    assert a is not None and b is not None
+    assert dataclasses.replace(a, message="") == dataclasses.replace(b, message="")
+    assert a.message == "policy_host='10.9.9.9' not in allowlist."
+
+
+def test_prose_that_names_a_grant_but_carries_no_code_is_not_continuable() -> None:
+    text = "pretrained_name_or_path='evil/repo' not in allowlist. Set STRANDS_MESH_HF_REPO_ALLOW to add it."
+    assert classify_refusal(text) is None
+    assert classify_refusal(ValidationError(text)) is None
+    assert classify_refusal({"message": text}) is None
+
+
+def test_a_rejection_the_operator_cannot_grant_has_no_card() -> None:
+    refusal = _refused(lambda: validate_command(_command(instruction="x" * 99999)))
+    assert refusal.code is None
+    assert classify_refusal(refusal) is None
+
+
+def test_an_unknown_code_falls_through_to_the_message() -> None:
+    assert classify_refusal(ValidationError("later", code="SOMETHING_NEW", subject="x")) is None
+    assert classify_refusal({"code": "SOMETHING_NEW", "subject": "x", "message": "later"}) is None
+    assert classify_refusal({"code": 7, "subject": "x"}) is None
+
+
+@pytest.mark.parametrize("source", [None, "", 42, ValueError("boom"), {}, {"status": "error"}])
+def test_things_that_are_not_refusals_are_not_consent(source: object) -> None:
+    assert classify_refusal(source) is None
+
+
+# --- the wire shape --------------------------------------------------------------------------
+
+
+def test_the_wire_mapping_classifies_like_the_exception() -> None:
+    exc = _refused(lambda: validate_command(_command(pretrained_name_or_path="sketchy-org/model")))
+    wire = {"code": exc.code, "subject": exc.subject, "message": str(exc)}
+    assert classify_refusal(wire) == classify_refusal(exc)
+
+
+def test_the_message_is_carried_for_display_and_bounded() -> None:
+    req = classify_refusal({"code": "HF_REPO_NOT_ALLOWED", "subject": "a/b", "message": "x" * 5000})
+    assert req is not None
+    assert len(req.message) == 2000
+    assert classify_refusal({"code": "HF_REPO_NOT_ALLOWED", "subject": "a/b", "message": 3}) is not None
+
+
+# --- the dashboard's own refusal -------------------------------------------------------------
+
+
+def test_the_agent_motion_verdict_is_accepted_as_the_dict_it_is() -> None:
+    verdict = agent_motion.agent_motion_allowed("task", peer=None, target="arm-left", env={})
+    assert verdict["allowed"] is False
+    req = classify_refusal(verdict, subject="arm-left")
+    assert req is not None
+    assert req.kind == "agent_physical_motion"
+    assert req.subject == "arm-left"
+    assert req.env_var == agent_motion.MOTION_ENV
+    assert req.message == verdict["reason"]
+    assert env_patch(req, {}) == {agent_motion.MOTION_ENV: "1"}
+    assert revoke_patch(req, {agent_motion.MOTION_ENV: "on"}) == {agent_motion.MOTION_ENV: ""}
+
+
+def test_a_verdict_that_allows_or_is_granted_is_not_a_request() -> None:
+    assert classify_refusal(agent_motion.agent_motion_allowed("status", peer=None, env={})) is None
+    granted = agent_motion.agent_motion_allowed("task", peer=None, env={agent_motion.MOTION_ENV: "1"})
+    assert granted["allowed"] is True
+    assert classify_refusal(granted) is None
+
+
+def test_the_grant_and_the_gate_agree_on_what_counts_as_granted() -> None:
+    req = build_request("agent_physical_motion", "arm-left")
+    assert req is not None
+    env = dict(env_patch(req, {}))
+    assert agent_motion.agent_motion_allowed("task", peer=None, env=env)["allowed"] is True
+    env.update(revoke_patch(req, env))
+    assert agent_motion.agent_motion_allowed("task", peer=None, env=env)["allowed"] is False
+
+
+# --- a hostile subject is shown as nothing and grants nothing --------------------------------
+
+
+@pytest.mark.parametrize(
+    ("code", "subject"),
+    [
+        ("HF_REPO_NOT_ALLOWED", "evil,nvidia"),
+        ("POLICY_TYPE_NOT_ALLOWED", "mock,evil"),
+        ("POLICY_HOST_NOT_ALLOWED", "10.9.9.9,0.0.0.0/0"),
+        ("TRUST_REMOTE_CODE_REQUIRED", "x y"),
+    ],
+)
+def test_a_subject_that_is_not_one_entry_asks_but_grants_nothing(code: str, subject: str) -> None:
+    req = classify_refusal(ValidationError("", code=code, subject=subject))
+    assert req is not None
+    assert req.subject is None
+    assert subject not in req.title
+    assert env_patch(req, {}) == {} or req.kind == "trust_remote_code"
+    assert not req.grantable or req.kind == "trust_remote_code"
+
+
+# --- the grants the machine holds, and the payload that offers them --------------------------
+
+
+def test_granted_state_reads_every_variable_from_the_contract() -> None:
+    env = {
+        GRANTS["TRUST_REMOTE_CODE_REQUIRED"]: "1",
+        GRANTS["HF_REPO_NOT_ALLOWED"]: "nvidia, my-org/model",
+        GRANTS["POLICY_TYPE_NOT_ALLOWED"]: "mock",
+        GRANTS["POLICY_HOST_NOT_ALLOWED"]: "10.9.9.9",
+        GRANTS["TELEOP_VALUE_OUT_OF_RANGE"]: "400",
+        "STRANDS_MESH_INPUT_SLEW_ABS": "800",
+        agent_motion.MOTION_ENV: "on",
+    }
+    state = granted_state(env)
+    assert state["kinds"] == list(KINDS)
+    assert state["trust_remote_code"] is True
+    assert state["hf_repo_allow"] == ["nvidia", "my-org/model"]
+    assert state["policy_type_allow"] == ["mock"]
+    assert state["policy_host_allow"] == ["10.9.9.9"]
+    assert state["agent_physical_motion"] is True
+    assert state["teleop_degree_units"] == {
+        "granted": True,
+        "value_abs": "400",
+        "slew_abs": "800",
+        "is_degree_preset": True,
+    }
+
+
+def test_a_hand_tuned_teleop_bound_is_granted_but_not_called_the_preset() -> None:
+    env = {GRANTS["TELEOP_VALUE_OUT_OF_RANGE"]: "1000"}
+    teleop = granted_state(env)["teleop_degree_units"]
+    assert teleop == {"granted": True, "value_abs": "1000", "slew_abs": None, "is_degree_preset": False}
+    assert granted_state({})["teleop_degree_units"]["granted"] is False
+
+
+def test_attach_consent_offers_the_first_continuable_source_only() -> None:
+    plain = ValidationError("schema failure")
+    coded = _refused(lambda: validate_command(_command(policy_host="10.9.9.9")))
+    payload = attach_consent({"status": "error"}, plain, coded, "some text")
+    assert payload["needs_consent"]["kind"] == "policy_host_allow"
+    assert payload["needs_consent"]["env_var"] == GRANTS["POLICY_HOST_NOT_ALLOWED"]
+    assert payload["needs_consent"]["grantable"] is True
+    assert "needs_consent" not in attach_consent({"status": "error"}, plain, "text", None)
+
+
+def test_as_dict_is_json_shaped() -> None:
+    req = build_request("hf_repo_allow", "my-org/model", "why")
+    assert req is not None
+    d = req.as_dict()
+    assert set(d) == {"kind", "scope", "title", "risk", "env_var", "subject", "message", "grants", "grantable"}
+    assert d["grants"] == ["load my-org/model"]
+    assert d["env_var"] == GRANTS["HF_REPO_NOT_ALLOWED"]
+
+
+def test_build_request_refuses_a_kind_it_does_not_know() -> None:
+    assert build_request("sudo") is None
+    assert env_patch(ConsentRequest("sudo", "sudo", "t", "r", "X"), {}) == {}
+    assert revoke_patch(ConsentRequest("sudo", "sudo", "t", "r", "X"), {"X": "1"}) == {}


### PR DESCRIPTION
**What**

`strands_robots/dashboard/consent.py`: `classify_refusal` turns a continuable refusal into a `ConsentRequest` the dashboard can show and grant. It reads `code` and `subject` from the exception, the wire mapping `{code, subject, message}`, or the `agent_motion_allowed` verdict; the environment variable each card offers comes from `refusal_codes.REFUSAL_GRANTS`. The message is carried for display only. One sentence in `docs/security.md` names it as the in-tree consumer of the contract.

**Why**

The consent card was the consumer still matching env-var names and regexes in refusal text, which `docs/security.md` calls the bug the codes exist to end.

**Tests**

`tests/test_dashboard_consent.py` (32) raises the real refusals and pins kind, subject, grant variable, patch and revoke per code; same code with different prose gives the same request; prose without a code gives none.

Follow-up: teleop slew refusals carry no code yet, so the slew card waits for one.

---

## Review Rounds

| Round | Concern | Fix commit | Pin test |
|---|---|---|---|
| R1 | Regex anchoring: `$` -> `\Z` in 3 allowlist patterns (security: trailing newline bypass) | `875b0f3` | `tests/test_allowlist_patterns_anchor_at_the_end_of_the_string.py` (whole-tree grader, 11 tests) |