### PR TITLE
fix(registry): aloha is two Dynamixel ViperX arms, not two Feetech SO arms

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,8 +468,8 @@ first use. List them at runtime with `from strands_robots import list_robots; li
 | **Mobile manip** | 1 | google_robot |
 
 **Hardware-capable** (drivable with `mode="real"` via LeRobot): `so100`,
-`so101`, `koch`, `omx`, `hope_jr`, `aloha`, `bi_openarm`, `reachy2`,
-`unitree_g1`, `lekiwi`, `earthrover`. All are simulatable.
+`so101`, `koch`, `omx`, `hope_jr`, `bi_so_follower`, `bi_openarm`, `reachy2`,
+`unitree_g1`, `lekiwi`, `earthrover`.
 
 ### Adding a robot
 

--- a/changelog.d/3406-aloha-is-not-two-so-arms.md
+++ b/changelog.d/3406-aloha-is-not-two-so-arms.md
@@ -1,0 +1,22 @@
+### Fixed: `aloha` no longer declares a Feetech lerobot type for its Dynamixel servos
+
+`aloha` is two ViperX 300s arms on Dynamixel Protocol 2.0, and its registry
+entry declared `hardware.lerobot_type = "bi_so_follower"` - two SO-100/SO-101
+followers on a Feetech STS3215 bus. `Robot("aloha", mode="real")` built that
+`BiSOFollower`, so the arm a caller got spoke a wire protocol its servos do not
+answer. lerobot ships no ALOHA robot, so there was nothing correct to point at:
+the entry is now simulation-only, and `mode="real"` refuses by name instead,
+reporting the native Dynamixel driver registered for it.
+
+`bi_so_follower` was also an *alias* of `aloha`, so the owner of two SO-101 arms
+who asked for that name got the 16-joint ViperX twin. It is now a robot of its
+own - `bi_so_follower`, aliases `bi_so100`/`bi_so101` - carrying the
+`bi_so_follower` lerobot type that describes it. Both SO spellings resolve to
+one entry because lerobot registers `so100_follower` and `so101_follower` on a
+single config class.
+
+`test_every_strands_lerobot_type_is_real` could not see this: `bi_so_follower`
+is a name lerobot really registers, which is all that check asks.
+`test_a_declared_lerobot_type_drives_the_motor_family_the_description_names`
+now derives each lerobot type's `MotorsBus` from lerobot's own source and
+refuses an entry whose description names the other servo family.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,7 +17,7 @@ graph TB
 
     subgraph factory_layer[Robot factory  -  strands_robots/robot.py]
         ROBOT["Robot()"]
-        REGISTRY["registry/robots.json<br/>73 robots, 8 categories"]
+        REGISTRY["registry/robots.json<br/>74 robots, 8 categories"]
         ROBOT --> REGISTRY
     end
 
@@ -77,7 +77,7 @@ graph TB
 | Module | What it owns | Key types |
 |--------|--------------|-----------|
 | `strands_robots/robot.py` | Factory `Robot(name, mode, backend, **kwargs)`. Name resolution, sim/real dispatch, mesh attach. | `Robot()` function |
-| `strands_robots/registry/` | 73 robots, 121 aliases, 8 categories. `robots.json` is source of truth. | `list_robots()`, `resolve_name()`, `get_robot()` |
+| `strands_robots/registry/` | 74 robots, 122 aliases, 8 categories. `robots.json` is source of truth. | `list_robots()`, `resolve_name()`, `get_robot()` |
 | `strands_robots/simulation/` | MuJoCo `AgentTool` - 77 actions. | `Simulation`, `SimWorld`, `SimRobot`, `SimObject`, `SimCamera` |
 | `strands_robots/simulation/base.py` | Backend ABC for future Isaac/Newton backends. | `SimEngine` |
 | `strands_robots/hardware_robot.py` | Real-servo path. Async task execution + status. | `Robot` (class), `TaskStatus`, `RobotTaskState` |

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -59,5 +59,5 @@ training a policy, and the full streaming data loop, each building on the last.
 ## See also
 
 - [Policy providers](../policies/overview.md) - GR00T, LeRobot Local, Cosmos 3.
-- [Robot catalog](../robots/index.md) - all 73 robots.
+- [Robot catalog](../robots/index.md) - all 74 robots.
 - [Real hardware](../hardware/robot-control.md) - same code, `mode="real"`.

--- a/docs/robots/bimanual.md
+++ b/docs/robots/bimanual.md
@@ -1,25 +1,30 @@
 ---
-description: Two-arm robots - Aloha, Trossen WX-AI, OpenArm bimanual.
+description: Two-arm robots - Aloha, bimanual SO-ARM, Trossen WX-AI, OpenArm bimanual.
 ---
 
 # Bimanual rigs
 
-Two-arm robots - Aloha, Trossen WX-AI, OpenArm bimanual.
+Two-arm robots - Aloha, bimanual SO-ARM, Trossen WX-AI, OpenArm bimanual.
 
 ```python
 from strands_robots import Robot
 sim = Robot("aloha")            # Trossen Aloha bimanual
 sim = Robot("bi_openarm")       # OpenArm bimanual
 sim = Robot("trossen_wxai")     # Trossen WX-AI
+
+# Two SO-101 followers on one Feetech bus - hardware only, no sim twin.
+arms = Robot("bi_so_follower", mode="real",
+             left_arm_config=..., right_arm_config=...)
 ```
 
 ## Catalog
 
 | Name | Description | Joints | Aliases |
 |------|-------------|-------:|---------|
-| `aloha` | ALOHA Bimanual (2x ViperX 300s, 14-DOF + 2 grippers) | 28 | `agibot_dual_arm`, `agibot_dual_arm_dexhand`, `agibot_dual_arm_full`, `agibot_dual_arm_gripper`, `agibot_genie1`, `bi_so_follower`, `galaxea_r1_pro` |
+| `aloha` | ALOHA Bimanual (2x ViperX 300s, 14-DOF + 2 grippers) _(simulation-only: lerobot ships no ALOHA robot)_ | 28 | `agibot_dual_arm`, `agibot_dual_arm_dexhand`, `agibot_dual_arm_full`, `agibot_dual_arm_gripper`, `agibot_genie1`, `galaxea_r1_pro` |
 | `bi_openarm` | Bi-manual OpenArm (dual-arm coordination) _(hardware-only, no sim asset)_ | ? | `bi_openarm_follower`, `dual_openarm`, `openarm_bimanual` |
 | `bi_rebot_b601` | Bi-manual reBot B601-DM (dual 6-DOF + gripper, Damiao CAN motors) _(hardware-only, no sim asset)_ | ? | `bi_rebot_b601_follower`, `dual_rebot_b601` |
+| `bi_so_follower` | Bimanual SO-ARM follower (2x SO-100/SO-101, 6-DOF each, Feetech STS3215) _(hardware-only, no sim asset)_ | ? | `bi_so100`, `bi_so101` |
 | `trossen_wxai` | Trossen WidowX AI Bimanual | 17 | `trossen_ai_bimanual` |
 
 ## Featured renders

--- a/docs/robots/index.md
+++ b/docs/robots/index.md
@@ -1,10 +1,10 @@
 ---
-description: 73 robots across 8 categories. Every name addressable from Robot('name').
+description: 74 robots across 8 categories. Every name addressable from Robot('name').
 ---
 
 # Robot catalog
 
-`strands-robots` ships with a registry of **73 robots** across 8 categories. Every robot
+`strands-robots` ships with a registry of **74 robots** across 8 categories. Every robot
 is addressable by name through the factory:
 
 ```python
@@ -26,7 +26,7 @@ sim = Robot("aloha")
 
     [:octicons-arrow-right-24: Arms catalog](arms.md)
 
--   :material-arrow-left-right:{ .lg .middle } **Bimanual** · 4
+-   :material-arrow-left-right:{ .lg .middle } **Bimanual** · 5
 
     ---
 

--- a/strands_robots/registry/robots.json
+++ b/strands_robots/registry/robots.json
@@ -395,16 +395,12 @@
         "scene_xml": "scene.xml",
         "robot_descriptions_module": "aloha_mj_description"
       },
-      "hardware": {
-        "lerobot_type": "bi_so_follower"
-      },
       "aliases": [
         "agibot_dual_arm",
         "agibot_dual_arm_dexhand",
         "agibot_dual_arm_full",
         "agibot_dual_arm_gripper",
         "agibot_genie1",
-        "bi_so_follower",
         "galaxea_r1_pro"
       ]
     },
@@ -430,6 +426,17 @@
       "aliases": [
         "bi_rebot_b601_follower",
         "dual_rebot_b601"
+      ]
+    },
+    "bi_so_follower": {
+      "description": "Bimanual SO-ARM follower (2x SO-100/SO-101, 6-DOF each, Feetech STS3215)",
+      "category": "bimanual",
+      "hardware": {
+        "lerobot_type": "bi_so_follower"
+      },
+      "aliases": [
+        "bi_so100",
+        "bi_so101"
       ]
     },
     "trossen_wxai": {

--- a/tests/drivers/test_native_driver_named_when_lerobot_has_no_type.py
+++ b/tests/drivers/test_native_driver_named_when_lerobot_has_no_type.py
@@ -9,7 +9,7 @@ Mini has no lerobot robot type, so before this driver ``mode="real"`` raised
 
 The Reachy Mini also declares ``hardware.driver="strands"`` on its registry
 entry, so :func:`~strands_robots.drivers.resolve_driver` sends it to its driver
-and it never meets that refusal. Four robots the Dynamixel driver serves declare
+and it never meets that refusal. Five robots the Dynamixel driver serves declare
 nothing, so the default routes them to lerobot - which has no robot type for any
 of them. They reached the generic listing of lerobot's sixteen robot types, and
 that listing never mentioned that this package ships the driver that builds
@@ -31,10 +31,9 @@ asked for.
 
 What is deliberately unchanged: which driver *wins*. Resolution precedence is
 untouched, no registry entry gains a declaration, and a robot lerobot can build
-still goes to lerobot. Whether ``koch`` and ``aloha`` - which have both a
-working lerobot type and a native driver - should prefer the native one is a
-preference, and ``unitree_g1`` shows the registry is where such a preference is
-declared. This changes only what a caller is told when the driver they were
+still goes to lerobot. Whether ``koch`` - the one robot left with both a working
+lerobot type and a native driver - should prefer the native one is a preference,
+and ``unitree_g1`` shows the registry is where such a preference is declared. This changes only what a caller is told when the driver they were
 routed to cannot build the robot at all.
 """
 
@@ -60,6 +59,7 @@ from strands_robots.registry import get_robot, list_robots
 #: which is how the Franka arms and the UR arms arrived here, each having moved
 #: out of :data:`NO_DRIVER_OF_EITHER_KIND` when its own driver landed.
 NATIVELY_DRIVEN_WITHOUT_A_LEROBOT_TYPE = (
+    "aloha",
     "vx300s",
     "wx250s",
     "trossen_wxai",
@@ -345,9 +345,14 @@ class TestNothingElseChanged:
         robot: Any = Robot(name, mode="real", driver="strands", port="/dev/ttyUSB0")
         assert type(robot) is get_native_driver_class(name)
 
-    @pytest.mark.parametrize("name", ["koch", "aloha"])
+    @pytest.mark.parametrize("name", ["koch"])
     def test_a_robot_lerobot_can_resolve_is_not_diverted(self, name: str) -> None:
-        """These have both drivers, so the preference is the registry's to declare."""
+        """This has both drivers, so the preference is the registry's to declare.
+
+        ``koch`` alone: ``aloha`` held this position on the strength of a
+        ``lerobot_type`` naming two Feetech SO arms, and moved into
+        :data:`NATIVELY_DRIVEN_WITHOUT_A_LEROBOT_TYPE` when that went away.
+        """
         assert _type_handed_to_lerobot(name) in _lerobot_robot_types()
         refusal = _refusal_for(name)
         assert "driver='strands'" not in refusal

--- a/tests/test_lerobot_hardware_conformance.py
+++ b/tests/test_lerobot_hardware_conformance.py
@@ -169,3 +169,204 @@ def test_from_source_entries_are_documented() -> None:
     # Sanity: at least verify the expected entries are present
     assert "rebot_b601" in from_source
     assert "bi_rebot_b601" in from_source
+
+
+# ---------------------------------------------------------------------------
+# Motor family. ``test_every_strands_lerobot_type_is_real`` asks whether a
+# declared ``lerobot_type`` is a name lerobot registers, and that is all it can
+# ask: ``aloha`` ("2x ViperX 300s") declared ``bi_so_follower``, a real name, and
+# passed for the registry's whole history while building a Feetech bus for
+# Dynamixel servos. A servo family is a wire protocol - Feetech is a half-duplex
+# TTL bus, Dynamixel is Protocol 2.0 - so the two are not configurable into each
+# other. A description naming one while its lerobot_type drives the other
+# describes a robot the mapping cannot move, and both facts are already in the
+# tree, so the contradiction is readable without hardware.
+# ---------------------------------------------------------------------------
+
+_BUS_RE = re.compile(r"\b(FeetechMotorsBus|DynamixelMotorsBus)\b")
+
+#: A bimanual package composes single arms rather than holding a bus, so the
+#: scan follows ``from ..so_follower import`` to where the bus is built.
+_SIBLING_IMPORT_RE = re.compile(r"^from \.\.([a-z0-9_]+) import", re.MULTILINE)
+
+#: Words that name a motor family unambiguously: a bus, a protocol, or a servo
+#: part number. Vendor names are deliberately absent - Trossen sells ViperX and
+#: WidowX arms on Dynamixel *and* supplies the MuJoCo model this registry loads
+#: for the Feetech SO-ARM100 ("TrossenRobotics SO-ARM100 (6-DOF, Feetech
+#: servos)"), so "Trossen" names no family and grading on it would report that
+#: correct entry as a contradiction.
+_FAMILY_MARKERS: dict[str, tuple[str, ...]] = {
+    "DynamixelMotorsBus": ("dynamixel", "viperx", "widowx", "xm430", "xm540", "xl330", "xl430"),
+    "FeetechMotorsBus": ("feetech", "sts3215", "sts3032", "scs0009"),
+}
+
+
+def _buses_in_package(pkg: Path, seen: frozenset[Path] = frozenset()) -> set[str]:
+    """Report the motor-bus classes ``pkg`` builds, following sibling re-exports.
+
+    Args:
+        pkg: A lerobot robot package directory.
+        seen: Packages already visited, so a cyclic re-export terminates.
+
+    Returns:
+        The bus class names found, empty for a robot on neither bus (CAN,
+        DDS, ZMQ).
+    """
+    if pkg in seen:
+        return set()
+    seen = seen | {pkg}
+    found: set[str] = set()
+    for py in sorted(pkg.glob("*.py")):
+        source = py.read_text(encoding="utf-8", errors="ignore")
+        found |= set(_BUS_RE.findall(source))
+        for sibling in _SIBLING_IMPORT_RE.findall(source):
+            candidate = pkg.parent / sibling
+            if candidate.is_dir():
+                found |= _buses_in_package(candidate, seen)
+    return found
+
+
+@pytest.fixture(scope="module")
+def lerobot_bus_by_type() -> dict[str, str]:
+    """Map lerobot robot type -> the single motor bus its package builds.
+
+    A package building two buses is left out rather than guessed at: there is no
+    one family for such a type, so no description of it can contradict one.
+    """
+    robots_dir = _find_lerobot_robots_dir()
+    if robots_dir is None:
+        pytest.skip("LeRobot robots package not found (sim-only / no [lerobot] extra)")
+    by_type: dict[str, str] = {}
+    configs = sorted(robots_dir.rglob("config*.py")) + sorted(robots_dir.rglob("configuration*.py"))
+    for cfg in configs:
+        registered = _REGISTER_RE.findall(cfg.read_text(encoding="utf-8", errors="ignore"))
+        if not registered:
+            continue
+        buses = _buses_in_package(cfg.parent)
+        if len(buses) == 1:
+            for name in registered:
+                by_type[name] = next(iter(buses))
+    return by_type
+
+
+@pytest.fixture(scope="module")
+def strands_descriptions() -> dict[str, str]:
+    """Map strands robot name -> its registry description."""
+    data = json.loads(REGISTRY_PATH.read_text())
+    robots = data.get("robots", data)
+    return {name: str(info.get("description", "")) for name, info in robots.items()}
+
+
+def _family_contradictions(
+    hw_types: dict[str, str],
+    descriptions: dict[str, str],
+    bus_by_type: dict[str, str],
+) -> dict[str, str]:
+    """Report entries describing one servo family while declaring the other's type.
+
+    Args:
+        hw_types: Strands robot name -> declared ``hardware.lerobot_type``.
+        descriptions: Strands robot name -> registry description.
+        bus_by_type: lerobot type -> the motor bus its package builds.
+
+    Returns:
+        Offending robot name -> what it describes against what it drives. A type
+        whose bus is unknown is not graded: there is no family to contradict.
+    """
+    contradictions: dict[str, str] = {}
+    for name, lerobot_type in sorted(hw_types.items()):
+        bus = bus_by_type.get(lerobot_type)
+        if bus is None:
+            continue
+        description = descriptions.get(name, "").lower()
+        for family, markers in _FAMILY_MARKERS.items():
+            if family == bus:
+                continue
+            named = [marker for marker in markers if marker in description]
+            if named:
+                contradictions[name] = f"describes {named} but {lerobot_type} builds a {bus}"
+    return contradictions
+
+
+def test_a_declared_lerobot_type_drives_the_motor_family_the_description_names(
+    strands_hw_types_all: dict[str, str],
+    strands_descriptions: dict[str, str],
+    lerobot_bus_by_type: dict[str, str],
+) -> None:
+    """No entry may describe one servo family and declare a type driving the other.
+
+    The regression for ``aloha``, whose description named ViperX 300s (Dynamixel
+    XM540/XM430) while ``hardware.lerobot_type`` was ``bi_so_follower`` - two
+    SO-ARM followers on a Feetech STS3215 bus. ``Robot("aloha", mode="real")``
+    built that bus and would have written Feetech packets to Dynamixel servos.
+    """
+    contradictions = _family_contradictions(strands_hw_types_all, strands_descriptions, lerobot_bus_by_type)
+    assert not contradictions, (
+        "Registry entries whose description names one motor family while their "
+        "hardware.lerobot_type drives the other. A servo family is a wire "
+        "protocol, so mode='real' would speak the wrong one to the servos: "
+        f"{contradictions}"
+    )
+
+
+def test_the_motor_family_derivation_grades_something(
+    strands_hw_types_all: dict[str, str],
+    strands_descriptions: dict[str, str],
+    lerobot_bus_by_type: dict[str, str],
+) -> None:
+    """Non-vacuity: the rule above passes trivially if it derives nothing.
+
+    Three ways it could go quiet, each pinned: neither bus recognised, the
+    bimanual sibling hop lost (``bi_so_follower`` builds no bus of its own, so
+    without it every bimanual entry grades as unknown - which is the entry the
+    rule exists for), and no description naming a family at all.
+    """
+    assert set(lerobot_bus_by_type.values()) == set(_FAMILY_MARKERS), (
+        f"expected both motor families among lerobot's robots, got {sorted(set(lerobot_bus_by_type.values()))}"
+    )
+    assert lerobot_bus_by_type.get("bi_so_follower") == "FeetechMotorsBus", (
+        "bi_so_follower composes two so_follower arms, so its bus is only reachable through the sibling-import hop"
+    )
+    claiming = {
+        name
+        for name, lerobot_type in strands_hw_types_all.items()
+        if (bus := lerobot_bus_by_type.get(lerobot_type))
+        and any(marker in strands_descriptions.get(name, "").lower() for marker in _FAMILY_MARKERS[bus])
+    }
+    assert claiming, "no registry description names the motor family its lerobot_type drives"
+
+
+#: ``aloha`` exactly as it stood before this rule existed: a ViperX description
+#: declaring the lerobot type for two Feetech SO arms.
+_ALOHA_BEFORE = ("ALOHA Bimanual (2x ViperX 300s, 14-DOF + 2 grippers)", "bi_so_follower")
+
+
+def test_the_rule_reports_the_entry_that_motivated_it(lerobot_bus_by_type: dict[str, str]) -> None:
+    """Grade the rule, not the registry: a correct registry passes any rule.
+
+    The live-registry cell above goes quiet the moment the registry is right,
+    so on its own it pins nothing about which words the rule recognises. Here
+    the offending entry is supplied, so narrowing ``_FAMILY_MARKERS`` until it
+    no longer reads "ViperX" as Dynamixel fails.
+    """
+    description, lerobot_type = _ALOHA_BEFORE
+    reported = _family_contradictions({"aloha": lerobot_type}, {"aloha": description}, lerobot_bus_by_type)
+    assert "aloha" in reported, (
+        f"the rule must report {description!r} declaring {lerobot_type!r}; "
+        f"got {reported} - _FAMILY_MARKERS no longer recognises this description"
+    )
+
+
+def test_a_correctly_described_entry_is_not_reported(lerobot_bus_by_type: dict[str, str]) -> None:
+    """Over-reach: the vendor that supplies both families is not a family claim.
+
+    ``so100`` reads "TrossenRobotics SO-ARM100 (6-DOF, Feetech servos)" - Trossen
+    sells Dynamixel ViperX arms and supplies this Feetech arm's MuJoCo model, so
+    a rule counting the vendor as a Dynamixel marker reports a correct entry.
+    """
+    reported = _family_contradictions(
+        {"so100": "so100_follower"},
+        {"so100": "TrossenRobotics SO-ARM100 (6-DOF, Feetech servos)"},
+        lerobot_bus_by_type,
+    )
+    assert reported == {}, f"a correct entry was reported as contradictory: {reported}"


### PR DESCRIPTION
`aloha` declared `hardware.lerobot_type = "bi_so_follower"`, so `Robot("aloha", mode="real")` built lerobot's `BiSOFollower` — **two SO-100/SO-101 followers on a Feetech STS3215 bus**. An ALOHA is two ViperX 300s arms on **Dynamixel Protocol 2.0**.

![aloha declared a Feetech lerobot type for Dynamixel servos](https://raw.githubusercontent.com/cagataycali/robots/pr3406-assets/aloha_mismatch.png)

## What the entry claimed vs what it built

Measured on `main` (`SOFollowerRobotConfig(port="/dev/null")` for each arm):

```
Robot("aloha", mode="real", left_arm_config=..., right_arm_config=...)
  -> BiSOFollower -> SOFollower
     bus class    : FeetechMotorsBus
     motor models : ['sts3215']
     motor names  : shoulder_pan, shoulder_lift, elbow_flex, wrist_flex, wrist_roll, gripper
```

The two buses are not configurable into each other. The same logical command, encoded by the two protocol codecs already in this tree (`drivers/feetech/protocol.py`, `drivers/dynamixel/protocol.py`):

| read present position | frame | bytes | header | address | checksum |
|---|---|--:|---|--:|---|
| Feetech (what was built) | `ff ff 01 04 02 38 02 be` | 8 | `ff ff` | 56 | 1-byte sum |
| Dynamixel (what ALOHA answers) | `ff ff fd 00 01 07 00 02 84 00 04 00 1d 15` | 14 | `ff ff fd 00` | 132 | CRC-16 |

Two bytes in common.

`bi_so_follower` was also an **alias of `aloha`**, so an owner of two SO-101 arms asking for that name received the ViperX twin: 16 joints (`waist, shoulder, elbow, forearm_roll, wrist_angle, wrist_rotate, left_finger, right_finger` per arm) instead of 12 (`1..6` per arm). No joint name is shared, so no policy or calibration crosses over.

## The change

`strands_robots/registry/robots.json`, +11/-4:

- **`aloha`** loses `hardware` entirely. lerobot ships no ALOHA robot (`src/lerobot/robots/` has no `aloha`/`viperx`/`trossen` package), so there is nothing correct to point at. It is now simulation-only, and `mode="real"` refuses through the machinery that already exists for this case, with no new message:
  ```
  ValueError: Unsupported robot type: 'aloha'. lerobot has no robot type for it, but this
  package ships a native driver for it (DynamixelDriver): build it with
  Robot('aloha', mode='real', driver='strands', ...). To make that the default for this
  robot, declare hardware.driver='strands' on its registry entry.
  ```
- **`bi_so_follower`** becomes a robot of its own carrying that lerobot type, aliases `bi_so100`/`bi_so101`. One entry for both spellings because lerobot registers `so100_follower` and `so101_follower` on a **single config class** (`config_so_follower.py:56-57` decorate the same `SOFollowerRobotConfig`), so they are one wire contract — this is why the entry is not named `bi_so101` with a `bi_so100` alias, which would re-create the alias-names-a-different-arm shape being removed here.
- The `agibot_*` / `galaxea_r1_pro` aliases are **deliberately left alone**: they carry no `hardware`, so no wire protocol is involved, and retiring a simulation name a caller may be using is a separate decision from correcting a bus.

## Why the existing guard could not see it

`test_every_strands_lerobot_type_is_real` asks whether a declared type is a name lerobot registers. `bi_so_follower` is, so the entry passed for the registry's entire history.

The new check derives each declared type's `MotorsBus` from lerobot's own source and refuses an entry whose description names the other family. On `main` @ `0fa5ded9`, with only the test file added and the registry untouched:

```
1 failed, 6 passed
FAILED test_a_declared_lerobot_type_drives_the_motor_family_the_description_names
  {'aloha': "describes ['viperx'] but bi_so_follower builds a FeetechMotorsBus"}
```

After the fix: `7 passed`. `aloha` was the only offender across all 16 entries that declare a `lerobot_type`.

### Mutation table (measured, file scope = 7 cells)

| mutation | fails | cells |
|---|--:|---|
| as shipped | 0 | — |
| vendor name `trossen` counted as a Dynamixel marker | 2 | live-registry rule, over-reach control |
| sibling-import hop dropped | 2 | non-vacuity, rule-detection |
| markers reduced to bus class names only | 1 | rule-detection |
| contradiction graded only when both families named | 1 | rule-detection |

Two design points the table pins. Vendor names are **excluded** from the marker vocabulary: Trossen sells Dynamixel ViperX arms *and* supplies the MuJoCo model this registry loads for the Feetech `so100` ("TrossenRobotics SO-ARM100 (6-DOF, Feetech servos)"), so counting it reports a correct entry. And the rule is graded against the offending entry **as a supplied value**, not only against the live registry — a correct registry passes any rule however narrow, so without that cell the marker vocabulary is unpinned.

## Also moved

`aloha` joins `NATIVELY_DRIVEN_WITHOUT_A_LEROBOT_TYPE` in `tests/drivers/test_native_driver_named_when_lerobot_has_no_type.py` — that file's derived-population grader catches the move, which is what it is for. Two of its docstring sentences stated the mapping this PR removes ("Four robots the Dynamixel driver serves", "``koch`` and ``aloha`` — which have both a working lerobot type and a native driver") and are corrected.

Docs: `aloha` moves off the README hardware-capable list; `bi_so_follower` gains a `docs/robots/bimanual.md` row; registry counts go 73→74 robots / 121→122 aliases / bimanual 4→5 in `docs/robots/index.md`, `docs/architecture.md`, `docs/getting-started/quickstart.md`.

## Not in this PR

`drivers/dynamixel/` is a stub whose four operative verbs refuse ("not wired yet (the Protocol-2.0 serial bus)"), and `protocol.py` has no consumer outside its own tests. It is reachable only through an explicit `driver="strands"` — `resolve_driver(name, None)` returns `"lerobot"` for all six robots it registers — so it is **not** on the path this PR fixes, and its module docstring argues its own existence as a deliberate stub. Removing it is a separate decision about that argument, not a consequence of correcting a bus mapping.

## Gate

- `ruff check` + `ruff format --check` on `strands_robots tests tests_integ`: clean (1943 files, ruff 0.15.22)
- `mypy`: `Success: no issues found in 1894 source files`
- `MUJOCO_GL=egl pytest tests/`: **50860 passed, 303 skipped, 0 failed** in 28m30s
- LOC: **+262 / -22**. `registry/robots.json` +11/-4 and the driver test +12/-7 are the change; the remaining +201 is the new guard and +22 the changelog fragment.

Renders produced headless in MuJoCo (`MUJOCO_GL=egl`) from the registry's own `aloha` and `so101` assets.