### PR TITLE
fix(drivers/feetech): a torque write is confirmed by the servo, not by the absence of an error

### DIFF
--- a/changelog.d/3398-feetech-torque-write-ack.md
+++ b/changelog.d/3398-feetech-torque-write-ack.md
@@ -1,0 +1,28 @@
+### Fixed: a Feetech torque write is confirmed by the servo, not by the absence of an error
+
+`FeetechBus.set_torque` wrote `Torque_Enable` to each servo and reported a motor
+failed only on `OSError` from the host's own port. The six-byte status packet a
+unicast `WRITE` returns - the reply `write_packet` documents, and the one the
+vendor SDK sets a packet timeout for after every write - was never read, so two
+things followed.
+
+Nothing measured the claim the driver makes about it. `FeetechDriver`'s
+`set_torque` and `stop` verbs refuse with "these motors did not answer and may
+still be driven", and that list could only ever be empty: an unplugged, mute or
+garbling servo was reported as released, and a `stop` on an arm whose elbow had
+lost its connector answered `torque_enabled: false` for a joint still holding
+its position.
+
+And the unread acks were left for the next reader. Six of them sit 36 bytes in
+front of the following `SYNC_READ` reply stream; on a port that reports
+`in_waiting` the read path's top-up recovers them, but on one that does not, the
+stream is read short - a healthy six-servo arm answered a state read with one
+joint and logged the other five as not replying.
+
+The ack is now read back per motor and framed through
+`parse_sync_read_replies`, which skips a half-duplex adapter's echo of the
+host's own frame rather than refusing it as bytes in front of a status packet. A
+motor that answered nothing or answered something that does not verify is named
+in the return, so the refusal has a measurement behind it and the bus is left
+clean for the next frame. The frame itself now comes from `write_packet` instead
+of being built inline, so the reply-expecting write is spelled once.

--- a/docs/hardware/tools.md
+++ b/docs/hardware/tools.md
@@ -180,6 +180,15 @@ the same rule to the frames it builds
 (`build_packet(..., allow_broadcast=False)`), so the tool and the driver cannot
 disagree about which address is a servo and which is the whole bus.
 
+A *unicast* write is not reply-less. The addressed servo answers it with a
+six-byte status packet - the frame a read is answered with, minus the parameters
+- and that reply is the only evidence the motor took the command. The native
+driver's bus reads it: `FeetechBus.set_torque` names a servo that did not
+acknowledge, which is what lets the `stop` verb report a joint that may still be
+driven instead of an arm that is safe to approach, and reading it is also what
+keeps six unread acks from sitting in front of the next state read's reply
+stream.
+
 | Option | Accepted | Why the bound is where it is |
 |--------|----------|------------------------------|
 | `motor_id` | integer in `[1, 254]`, or `[1, 253]` for an action that reads a reply | the frame carries the ID in one byte, of which `0xfd` is the highest a servo may hold and `0xfe` is the broadcast, while `0xff` is the header value |

--- a/strands_robots/drivers/feetech/bus.py
+++ b/strands_robots/drivers/feetech/bus.py
@@ -36,9 +36,8 @@ from typing import Any, Final
 from strands_robots.drivers.feetech.protocol import (
     MAX_GOAL_POSITION,
     SIGN_BIT,
-    Instruction,
+    STATUS_OVERHEAD,
     Register,
-    build_packet,
     decode_sign_magnitude,
     decode_word,
     encode_word,
@@ -46,6 +45,7 @@ from strands_robots.drivers.feetech.protocol import (
     sync_read_packet,
     sync_read_reply_size,
     sync_write_packet,
+    write_packet,
 )
 from strands_robots.utils import positive_count_error, positive_finite_number_error, require_optional
 
@@ -139,6 +139,11 @@ READABLE_REGISTERS: Final[dict[str, Register]] = {
 
 #: Bytes each readable register carries.
 _REGISTER_WIDTH: Final[int] = 2
+
+#: Param bytes a servo's answer to a ``WRITE`` carries: none. The frame is the
+#: whole reply, which is why the ack read asks the port for
+#: :data:`~strands_robots.drivers.feetech.protocol.STATUS_OVERHEAD` bytes.
+_ACK_PARAM_COUNT: Final[int] = 0
 
 #: Seconds a read waits for a servo's reply. Named rather than spelled
 #: twice: :class:`~strands_robots.drivers.feetech.driver.FeetechDriver`
@@ -393,6 +398,31 @@ class FeetechBus:
     def set_torque(self, enabled: bool) -> list[str]:
         """Energize or release every motor, returning the ones that failed.
 
+        A unicast ``WRITE`` is answered - the servo returns the empty status
+        packet :func:`~strands_robots.drivers.feetech.protocol.write_packet`
+        documents - and that reply is read back here, for two reasons.
+
+        It is the only evidence the motor took the command. Without it the sole
+        failure this could report is an ``OSError`` from the host's own port, so
+        a servo that is unplugged, mute, or answering garbage is reported as
+        released; the refusal
+        :meth:`~strands_robots.drivers.feetech.driver.FeetechDriver._set_torque_envelope`
+        raises on a non-empty return names those motors as possibly still
+        driven, and a claim about a joint that may still be moving is worth
+        measuring rather than assuming.
+
+        And the acks are frames the *next* reader would otherwise find in front
+        of its own: six unread ones sit 36 bytes ahead of the following
+        ``SYNC_READ`` stream, so a healthy arm reads back as one joint and five
+        servos that did not answer.
+
+        The reply's error byte is not graded: a servo raising a flag still
+        answered and still took the write, and what is being distinguished here
+        is silence. A mute servo costs one read window, which is what measuring
+        silence costs; the settle is paid per servo because the writes are per
+        servo, and a torque sweep is a one-shot verb rather than the 30 Hz state
+        path :meth:`sync_read` keeps one settle for.
+
         Every motor is attempted even after one fails: a release that gave up
         part-way would report the arm safe while some joints are still driven.
 
@@ -400,9 +430,9 @@ class FeetechBus:
             enabled: ``True`` to energize, ``False`` to release.
 
         Returns:
-            Names of motors whose write failed; empty when all succeeded. A
-            non-empty list after ``enabled=False`` means the arm is NOT fully
-            de-energized.
+            Names of motors that did not acknowledge the write; empty when all
+            six answered. A non-empty list after ``enabled=False`` means the arm
+            is NOT fully de-energized.
 
         Raises:
             RuntimeError: When the bus is not open.
@@ -410,14 +440,27 @@ class FeetechBus:
         conn = self._require_open("setting torque")
         failed: list[str] = []
         for name, spec in self.motors.items():
-            packet = build_packet(
-                spec.motor_id,
-                Instruction.WRITE,
-                bytes([Register.TORQUE_ENABLE, 1 if enabled else 0]),
-            )
+            packet = write_packet(spec.motor_id, Register.TORQUE_ENABLE, bytes([1 if enabled else 0]))
             try:
                 conn.write(packet)
+                time.sleep(_REPLY_SETTLE_S)
+                raw = bytes(conn.read(STATUS_OVERHEAD))
+                echoed = int(getattr(conn, "in_waiting", 0) or 0)
+                if echoed:
+                    raw += bytes(conn.read(echoed))
             except OSError as e:
                 logger.error("failed to set torque on %s (id %d): %s", name, spec.motor_id, e)
+                failed.append(name)
+                continue
+            # The stream framer rather than a lone packet parse, for the reason
+            # :meth:`_sync_read_once` uses it: it skips the host's own echo,
+            # which `parse_status_packet` refuses as bytes in front of a frame.
+            if spec.motor_id not in parse_sync_read_replies(raw, [spec.motor_id], _ACK_PARAM_COUNT):
+                logger.error(
+                    "no verified torque ack from %s (id %d); discarding %s",
+                    name,
+                    spec.motor_id,
+                    raw.hex(" ") if raw else "an empty read",
+                )
                 failed.append(name)
         return failed

--- a/tests/drivers/conftest.py
+++ b/tests/drivers/conftest.py
@@ -31,6 +31,12 @@ class FakeServoPort:
     frame, so the stream a reader has to survive is exactly the one a mute servo
     produces - the frames of its neighbours, back to back, with a gap.
 
+    A unicast ``WRITE`` is answered too, with the empty status frame the servo
+    sends to acknowledge it - the vendor SDK's ``txRxPacket`` sets a six-byte
+    packet timeout after every one of them. A fake that answered only reads
+    would let a write-and-forget path pass while the acks it left behind piled
+    up in front of the next reader's frame.
+
     Args:
         counts: Motor ID -> the raw register value that motor answers with.
             A motor absent from this map answers nothing, which is how a
@@ -75,6 +81,10 @@ class FakeServoPort:
             motor_id = data[2]
             if motor_id in self.counts:
                 self._pending += self.leading_noise + self._status_frame(motor_id, self.counts[motor_id])
+        elif instruction == 0x03:  # WRITE: the addressed servo acks with an empty frame
+            motor_id = data[2]
+            if motor_id in self.counts:
+                self._pending += self.leading_noise + self._frame(motor_id, b"")
         elif instruction == 0x82:  # SYNC_READ: every addressed servo answers, in order
             replies = b"".join(
                 self._status_frame(motor_id, self.counts[motor_id])
@@ -98,11 +108,20 @@ class FakeServoPort:
     # -- frame construction ------------------------------------------------ #
 
     @staticmethod
-    def _status_frame(motor_id: int, value: int) -> bytes:
-        """Build the reply a servo sends for a two-byte register read."""
-        params = bytes([value & 0xFF, (value >> 8) & 0xFF])
+    def _frame(motor_id: int, params: bytes) -> bytes:
+        """Build one status frame from ``motor_id`` carrying ``params``.
+
+        Empty params is the acknowledgement of a ``WRITE``; two bytes is the
+        answer to a register read. One builder for both, so the ack and the
+        reading cannot drift into two spellings of the same layout.
+        """
         body = bytes([motor_id, len(params) + 2, 0x00]) + params
         return b"\xff\xff" + body + bytes([(~sum(body)) & 0xFF])
+
+    @classmethod
+    def _status_frame(cls, motor_id: int, value: int) -> bytes:
+        """Build the reply a servo sends for a two-byte register read."""
+        return cls._frame(motor_id, bytes([value & 0xFF, (value >> 8) & 0xFF]))
 
 
 def open_bus(port: FakeServoPort, **kwargs: object) -> FeetechBus:

--- a/tests/drivers/test_feetech_torque_write_is_acknowledged.py
+++ b/tests/drivers/test_feetech_torque_write_is_acknowledged.py
@@ -1,0 +1,142 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""A torque write is answered, and :meth:`FeetechBus.set_torque` reads the answer.
+
+A unicast ``WRITE`` on the Feetech bus returns a six-byte status packet. That
+reply is the only evidence a servo took the command, so it is what
+:meth:`~strands_robots.drivers.feetech.driver.FeetechDriver._set_torque_envelope`
+means when it refuses with "these motors did not answer and may still be
+driven" - and it is also six frames the next reader has to get past.
+
+Both halves are graded here: a servo that did not answer is named rather than
+assumed released, and the state read that follows a torque sweep sees its own
+frames instead of the sweep's leftovers.
+
+The bus's other traffic is graded in :mod:`test_feetech_bus`, the codec in
+:mod:`test_feetech_protocol`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from strands_robots.drivers.feetech import FeetechDriver
+from strands_robots.drivers.feetech.bus import SO_ARM_MOTORS
+from tests.drivers.conftest import MIDPOINT_COUNTS, FakeServoPort, open_bus
+
+#: The arm with its elbow unplugged: servo 3 is on the bus map but answers
+#: nothing, which is what a loose connector looks like from the host.
+MUTE_ELBOW_COUNTS = {motor_id: counts for motor_id, counts in MIDPOINT_COUNTS.items() if motor_id != 3}
+
+
+class PortWithoutInWaiting(FakeServoPort):
+    """A port object that does not report its buffer.
+
+    :meth:`FeetechBus._sync_read_once` documents support for one ("a port
+    without that attribute simply skips the top-up"), so it is the port that
+    shows what unread acks in front of a reply stream cost: without a top-up to
+    recover them, the bytes they displaced are gone.
+    """
+
+    @property
+    def in_waiting(self) -> int:
+        return 0
+
+
+class TruncatingPort(FakeServoPort):
+    """Every ack arrives one byte short, so no frame verifies.
+
+    A servo that answered something unusable is not distinguishable from one
+    that stayed silent, and both mean the same thing: nothing confirmed the
+    write.
+    """
+
+    def read(self, size: int) -> bytes:
+        return super().read(size)[:-1]
+
+
+class EchoingPort(FakeServoPort):
+    """A half-duplex adapter that echoes the host's own frame before the reply.
+
+    The frame is addressed to the servo the ack comes from, so it is not skipped
+    for its ID - it is skipped because it does not verify as a status packet.
+    """
+
+    def write(self, data: bytes) -> int:
+        self._pending += bytes(data)
+        return super().write(data)
+
+
+def _stop_envelope(driver: FeetechDriver) -> dict[str, Any]:
+    """Run the driver's ``stop`` verb and return the tool envelope it yields."""
+
+    async def drive() -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        async for event in driver.stream({"toolUseId": "t", "name": "so101", "input": {"action": "stop"}}, {}):
+            if isinstance(event, dict) and "status" in event:
+                result = event
+        return result
+
+    return asyncio.run(drive())
+
+
+class TestAnAnsweredWriteIsReadBack:
+    """The ack is consumed, so it is neither assumed nor left on the bus."""
+
+    @pytest.mark.parametrize("enabled", [True, False])
+    def test_a_healthy_arm_answers_every_torque_write(self, servo_port: FakeServoPort, enabled: bool) -> None:
+        """Six writes, six acks read: nothing failed and nothing is left buffered."""
+        bus = open_bus(servo_port)
+        assert bus.set_torque(enabled) == []
+        assert len(servo_port.writes) == len(SO_ARM_MOTORS)
+        assert servo_port.in_waiting == 0, "the acks are still in front of the next reader's frame"
+
+    def test_the_state_read_after_a_sweep_sees_its_own_frames(self) -> None:
+        """The read following a sweep answers with the whole arm.
+
+        Six unread acks are 36 bytes ahead of a ``SYNC_READ`` reply stream, and
+        a port with nothing to top up from cannot get them back: the reply is
+        read short and five healthy servos report as not answering.
+        """
+        port = PortWithoutInWaiting(MIDPOINT_COUNTS)
+        bus = open_bus(port)
+        bus.set_torque(True)
+        assert sorted(bus.sync_read("Present_Position")) == sorted(SO_ARM_MOTORS)
+
+    def test_the_hosts_own_echo_in_front_of_the_ack_is_skipped(self) -> None:
+        """An echoing adapter is not a mute arm: the ack behind the echo counts."""
+        bus = open_bus(EchoingPort(MIDPOINT_COUNTS))
+        assert bus.set_torque(False) == []
+
+
+class TestASilentServoIsNamed:
+    """ "Did not answer" is measured, because the caller is told the joint may still be driven."""
+
+    @pytest.mark.parametrize(
+        ("port", "expected"),
+        [
+            pytest.param(FakeServoPort(MUTE_ELBOW_COUNTS), ["elbow_flex"], id="one-servo-mute"),
+            pytest.param(TruncatingPort(MIDPOINT_COUNTS), list(SO_ARM_MOTORS), id="no-frame-verifies"),
+        ],
+    )
+    def test_a_servo_that_did_not_answer_is_reported_not_assumed_released(
+        self, port: FakeServoPort, expected: list[str]
+    ) -> None:
+        """Named in the return, and every other motor was still attempted."""
+        bus = open_bus(port)
+        assert bus.set_torque(False) == expected
+        assert len(port.writes) == len(SO_ARM_MOTORS)
+
+    def test_stop_refuses_naming_the_joint_that_may_still_be_driven(self) -> None:
+        """The driver's teardown verb reports a partial release as a refusal.
+
+        A success envelope here tells an operator the arm is safe to approach.
+        """
+        driver = FeetechDriver(tool_name="so101", port="/dev/fake")
+        driver.bus._conn = FakeServoPort(MUTE_ELBOW_COUNTS)
+        envelope = _stop_envelope(driver)
+        assert envelope["status"] == "error"
+        assert "elbow_flex" in envelope["content"][0]["text"]


### PR DESCRIPTION
![measured](https://raw.githubusercontent.com/cagataycali/robots/assets/feetech-torque-ack/torque-ack.png)

Closes #3398.

`FeetechBus.set_torque` writes `Torque_Enable` to each servo and appends to `failed` only on `OSError` from the host's own port. A unicast `WRITE` is answered, though - the six-byte status packet `write_packet`'s own docstring documents ("the servo replies with an empty status packet"), and the one the vendor SDK sets a packet timeout for after every write - and that reply was never read. Two things followed, both measured above.

**The claim the driver makes about it could not be false.** `FeetechDriver`'s `set_torque` and `stop` refuse with "these motors did not answer and may still be driven", and that list could only ever be empty. An arm whose elbow servo has lost its connector answers `stop` with `status="success"` and `{"torque_enabled": false}` - panel C - so an operator is told a joint still holding its position is safe to approach.

**The unread acks were the next reader's problem.** Six of them sit 36 bytes in front of the following `SYNC_READ` reply stream (panel A). On a port that reports `in_waiting`, `_sync_read_once`'s top-up recovers them; on one that does not - a port shape that method documents support for - the stream is read short, and a healthy six-servo arm answers the very next state read with one joint and logs the other five as not replying (panel B).

## Change

`set_torque` reads the ack per motor and frames it through `parse_sync_read_replies`, not `parse_status_packet`: the stream framer skips a half-duplex adapter's echo of the host's own frame, which the lone-frame parser refuses as bytes in front of a status packet. A motor that answered nothing, or answered something that does not verify, is named in the return. The frame now comes from `write_packet` rather than being built inline from `build_packet` + `Instruction.WRITE`, so the reply-expecting write is spelled once.

The reply's error byte is deliberately not graded: a servo raising a flag still answered and still took the write, and what is being distinguished here is silence. A mute servo costs one read window, which is what measuring silence costs.

## Measured

| | `main` | this PR |
|---|---|---|
| bytes left in the input buffer after a six-joint sweep | 36 | 0 |
| `set_torque(False)` with servo 3 mute | `[]` | `['elbow_flex']` |
| `set_torque(False)` when no ack verifies | `[]` | all six names |
| `stop` envelope on that arm | `success`, `{"torque_enabled": false}` | `error`, `... may still be driven: ['elbow_flex']` |
| joints the next state read returns (port without `in_waiting`) | 1 of 6 | 6 of 6 |

## Pins

`tests/drivers/test_feetech_torque_write_is_acknowledged.py`, 7 cells. On `upstream/main` with only the fake's ack teaching copied in, **6 of 7 fail**; the seventh (the echo cell) passes there because nothing is read, so nothing can misparse.

| mutation of the fix | cells failing |
|---|---|
| the ack is not read at all (`main` today) | 6 |
| the ack is read, but never graded | 3 |
| no `in_waiting` top-up after the ack read | 1 (echo) |
| graded with `parse_status_packet` instead of the stream framer | 1 (echo) |
| the per-servo settle removed | 0 - a fake port buffers instantly, so the settle is a wire-timing property this suite cannot grade |

`FakeServoPort` now answers a unicast `WRITE` the way the hardware does, through one frame builder shared with its read replies so the ack and the reading cannot drift into two spellings of the same layout. That is what lets any write-and-forget path on this bus be graded at all.

## Checks

`tests/drivers/` 2859 passed / 17 skipped. Full `tests/` 50842 passed / 303 skipped, one unrelated load-sensitive failure (`test_rendering_pacers_survive_a_clock_step[backward_2s]`, "premise: only 0 frames captured", 16/16 green standalone, no code path in this diff). `ruff check` + `ruff format --check` clean; `mypy` clean over 1895 files.

LOC: `bus.py` +53/-10 (118 -> 128 executable statements, the read and its grade), `conftest.py` +22/-3, new pin +142, changelog +28, docs +9.