### PR TITLE
fix(hardware_robot): a camera type is resolved through lerobot's registry, like the robot beside it

### DIFF
--- a/changelog.d/3408-camera-type-comes-from-lerobots-registry.md
+++ b/changelog.d/3408-camera-type-comes-from-lerobots-registry.md
@@ -1,0 +1,26 @@
+### Fixed: `Robot(cameras=...)` resolves the camera `type` through lerobot's registry, so every backend lerobot ships is attachable
+
+`_build_camera_config` imported `OpenCVCameraConfig` unconditionally and refused
+any other `type`, while the robot name beside it has always been resolved
+generically through lerobot's draccus `ChoiceRegistry`. A camera dict *is* a
+serialized `CameraConfig` - `type` is draccus' own choice discriminator and the
+remaining keys are fields of the class it selects - so both halves are now
+derived: `CameraConfig.get_choice_class(type)` picks the class, and
+`dataclasses.fields()` of that class defines the accepted options.
+`intelrealsense`, `zmq`, `reachy2_camera` and any installed `lerobot_camera_*`
+plugin are attachable; a field no OpenCV config declares (`use_depth`,
+`serial_number_or_name`) is reachable for the first time.
+
+This closed a contradiction inside the package: `tools/lerobot_camera` lists and
+opens a RealSense, and the real-mode docs name a `realsense_top` camera, but
+attaching one to a robot raised `Unsupported camera type`. The refusal now lists
+every registered choice and, when the spelling is close, names it - lerobot
+registers Intel RealSense as `intelrealsense`, so the obvious guess `realsense`
+was a dead end. An absent vendor SDK is still reported as the absent SDK, by
+lerobot, where the device is opened.
+
+The choices are populated lazily (`lerobot.cameras.__init__` deliberately
+imports no backend, so the registry starts empty), so a `pkgutil` walk mirrors
+the one the robot registry already does. The third-party plugin loader both
+walks share moved into one cached helper, since a single call registers every
+kind at once.

--- a/docs/getting-started/robot-factory.md
+++ b/docs/getting-started/robot-factory.md
@@ -57,11 +57,26 @@ or alias rather than letting it resolve to that robot. Full alias map in
 robot = Robot(
     "so100",
     mode="real",
-    cameras={"wrist": {"type": "opencv", "index_or_path": "/dev/video0"}},
+    cameras={
+        "wrist": {"type": "opencv", "index_or_path": "/dev/video0"},
+        "top": {"type": "intelrealsense", "serial_number_or_name": "819312071961"},
+    },
     port="/dev/tty.usbserial-A50285BI",
     control_frequency=50.0,
 )
 ```
+
+Each `cameras` entry is a serialized lerobot `CameraConfig`, so `type` is resolved
+against lerobot's own choice registry - the same registry the robot name itself is
+resolved against. Every backend lerobot ships is therefore attachable
+(`opencv`, `intelrealsense`, `zmq`, `reachy2_camera`), as is any installed
+`lerobot_camera_*` plugin, and the remaining keys are the fields of the class the
+`type` resolves to. Note the registered name for Intel RealSense is
+`intelrealsense`, not `realsense`; an unregistered `type` raises `ValueError`
+listing the registered ones. `fps`, `width` and `height` are common to every
+backend and default to 30/640/480 when unset - a vendor SDK the backend needs
+(`pyrealsense2` for `intelrealsense`) is required when the device is opened, not
+when the config is built.
 
 `control_frequency` (Hz) sets the control loop's per-action period,
 `1 / control_frequency` - the only throttle between two servo commands. It must be a

--- a/docs/hardware/robot-control.md
+++ b/docs/hardware/robot-control.md
@@ -12,7 +12,12 @@ from strands_robots import Robot
 robot = Robot(
     "so100",
     mode="real",
-    cameras={"wrist": {"type": "opencv", "index_or_path": "/dev/video0"}},
+    cameras={
+        "wrist": {"type": "opencv", "index_or_path": "/dev/video0"},
+        # A RealSense is selected by lerobot's registered name for it,
+        # ``intelrealsense``, and identified by serial rather than by device path.
+        "top": {"type": "intelrealsense", "serial_number_or_name": "819312071961", "use_depth": True},
+    },
     port="/dev/tty.usbserial-A50285BI",
     control_frequency=50.0,
 )
@@ -35,7 +40,7 @@ robot.cleanup()
 |-------|------|
 | `tool_name` | Tool identifier for the agent. |
 | `robot` | LeRobot `Robot` instance, `RobotConfig`, or string (e.g. `"so100"`). |
-| `cameras` | `{name: config_dict}`. Config keys are `type` (backend selector, `opencv`) plus the fields of lerobot's `OpenCVCameraConfig`: `index_or_path` (required), `fps`, `width`, `height`, `color_mode`, `rotation`, `warmup_s`, `fourcc`, `backend`. An unknown key raises `ValueError`. |
+| `cameras` | `{name: config_dict}`. Each dict is a serialized lerobot `CameraConfig`: `type` selects the backend from lerobot's own registry (`opencv` default, `intelrealsense`, `zmq`, `reachy2_camera`, plus any installed `lerobot_camera_*` plugin) and the remaining keys are the fields of the class it resolves to. `fps`/`width`/`height` are common to every backend and default to 30/640/480; the required field is per backend (`index_or_path` for `opencv`, `serial_number_or_name` for `intelrealsense`, `server_address` for `zmq`). An unknown `type` or key raises `ValueError` listing the accepted vocabulary. |
 | `action_horizon` | Actions per inference step (default 8; must be a positive integer). |
 | `data_config` | GR00T data_config name. |
 | `control_frequency` | Control loop Hz (default 50). |

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -130,28 +130,135 @@ _FORWARDABLE_KWARGS = (
 # ---------------------------------------------------------------------------
 #
 # ``Robot(..., cameras={"front": {...}})`` describes each camera with a
-# free-form dict whose keys are the fields of lerobot's camera config
-# dataclass. The accepted vocabulary is therefore derived from
-# ``dataclasses.fields()`` rather than hand-picked: a hand-picked list leaves
-# every field it forgets unreachable (no caller can set it at all) and silently
-# discards every key it does not recognise, so a typo like ``heigth=1080``
-# reports success having configured the default resolution.
+# free-form dict. That dict is a serialized lerobot ``CameraConfig``: ``type``
+# is draccus' own choice discriminator (``CameraConfig.type`` returns
+# ``get_choice_name(cls)``) and every other key is a field of the dataclass that
+# discriminator selects. So both halves of the vocabulary are derived, never
+# hand-picked:
+#
+#   - the set of accepted ``type`` values is ``CameraConfig.get_known_choices()``
+#     -- the same draccus ``ChoiceRegistry`` lookup ``_create_minimal_config``
+#     already uses for ``robot_type``, and the one ``make_cameras_from_configs``
+#     dispatches on. A camera backend lerobot ships or a vendor plugin registers
+#     is therefore attachable the day it lands, with no mapping to maintain here.
+#   - the set of accepted option keys is ``dataclasses.fields()`` of the
+#     resolved class. A hand-picked list leaves every field it forgets
+#     unreachable (no caller can set it at all) and silently discards every key
+#     it does not recognise, so a typo like ``heigth=1080`` reports success
+#     having configured the default resolution.
 #
 # ``strands_robots`` supplies its own defaults for the three fields lerobot
 # leaves as ``None`` (meaning "whatever the device negotiates") so an
-# unconfigured camera has a predictable, documented stream. Every other field
-# keeps lerobot's own default.
+# unconfigured camera has a predictable, documented stream. Those three are
+# declared on the ``CameraConfig`` base, so they are fields of every registered
+# choice and the defaults apply to a RealSense exactly as they do to a webcam.
+# Every other field keeps lerobot's own default.
 #
 # Invariant: every key here must be a field lerobot still declares. If one is
-# renamed upstream the stale key reaches ``OpenCVCameraConfig(**options)`` and
-# fails loudly for every camera rather than being silently dropped -- and the
-# test suite asserts the containment directly, so the drift is caught before a
+# renamed upstream the stale key reaches the config constructor and fails
+# loudly for every camera rather than being silently dropped -- and the test
+# suite asserts the containment directly, so the drift is caught before a
 # release rather than at an operator's ``Robot()`` call.
-_OPENCV_CAMERA_DEFAULTS: dict[str, Any] = {"fps": 30, "width": 640, "height": 480}
+_CAMERA_STREAM_DEFAULTS: dict[str, Any] = {"fps": 30, "width": 640, "height": 480}
 
 # ``type`` selects which camera backend to build. It is consumed by the
-# dispatch below, not forwarded to the config dataclass.
+# registry lookup below, not forwarded to the config dataclass.
 _CAMERA_TYPE_KEY = "type"
+
+
+@functools.cache
+def _ensure_lerobot_cameras_registered() -> None:
+    """Import every camera backend subpackage so CameraConfig is populated.
+
+    The mirror of :func:`_ensure_lerobot_robots_registered`, and for the same
+    reason: each backend registers its config via
+    ``@CameraConfig.register_subclass`` at module-import time, but
+    ``lerobot.cameras.__init__`` deliberately does not import them -- it says so
+    in a comment, to avoid pulling backend-specific dependencies into every
+    ``import lerobot``. Until they are imported ``CameraConfig`` has *no*
+    registered choices at all, so a registry lookup that skips this step reports
+    every camera type as unknown.
+
+    Walks ``lerobot.cameras`` with ``pkgutil`` so a backend lerobot adds in a
+    future release needs no change here, then registers third-party
+    ``lerobot_camera_*`` distributions through lerobot's own plugin loader.
+
+    Idempotent via ``@functools.cache`` -- the first call walks the tree,
+    subsequent calls are dict lookups.
+    """
+    try:
+        import lerobot.cameras as _lr_cameras
+    except ImportError as exc:
+        # Mirrors the robot walk: lerobot wholly absent is expected on
+        # sim-only hosts (debug), while lerobot present but
+        # ``lerobot.cameras`` unimportable is a partial install worth a
+        # warning. Either way the caller gets a clean "Unsupported camera
+        # type" naming the choices that did register.
+        try:
+            import lerobot  # noqa: F401  (probe-only)
+        except ImportError:
+            logger.debug("lerobot not installed: %s", exc)
+        else:
+            logger.warning(
+                "lerobot is installed but lerobot.cameras is not importable (partial install?): %s",
+                exc,
+            )
+        return
+
+    for _, sub_name, is_pkg in pkgutil.iter_modules(_lr_cameras.__path__):
+        if not is_pkg:
+            continue
+        full_name = f"{_lr_cameras.__name__}.{sub_name}"
+        try:
+            importlib.import_module(full_name)
+        except (ImportError, OSError) as exc:
+            # A backend whose SDK is absent (``pyrealsense2``, ``reachy2_sdk``)
+            # or whose ``__init__`` probes the OS. It simply does not appear in
+            # the choice registry, which is the correct outcome: naming it later
+            # raises "Unsupported camera type" listing what is available.
+            # ``(ImportError, OSError)`` is the canonical narrow pair for a
+            # hardware-probing import per AGENTS.md > Review Learnings (#86).
+            logger.debug("[hardware_robot] skip %s: %s", full_name, exc)
+
+    _ensure_lerobot_plugins_registered()
+
+
+def _resolve_camera_config_class(camera_name: str, cam_type: Any) -> type:
+    """Resolve a camera ``type`` to the lerobot config class it names.
+
+    Args:
+        camera_name: The key this camera was registered under, named in the
+            refusal so a multi-camera rig reports which entry is at fault.
+        cam_type: The requested ``type`` value, as the caller spelled it.
+
+    Returns:
+        The registered ``CameraConfig`` subclass for ``cam_type``.
+
+    Raises:
+        ValueError: If ``cam_type`` is not a registered choice. The refusal
+            lists every choice that did register and, when the spelling is
+            close to one of them, names it -- lerobot registers Intel RealSense
+            as ``intelrealsense``, so the obvious guess ``realsense`` is a
+            dead end without the suggestion.
+    """
+    from lerobot.cameras.configs import CameraConfig
+
+    _ensure_lerobot_cameras_registered()
+    try:
+        return cast(type, CameraConfig.get_choice_class(cam_type))
+    except (KeyError, TypeError):
+        # KeyError: not a registered choice. TypeError: an unhashable value
+        # (a list, a dict) can never be a registry key, so it is the same
+        # refusal rather than a traceback out of the registry's dict lookup.
+        known = sorted(CameraConfig.get_known_choices())
+        close = difflib.get_close_matches(str(cam_type), known, n=1, cutoff=0.7)
+        hint = f" Did you mean {close[0]!r}?" if close else ""
+        # ``from None`` -- the registry's KeyError is an internal detail of
+        # draccus; suppress the chained traceback for a cleaner error.
+        raise ValueError(
+            f"Unsupported camera type for camera {camera_name!r}: {cam_type!r}.{hint} "
+            f"Known lerobot camera types: {known}."
+        ) from None
 
 
 def _build_camera_config(camera_name: str, config: Any) -> Any:
@@ -160,34 +267,34 @@ def _build_camera_config(camera_name: str, config: Any) -> Any:
     Args:
         camera_name: The key this camera was registered under. Named in every
             error so a multi-camera rig reports which entry is at fault.
-        config: The per-camera options. Accepted keys are the declared fields
-            of lerobot's ``OpenCVCameraConfig`` plus ``type``, which selects
-            the camera backend (``opencv`` is the only one implemented).
+        config: The per-camera options. ``type`` selects the camera backend
+            from lerobot's ``CameraConfig`` choice registry (default
+            ``opencv``); every other accepted key is a declared field of the
+            config class that choice resolves to.
 
     Returns:
-        The constructed ``OpenCVCameraConfig``.
+        An instance of the ``CameraConfig`` subclass the requested ``type``
+        names, ready for ``lerobot.cameras.make_cameras_from_configs``.
 
     Raises:
-        ValueError: If ``config`` is not a mapping, names an unimplemented
-            camera ``type``, carries a key that is not a declared field, omits
-            a field that has no default, or holds a value lerobot's own config
-            validation refuses. An unknown key is refused rather than dropped
-            per AGENTS.md > Review Learnings (#86): a silently discarded option
-            reports success while the camera streams at the default.
+        ValueError: If ``config`` is not a mapping, names a camera ``type``
+            lerobot does not register, carries a key that is not a declared
+            field of the resolved class, omits a field that has no default, or
+            holds a value lerobot's own config validation refuses. An unknown
+            key is refused rather than dropped per AGENTS.md > Review Learnings
+            (#86): a silently discarded option reports success while the camera
+            streams at the default.
     """
-    from lerobot.cameras.opencv.configuration_opencv import OpenCVCameraConfig
-
     if not isinstance(config, Mapping):
         raise ValueError(
             f"Camera {camera_name!r} config must be a mapping of option name to value, "
             f"got {type(config).__name__}: {config!r}."
         )
 
-    cam_type = config.get(_CAMERA_TYPE_KEY, "opencv")
-    if cam_type != "opencv":
-        raise ValueError(f"Unsupported camera type: {cam_type}")
+    ConfigClass = _resolve_camera_config_class(camera_name, config.get(_CAMERA_TYPE_KEY, "opencv"))
+    class_name = ConfigClass.__name__
 
-    fields = {f.name: f for f in dataclasses.fields(OpenCVCameraConfig)}
+    fields = {f.name: f for f in dataclasses.fields(ConfigClass)}
     accepted = sorted(set(fields) | {_CAMERA_TYPE_KEY})
 
     unknown = sorted(set(config) - set(fields) - {_CAMERA_TYPE_KEY}, key=repr)
@@ -198,9 +305,12 @@ def _build_camera_config(camera_name: str, config: Any) -> Any:
             if close:
                 hints.append(f"{key!r} -> {close[0]!r}")
         hint = f" Did you mean: {', '.join(hints)}?" if hints else ""
+        # The suggestion is drawn from the resolved class's own fields: an
+        # ``index_or_path`` sent to a RealSense is a real mistake, and pointing
+        # at ``serial_number_or_name`` is what makes it fixable.
         raise ValueError(
             f"Unknown option(s) for camera {camera_name!r}: {unknown}.{hint} "
-            f"OpenCVCameraConfig accepts: {accepted} (where {_CAMERA_TYPE_KEY!r} selects "
+            f"{class_name} accepts: {accepted} (where {_CAMERA_TYPE_KEY!r} selects "
             f"the camera backend). (If this is a typo, fix it.)"
         )
 
@@ -208,25 +318,25 @@ def _build_camera_config(camera_name: str, config: Any) -> Any:
         name
         for name, field in fields.items()
         if name not in config
-        and name not in _OPENCV_CAMERA_DEFAULTS
+        and name not in _CAMERA_STREAM_DEFAULTS
         and field.default is dataclasses.MISSING
         and field.default_factory is dataclasses.MISSING
     )
     if missing:
         raise ValueError(
-            f"Camera {camera_name!r} is missing required option(s): {missing}. OpenCVCameraConfig accepts: {accepted}."
+            f"Camera {camera_name!r} is missing required option(s): {missing}. {class_name} accepts: {accepted}."
         )
 
     # strands defaults first so an explicitly configured value always wins.
-    options = {**_OPENCV_CAMERA_DEFAULTS, **{name: config[name] for name in fields if name in config}}
+    options = {**_CAMERA_STREAM_DEFAULTS, **{name: config[name] for name in fields if name in config}}
     try:
-        return OpenCVCameraConfig(**options)
+        return ConfigClass(**options)
     except (TypeError, ValueError) as exc:
         # Names the camera, which lerobot's own message cannot: its
         # ``__post_init__`` validation (e.g. a 3-character ``fourcc``) raises
         # with no idea which entry of the ``cameras`` dict it came from.
         raise ValueError(
-            f"Failed to construct OpenCVCameraConfig for camera {camera_name!r}: {exc}. Options: {options}"
+            f"Failed to construct {class_name} for camera {camera_name!r}: {exc}. Options: {options}"
         ) from exc
 
 
@@ -375,9 +485,24 @@ def _ensure_lerobot_robots_registered() -> None:
             # genuine bugs in driver registration code.
             logger.debug("[hardware_robot] skip %s: %s", full_name, exc)
 
-    # Pick up third-party plugins (``lerobot_robot_*`` distributions) via
-    # lerobot's own loader if available -- lets external robot vendors
-    # expose drivers without any strands_robots involvement.
+    _ensure_lerobot_plugins_registered()
+
+
+@functools.cache
+def _ensure_lerobot_plugins_registered() -> None:
+    """Import every installed third-party lerobot plugin distribution.
+
+    lerobot's own loader imports every distribution whose name starts with one
+    of its plugin prefixes (``lerobot_robot_``, ``lerobot_camera_``,
+    ``lerobot_teleoperator_``, ...), and each of those registers itself into the
+    matching :class:`draccus.ChoiceRegistry` as an import side effect. One call
+    therefore populates every registry at once, which is why this is a single
+    cached helper rather than a per-kind step: a vendor camera and a vendor
+    robot arrive from the same import, so registering one kind while the caller
+    happens to be resolving the other would leave the second unreachable.
+
+    Idempotent via ``@functools.cache``.
+    """
     try:
         from lerobot.utils.import_utils import register_third_party_plugins
     except ImportError:
@@ -1044,9 +1169,10 @@ class Robot(TeleopMixin, AgentTool):
         missing ``remote_ip`` would point a network robot's caller at the wrong
         bus entirely.
 
-        Each entry of ``cameras`` follows the same contract, resolved against
-        the fields of lerobot's ``OpenCVCameraConfig`` -- see
-        :func:`_build_camera_config`.
+        Each entry of ``cameras`` follows the same contract twice over: its
+        ``type`` is resolved against lerobot's ``CameraConfig`` choice registry
+        and its remaining keys against the fields of the class that resolves to
+        -- see :func:`_build_camera_config`.
 
         Forwarded values are otherwise passed through as given, because their
         accepted domains are robot-specific. ``max_relative_target`` is the

--- a/tests/test_hardware_robot_camera_config.py
+++ b/tests/test_hardware_robot_camera_config.py
@@ -32,7 +32,7 @@ pytest.importorskip("lerobot")
 
 from lerobot.cameras.opencv.configuration_opencv import OpenCVCameraConfig
 
-from strands_robots.hardware_robot import _OPENCV_CAMERA_DEFAULTS, _build_camera_config
+from strands_robots.hardware_robot import _CAMERA_STREAM_DEFAULTS, _build_camera_config
 
 from .test_hardware_robot_config import _make_robot
 
@@ -105,7 +105,7 @@ class TestFieldReachability:
         If lerobot renames one of these, forwarding the stale key would fail at
         construction time for every camera. Catch the drift here instead.
         """
-        assert set(_OPENCV_CAMERA_DEFAULTS) <= set(_declared_fields())
+        assert set(_CAMERA_STREAM_DEFAULTS) <= set(_declared_fields())
 
 
 class TestUnknownOptionsRefused:

--- a/tests/test_hardware_robot_camera_type_registry.py
+++ b/tests/test_hardware_robot_camera_type_registry.py
@@ -1,0 +1,269 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""The camera ``type`` a hardware ``Robot`` accepts is lerobot's own registry.
+
+``Robot(..., cameras={"top": {"type": ..., ...}})`` describes each camera with a
+serialized lerobot ``CameraConfig``: ``type`` is draccus' choice discriminator
+(``CameraConfig.type`` returns ``get_choice_name(cls)``) and the remaining keys
+are fields of the class it selects. So the set of accepted ``type`` values must
+be ``CameraConfig.get_known_choices()`` -- the same ``ChoiceRegistry`` lookup
+``_create_minimal_config`` already uses for ``robot_type``, and the one
+``lerobot.cameras.make_cameras_from_configs`` dispatches on.
+
+Pre-fix the builder resolved ``OpenCVCameraConfig`` unconditionally and refused
+every other ``type``, so a RealSense, a ZMQ stream and a Reachy 2 camera were
+all unattachable through the factory -- while ``tools/lerobot_camera`` in this
+same package opens a RealSense, and the docs' real-mode examples name
+``realsense_top``. Every cell here fails on that builder.
+
+The choices are populated lazily, which is the other half of the fix: importing
+``lerobot.cameras`` registers nothing at all (pinned below), so a registry
+lookup that skips the subpackage walk reports every camera type as unknown.
+
+No camera hardware and no vendor SDK is touched: only config dataclasses are
+constructed.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+pytest.importorskip("lerobot")
+
+from lerobot.cameras.configs import CameraConfig
+
+from strands_robots.hardware_robot import (
+    _CAMERA_STREAM_DEFAULTS,
+    _build_camera_config,
+    _ensure_lerobot_cameras_registered,
+)
+
+from .test_hardware_robot_config import _make_robot
+
+# A minimal valid option set for every camera backend lerobot registers, keyed
+# by the ``type`` that selects it. Only the required fields are named; the rest
+# come from lerobot's defaults and this package's stream defaults.
+#
+# Kept as an explicit map, with the coverage assertion below, for the same
+# reason ``test_hardware_robot_camera_config._PROBE_VALUES`` is: a backend
+# lerobot adds in a future release fails that cell until someone verifies it is
+# attachable, instead of quietly joining an unreachable set. A derived value per
+# field cannot replace it -- ``Reachy2CameraConfig.__post_init__`` enumerates
+# ``name`` and ``image_type``, so only a real pairing constructs.
+_MINIMAL_OPTIONS: dict[str, dict[str, object]] = {
+    "opencv": {"index_or_path": 0},
+    "intelrealsense": {"serial_number_or_name": "819312071961"},
+    "zmq": {"server_address": "tcp://127.0.0.1"},
+    "reachy2_camera": {"name": "teleop", "image_type": "left"},
+}
+
+
+@pytest.fixture(autouse=True)
+def _registered() -> None:
+    """Populate the choice registry the way ``Robot()`` does."""
+    _ensure_lerobot_cameras_registered()
+
+
+def _choices() -> list[str]:
+    return sorted(CameraConfig.get_known_choices())
+
+
+class TestTheRegistryIsTheVocabulary:
+    def test_importing_lerobot_cameras_registers_nothing(self) -> None:
+        """The premise for the walk: the choices are populated lazily.
+
+        ``lerobot.cameras.__init__`` deliberately does not import its backend
+        subpackages, and says so in a comment, to keep backend-specific
+        dependencies out of every ``import lerobot``. A registry lookup that
+        skips :func:`~strands_robots.hardware_robot._ensure_lerobot_cameras_registered`
+        therefore answers *every* camera type as unknown -- including
+        ``opencv``. Run in a fresh interpreter because registration is a
+        process-global import side effect this session has already performed.
+
+        Should lerobot start importing them eagerly, the walk stays correct (it
+        is idempotent) and this cell is what says the premise moved.
+        """
+        probe = (
+            "from lerobot.cameras.configs import CameraConfig\n"
+            "import lerobot.cameras\n"
+            "from lerobot.cameras.utils import make_cameras_from_configs\n"
+            "print(sorted(CameraConfig.get_known_choices()))\n"
+        )
+        out = subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True, check=True)
+        assert out.stdout.strip() == "[]"
+
+    def test_the_walk_registers_the_backends_lerobot_ships(self) -> None:
+        """The walk finds more than the one backend the builder used to hardcode."""
+        assert "opencv" in _choices()
+        assert "intelrealsense" in _choices()
+        assert len(_choices()) > 1
+
+    def test_every_registered_choice_is_covered_by_this_module(self) -> None:
+        """A backend lerobot adds must be verified attachable, not assumed.
+
+        This is the cell that fails when lerobot registers a fifth camera type:
+        add it to ``_MINIMAL_OPTIONS`` and the parametrized cells below prove
+        the factory can attach it.
+        """
+        assert sorted(_MINIMAL_OPTIONS) == _choices()
+
+    @pytest.mark.parametrize("cam_type", sorted(_MINIMAL_OPTIONS))
+    def test_every_registered_choice_builds_its_own_config_class(self, cam_type: str) -> None:
+        """Each ``type`` resolves to the class lerobot registered under it.
+
+        Pre-fix only ``opencv`` reached a config at all; every other cell raised
+        ``Unsupported camera type``.
+        """
+        built = _build_camera_config("top", {"type": cam_type, **_MINIMAL_OPTIONS[cam_type]})
+
+        assert isinstance(built, CameraConfig)
+        assert type(built) is CameraConfig.get_choice_class(cam_type)
+        # ``type`` round-trips: it is what ``make_cameras_from_configs``
+        # dispatches on, so a config whose discriminator disagreed with the
+        # requested type would open the wrong device.
+        assert built.type == cam_type
+
+    @pytest.mark.parametrize("cam_type", sorted(_MINIMAL_OPTIONS))
+    def test_the_stream_defaults_apply_to_every_choice(self, cam_type: str) -> None:
+        """``fps``/``width``/``height`` are declared on the ``CameraConfig`` base.
+
+        So this package's documented stream defaults are not an OpenCV
+        privilege: an unconfigured RealSense gets the same predictable stream as
+        an unconfigured webcam, rather than lerobot's ``None`` ("whatever the
+        device negotiates").
+        """
+        built = _build_camera_config("top", {"type": cam_type, **_MINIMAL_OPTIONS[cam_type]})
+
+        assert (built.fps, built.width, built.height) == (
+            _CAMERA_STREAM_DEFAULTS["fps"],
+            _CAMERA_STREAM_DEFAULTS["width"],
+            _CAMERA_STREAM_DEFAULTS["height"],
+        )
+
+    @pytest.mark.parametrize("cam_type", sorted(_MINIMAL_OPTIONS))
+    def test_an_explicit_stream_option_still_wins(self, cam_type: str) -> None:
+        """The defaults fill gaps; they never override a configured value."""
+        built = _build_camera_config(
+            "top", {"type": cam_type, **_MINIMAL_OPTIONS[cam_type], "width": 1280, "height": 720}
+        )
+
+        assert (built.width, built.height) == (1280, 720)
+
+    def test_a_realsense_is_attachable_through_the_public_cameras_kwarg(self) -> None:
+        """The contract holds through the surface an operator really calls.
+
+        ``tools/lerobot_camera`` in this package opens a RealSense and the
+        real-mode docs name ``realsense_top``, but pre-fix this raised
+        ``Unsupported camera type`` -- the tool could list the device the
+        factory refused to attach.
+        """
+        pytest.importorskip("lerobot.robots.so_follower")
+        hw = _make_robot()
+
+        cfg = hw._create_minimal_config(
+            "so101_follower",
+            {"realsense_top": {"type": "intelrealsense", "serial_number_or_name": "819312071961"}},
+            port="/dev/ttyACM0",
+        )
+
+        cam = cfg.cameras["realsense_top"]
+        assert type(cam).__name__ == "RealSenseCameraConfig"
+        assert cam.serial_number_or_name == "819312071961"
+
+
+class TestAnUnregisteredTypeIsRefusedWithTheRegistrySListing:
+    def test_an_unregistered_type_lists_every_registered_one(self) -> None:
+        """The refusal survives, and now says what the alternatives are.
+
+        Pre-fix it named only the rejected value, so ``opencv`` -- the one type
+        that worked -- was never mentioned.
+        """
+        with pytest.raises(ValueError) as excinfo:
+            _build_camera_config("top", {"type": "thermal"})
+
+        message = str(excinfo.value)
+        assert "Unsupported camera type" in message
+        assert "'thermal'" in message
+        assert "'top'" in message  # which camera is at fault
+        for choice in _choices():
+            assert choice in message
+
+    def test_the_realsense_spelling_is_answered_with_the_registered_one(self) -> None:
+        """``realsense`` is the obvious guess and lerobot registers ``intelrealsense``.
+
+        The two spellings are a real divergence inside this package: the
+        ``lerobot_camera`` tool takes ``camera_type="realsense"`` as a tool
+        argument, while the factory's ``type`` is draccus' discriminator and so
+        must be the registry's name. Naming the registered spelling is what
+        keeps that divergence from being a dead end -- the tool's own refusal
+        test makes the same argument about not sending a caller "looking for a
+        spelling that does not exist".
+        """
+        with pytest.raises(ValueError) as excinfo:
+            _build_camera_config("top", {"type": "realsense", "serial_number_or_name": "123"})
+
+        assert "Did you mean 'intelrealsense'?" in str(excinfo.value)
+
+    def test_an_unhashable_type_is_refused_not_a_traceback(self) -> None:
+        """A list can never be a registry key, so it is the same refusal.
+
+        The lookup is a dict subscript; without this the ``TypeError:
+        unhashable type`` escapes from inside draccus.
+        """
+        with pytest.raises(ValueError, match="Unsupported camera type"):
+            _build_camera_config("top", {"type": ["intelrealsense"]})
+
+
+class TestTheOptionVocabularyFollowsTheResolvedClass:
+    def test_an_opencv_option_on_a_realsense_lists_realsenses_fields(self) -> None:
+        """The accepted vocabulary is the resolved class's, not OpenCV's.
+
+        ``index_or_path`` identifies a webcam; a RealSense is identified by
+        ``serial_number_or_name``. Listing OpenCV's fields here would send the
+        caller after an option this config does not declare.
+        """
+        with pytest.raises(ValueError) as excinfo:
+            _build_camera_config("top", {"type": "intelrealsense", "index_or_path": 0})
+
+        message = str(excinfo.value)
+        assert "index_or_path" in message  # the offending key
+        assert "RealSenseCameraConfig accepts" in message
+        assert "serial_number_or_name" in message
+        assert "'fourcc'" not in message  # an OpenCV-only field
+
+    def test_a_realsense_only_field_is_reachable(self) -> None:
+        """A field no OpenCV config declares can actually be configured.
+
+        Pre-fix ``use_depth`` was unreachable through ``Robot()``: the only
+        config class the builder would construct does not declare it.
+        """
+        built = _build_camera_config(
+            "top", {"type": "intelrealsense", "serial_number_or_name": "123", "use_depth": True}
+        )
+
+        assert built.use_depth is True
+
+    def test_a_missing_required_option_names_the_resolved_class(self) -> None:
+        """Each backend has its own required field, and the refusal says which."""
+        with pytest.raises(ValueError) as excinfo:
+            _build_camera_config("top", {"type": "zmq"})
+
+        message = str(excinfo.value)
+        assert "missing required option(s): ['server_address']" in message
+        assert "ZMQCameraConfig accepts" in message
+
+    def test_a_value_lerobot_refuses_names_the_camera_and_the_class(self) -> None:
+        """lerobot's own ``__post_init__`` validation is reported per camera.
+
+        ``ZMQCameraConfig`` refuses a port outside 1..65535 with no idea which
+        entry of a multi-camera ``cameras`` dict it came from.
+        """
+        with pytest.raises(ValueError) as excinfo:
+            _build_camera_config("wrist", {"type": "zmq", "server_address": "tcp://127.0.0.1", "port": 0})
+
+        message = str(excinfo.value)
+        assert "Failed to construct ZMQCameraConfig for camera 'wrist'" in message
+        assert "port" in message

--- a/tests/test_hardware_robot_config.py
+++ b/tests/test_hardware_robot_config.py
@@ -82,12 +82,20 @@ class TestCreateMinimalConfig:
         assert cam.width == 640
         assert cam.height == 480
 
-    def test_unsupported_camera_type_is_rejected(self):
+    def test_unregistered_camera_type_is_rejected(self):
+        """A ``type`` lerobot does not register is refused, listing the ones it does.
+
+        ``realsense`` used to be this test's example of an unsupported type. It
+        is not one: lerobot registers Intel RealSense as ``intelrealsense`` and
+        the factory builds it (see
+        ``tests/test_hardware_robot_camera_type_registry.py``). Only a type
+        absent from ``CameraConfig``'s choice registry is refused here.
+        """
         hw = _make_robot()
-        with pytest.raises(ValueError, match="Unsupported camera type: realsense"):
+        with pytest.raises(ValueError, match="Unsupported camera type for camera 'c': 'thermal'"):
             hw._create_minimal_config(
                 "so101_follower",
-                {"c": {"type": "realsense", "index_or_path": 0}},
+                {"c": {"type": "thermal", "index_or_path": 0}},
                 port="/dev/ttyACM0",
             )
 

--- a/tests/test_hardware_robot_lifecycle.py
+++ b/tests/test_hardware_robot_lifecycle.py
@@ -1330,28 +1330,44 @@ class TestStreamExecuteHappyPath:
         hw.cleanup()
 
 
-class TestEnsureLerobotRobotsRegistered:
-    """Behavior tests for ``_ensure_lerobot_robots_registered``.
+class TestEnsureLerobotRegistriesArePopulated:
+    """Behavior tests for the lazy draccus-registry walks.
 
-    This helper populates lerobot's ``RobotConfig`` choice registry by
-    walking every ``lerobot.robots`` subpackage (so robot types whose driver
-    lives in a shared module -- e.g. ``so101_follower`` in ``so_follower`` --
-    are discovered) and then invoking lerobot's third-party plugin loader.
-    The walk is driven entirely by ``pkgutil``/``importlib``/``sys.modules``,
-    so every branch is exercised with injected fakes and no real lerobot
-    driver imports, USB probes, or hardware.
+    Two helpers populate a lerobot choice registry the same way: one walks
+    every ``lerobot.robots`` subpackage (so robot types whose driver lives in a
+    shared module -- e.g. ``so101_follower`` in ``so_follower`` -- are
+    discovered), one walks every ``lerobot.cameras`` backend. Both then invoke
+    lerobot's third-party plugin loader through the single cached helper that
+    owns it, since one call registers every kind at once. The walks are driven
+    entirely by ``pkgutil``/``importlib``/``sys.modules``, so every branch is
+    exercised with injected fakes and no real lerobot driver imports, USB
+    probes, vendor SDKs, or hardware.
 
-    The function is ``@functools.cache``d; ``cache_clear()`` runs before each
-    case so the walk actually re-executes.
+    Branches common to both walks are parametrized over both, so a walk cannot
+    be added with the shared contract untested.
+
+    Every helper is ``@functools.cache``d; the fixture clears them all before
+    each case so the walk actually re-executes. The set is *discovered* rather
+    than listed: clearing only the robot walk left the plugin-loader cases
+    passing vacuously the moment the loader moved into its own cached helper --
+    whichever ran first cached the result for the rest.
     """
 
     @pytest.fixture(autouse=True)
     def _clear_cache(self):
         import strands_robots.hardware_robot as hw
 
-        hw._ensure_lerobot_robots_registered.cache_clear()
+        cached = [
+            value
+            for name, value in vars(hw).items()
+            if name.startswith("_ensure_lerobot") and hasattr(value, "cache_clear")
+        ]
+        assert len(cached) >= 3, f"expected the walks plus the plugin loader; found {len(cached)}"
+        for func in cached:
+            func.cache_clear()
         yield
-        hw._ensure_lerobot_robots_registered.cache_clear()
+        for func in cached:
+            func.cache_clear()
 
     @staticmethod
     def _install_fake_lerobot_robots(monkeypatch, subpackages):
@@ -1367,26 +1383,49 @@ class TestEnsureLerobotRobotsRegistered:
         monkeypatch.setattr(hw.pkgutil, "iter_modules", lambda path: iter(modinfo))
         return fake_robots
 
-    def test_lerobot_robots_absent_and_lerobot_absent_is_debug(self, monkeypatch, caplog):
-        """lerobot wholly missing -> debug-level, no warning, returns cleanly."""
+    @pytest.mark.parametrize(
+        ("walk", "package"),
+        [
+            ("_ensure_lerobot_robots_registered", "lerobot.robots"),
+            ("_ensure_lerobot_cameras_registered", "lerobot.cameras"),
+        ],
+    )
+    def test_lerobot_wholly_absent_is_debug(self, monkeypatch, caplog, walk, package):
+        """lerobot wholly missing -> debug-level, no warning, returns cleanly.
+
+        Expected on a sim-only host that never reaches hardware code: the
+        caller gets a clean "Unsupported robot/camera type" at the lookup site
+        instead of a warning about an install it does not want.
+        """
         import strands_robots.hardware_robot as hw
 
-        monkeypatch.setitem(sys.modules, "lerobot.robots", None)
+        monkeypatch.setitem(sys.modules, package, None)
         monkeypatch.setitem(sys.modules, "lerobot", None)
         with caplog.at_level("WARNING"):
-            hw._ensure_lerobot_robots_registered()
+            getattr(hw, walk)()
         assert not [r for r in caplog.records if r.levelname == "WARNING"]
 
-    def test_partial_install_warns(self, monkeypatch, caplog):
-        """lerobot present but lerobot.robots unimportable -> a warning fires."""
+    @pytest.mark.parametrize(
+        ("walk", "package"),
+        [
+            ("_ensure_lerobot_robots_registered", "lerobot.robots"),
+            ("_ensure_lerobot_cameras_registered", "lerobot.cameras"),
+        ],
+    )
+    def test_partial_install_warns(self, monkeypatch, caplog, walk, package):
+        """lerobot present but its subpackage unimportable -> a warning fires.
+
+        A genuine partial-install signal, worth surfacing without
+        ``--log-level=DEBUG``, which is what separates it from the case above.
+        """
         import strands_robots.hardware_robot as hw
 
-        # ``import lerobot.robots`` fails, but the ``import lerobot`` probe
+        # ``import lerobot.<kind>`` fails, but the ``import lerobot`` probe
         # succeeds -> the partial-install warning branch.
-        monkeypatch.setitem(sys.modules, "lerobot.robots", None)
+        monkeypatch.setitem(sys.modules, package, None)
         monkeypatch.setitem(sys.modules, "lerobot", types.ModuleType("lerobot"))
         with caplog.at_level("WARNING"):
-            hw._ensure_lerobot_robots_registered()
+            getattr(hw, walk)()
         assert any("partial install" in r.message for r in caplog.records)
 
     def test_walks_subpackages_and_skips_failing_driver(self, monkeypatch):
@@ -1419,6 +1458,44 @@ class TestEnsureLerobotRobotsRegistered:
         assert "lerobot.robots.so_follower" in imported
         assert "lerobot.robots.unitree" in imported
         assert "lerobot.robots._helpers" not in imported
+
+    def test_camera_walk_skips_a_backend_whose_sdk_is_absent(self, monkeypatch):
+        """A backend whose import fails is left out of the registry, not fatal.
+
+        ``lerobot.cameras.realsense`` and ``reachy2_camera`` reach vendor SDKs;
+        one absent SDK must not cost the caller ``opencv``. The requested type
+        is then refused at the lookup with the choices that did register.
+        """
+        import strands_robots.hardware_robot as hw
+
+        fake_cameras = types.ModuleType("lerobot.cameras")
+        fake_cameras.__path__ = ["/fake/lerobot/cameras"]  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "lerobot.cameras", fake_cameras)
+        modinfo = [
+            pkgutil.ModuleInfo(None, name, ispkg)
+            for name, ispkg in [("opencv", True), ("realsense", True), ("configs", False)]
+        ]
+        monkeypatch.setattr(hw.pkgutil, "iter_modules", lambda path: iter(modinfo))
+        imported: list[str] = []
+
+        def fake_import(name):
+            imported.append(name)
+            if name.endswith("realsense"):
+                raise ImportError("No module named 'pyrealsense2'")
+            return types.ModuleType(name)
+
+        monkeypatch.setattr(hw.importlib, "import_module", fake_import)
+        plugins = types.ModuleType("lerobot.utils.import_utils")
+        plugins.register_third_party_plugins = lambda: None  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "lerobot.utils.import_utils", plugins)
+
+        hw._ensure_lerobot_cameras_registered()
+
+        assert "lerobot.cameras.opencv" in imported
+        assert "lerobot.cameras.realsense" in imported
+        # ``configs`` is a module, not a backend package, so the ``is_pkg``
+        # guard skips it -- it holds the base class, not a registration.
+        assert "lerobot.cameras.configs" not in imported
 
     def test_third_party_loader_missing_is_debug(self, monkeypatch, caplog):
         """Older lerobot without ``register_third_party_plugins`` -> debug,

--- a/tests/test_robot_factory.py
+++ b/tests/test_robot_factory.py
@@ -1021,23 +1021,24 @@ class TestRealModeConfigDiscovery:
         assert front.index_or_path == "/dev/video2"
         assert (front.fps, front.width, front.height) == (60, 1280, 720)
 
-    def test_unsupported_camera_type_raises_value_error(self):
-        """A non-opencv camera ``type`` is rejected with an actionable error.
+    def test_unregistered_camera_type_raises_value_error(self):
+        """A camera ``type`` lerobot does not register is rejected actionably.
 
-        ``opencv`` is the only backend ``_create_minimal_config`` knows how to
-        build; any other ``type`` (e.g. a typo or an unimplemented backend) must
-        fail loudly at config-build time rather than be silently dropped, so the
-        operator learns immediately the camera will not be wired up.
+        The accepted types are ``CameraConfig``'s choice registry, so a backend
+        lerobot ships is attachable; a ``type`` absent from it (a typo, a
+        backend that needs a plugin that is not installed) must fail loudly at
+        config-build time rather than be silently dropped, so the operator
+        learns immediately the camera will not be wired up.
         """
         pytest.importorskip("lerobot.robots.so_follower")
         from strands_robots.hardware_robot import Robot as HwRobot
 
         hw = HwRobot.__new__(HwRobot)
         hw.tool_name_str = "so101_badcam"
-        with pytest.raises(ValueError, match="Unsupported camera type: realsense"):
+        with pytest.raises(ValueError, match="Unsupported camera type for camera 'depth': 'thermal'"):
             hw._create_minimal_config(
                 "so101_follower",
-                cameras={"depth": {"type": "realsense", "index_or_path": 0}},
+                cameras={"depth": {"type": "thermal", "index_or_path": 0}},
                 port="/dev/null",
             )
 
@@ -1631,12 +1632,38 @@ class TestThirdPartyPluginGuardIsNarrow:
         """#291: the register_third_party_plugins() guard must NOT be a bare
         except Exception. Pin the narrowed (ImportError, AttributeError,
         OSError) tuple by source inspection so the BLE001 pattern cannot
-        silently return."""
+        silently return.
+
+        The function under inspection is *discovered* from the call it guards
+        rather than named: this test previously read
+        ``_ensure_lerobot_robots_registered``, and moving the call into its own
+        helper -- so the camera registry could reuse it -- made the assertion
+        read a body that no longer contained the guard. A guard keyed on a
+        function name passes vacuously the moment that call moves one function
+        over.
+        """
+        import ast
         import inspect
 
         from strands_robots import hardware_robot
 
-        src = inspect.getsource(hardware_robot._ensure_lerobot_robots_registered)
+        module = ast.parse(inspect.getsource(hardware_robot))
+        callers = [
+            node
+            for node in ast.walk(module)
+            if isinstance(node, ast.FunctionDef)
+            and any(
+                isinstance(call.func, ast.Name) and call.func.id == "register_third_party_plugins"
+                for call in ast.walk(node)
+                if isinstance(call, ast.Call)
+            )
+        ]
+        assert len(callers) == 1, (
+            f"expected exactly one function to call register_third_party_plugins(); "
+            f"found {[node.name for node in callers]}"
+        )
+
+        src = ast.get_source_segment(inspect.getsource(hardware_robot), callers[0]) or ""
         assert "except (ImportError, AttributeError, OSError)" in src, (
             "register_third_party_plugins must be guarded by a narrow exception tuple (#291)"
         )

--- a/tests/tools/test_realsense_availability_tracks_the_sdk.py
+++ b/tests/tools/test_realsense_availability_tracks_the_sdk.py
@@ -102,3 +102,39 @@ def test_both_surfaces_report_the_absent_sdk_with_one_install(
     with pytest.raises(ImportError) as excinfo:
         cam_mod._create_camera("realsense", "0", 640, 480, 30, "RGB", "NO_ROTATION")
     assert str(excinfo.value) == cam_mod.REALSENSE_SDK_ABSENT
+
+
+def test_the_robot_factory_reports_the_absent_sdk_and_not_an_unsupported_type() -> None:
+    """The mirror of the creator's refusal, on the surface that attaches a camera.
+
+    ``Robot(..., cameras={"top": {"type": "intelrealsense", ...}})`` used to be
+    refused with ``Unsupported camera type`` because the factory built
+    ``OpenCVCameraConfig`` unconditionally - so this package could *list* a
+    RealSense through the tool above while refusing to attach the same device to
+    a robot, and the refusal named a spelling problem rather than the install.
+
+    The factory now resolves the type through lerobot's ``CameraConfig``
+    registry, so an absent SDK is reported by lerobot itself where the device is
+    opened - naming ``pyrealsense2`` and the same extra the tool names. The
+    config is built either way: a config is not a device, and refusing to
+    describe a camera the operator has not connected yet would make the SDK a
+    build-time dependency of a robot definition.
+    """
+    pytest.importorskip("lerobot")
+    from lerobot.cameras.utils import make_cameras_from_configs
+
+    from strands_robots.hardware_robot import _build_camera_config
+
+    config = _build_camera_config("top", {"type": "intelrealsense", "serial_number_or_name": "123"})
+    assert type(config).__name__ == "RealSenseCameraConfig"
+
+    if _sdk_present():
+        pytest.skip("the SDK is installed, so opening the device is not refused")
+
+    with pytest.raises(ImportError) as excinfo:
+        make_cameras_from_configs({"top": config})
+
+    message = str(excinfo.value)
+    assert "pyrealsense2" in message
+    assert _EXTRA_INSTALL in message
+    assert "Unsupported camera type" not in message


### PR DESCRIPTION
![camera type registry, before and after](https://raw.githubusercontent.com/cagataycali/robots/assets/camera-registry-3404/camera-registry.png)

`_create_minimal_config` resolves the robot name generically -- `RobotConfig.get_choice_class(robot_type)` on lerobot's draccus `ChoiceRegistry`, so "we automatically support every robot lerobot ships without maintaining a hand-rolled mapping". `_build_camera_config`, twenty lines above it, imported `OpenCVCameraConfig` unconditionally and refused everything else.

A camera dict *is* a serialized `CameraConfig`: `type` is draccus' own choice discriminator (`CameraConfig.type` returns `get_choice_name(cls)`) and the remaining keys are fields of the class it selects -- which is exactly what `lerobot.cameras.make_cameras_from_configs` dispatches on. So both halves are now derived: `CameraConfig.get_choice_class(type)` picks the class, `dataclasses.fields()` of that class defines the accepted options.

## The contradiction this closes

`tools/lerobot_camera._create_camera` in this same package opens a RealSense, and `tests/tools/test_realsense_availability_tracks_the_sdk.py` argues the point in its own words -- an absent SDK must be reported as an absent SDK, because a type refusal "sends the caller looking for a spelling that does not exist". The real-mode docs name `realsense_top` / `realsense_side` cameras. Yet attaching one to a robot raised `ValueError: Unsupported camera type: realsense`. The tool could list the device the factory refused to attach.

## Two measured facts shaped the fix

**lerobot registers Intel RealSense as `intelrealsense`.**

```
$ grep -rn register_subclass src/lerobot/cameras/
realsense/configuration_realsense.py:20:@CameraConfig.register_subclass("intelrealsense")
reachy2_camera/configuration_reachy2_camera.py:22:@CameraConfig.register_subclass("reachy2_camera")
opencv/configuration_opencv.py:23:@CameraConfig.register_subclass("opencv")
zmq/configuration_zmq.py:24:@CameraConfig.register_subclass("zmq")
```

The factory's `type` is the discriminator, so it must be the registry's spelling; no alias was added. The refusal carries a `difflib` suggestion instead, so the obvious guess resolves itself:

```
Unsupported camera type for camera 'top': 'realsense'. Did you mean 'intelrealsense'?
  Known lerobot camera types: ['intelrealsense', 'opencv', 'reachy2_camera', 'zmq'].
```

**The registry is populated lazily -- a bare `get_choice_class` would have reported every type unknown, `opencv` included.**

```
$ python3 -c "from lerobot.cameras.configs import CameraConfig; import lerobot.cameras
> from lerobot.cameras.utils import make_cameras_from_configs
> print(sorted(CameraConfig.get_known_choices()))"
[]
```

`lerobot/cameras/__init__.py` carries an explicit comment refusing to re-export the backend configs "to avoid pulling backend-specific dependencies". So `_ensure_lerobot_cameras_registered` mirrors the `pkgutil` walk `_ensure_lerobot_robots_registered` already does, with the same `(ImportError, OSError)` skip -- all four backends register with no vendor SDK installed. The third-party plugin loader both walks share (it covers `lerobot_camera_*` as well as `lerobot_robot_*`) moved into one cached helper, since a single call registers every kind at once.

## Behaviour

| `cameras={"top": {...}}` | before | after |
|---|---|---|
| `type="opencv", index_or_path=0` | `OpenCVCameraConfig` | `OpenCVCameraConfig` |
| `type="intelrealsense", serial_number_or_name="..."` | `ValueError: Unsupported camera type: intelrealsense` | `RealSenseCameraConfig` |
| `type="zmq", server_address="tcp://..."` | `ValueError: Unsupported camera type: zmq` | `ZMQCameraConfig` |
| `type="reachy2_camera", name="teleop", image_type="left"` | `ValueError: Unsupported camera type: reachy2_camera` | `Reachy2CameraConfig` |
| `type="realsense"` (wrong spelling) | `Unsupported camera type: realsense` | refused, naming `'intelrealsense'` |
| `type="intelrealsense", use_depth=True` | unreachable field | `use_depth=True` |
| `type="intelrealsense", index_or_path=0` | -- | refused, listing **RealSense's** fields (`serial_number_or_name`), not OpenCV's |
| unregistered `type="thermal"` | named only the rejected value | lists every registered choice |

An absent vendor SDK is still reported by lerobot, where the device is opened, and is not a type refusal -- measured with `pyrealsense2` absent:

```
ImportError: 'pyrealsense2' is required but not installed.
  Install it with: pip install 'lerobot[intelrealsense]'
"Unsupported camera type" in message: False
```

The second panel above is the stream `use_depth=True` selects: SO-101 rendered headless in MuJoCo (`MUJOCO_GL=egl`), colour beside depth, 0.42-1.30 m. Pre-fix that field was unreachable through `Robot()` because the only class the builder would construct does not declare it.

## Tests

`tests/test_hardware_robot_camera_type_registry.py` (new, 23 cells). Table-driven over `CameraConfig.get_known_choices()`, with a coverage cell asserting the case map names every registered choice -- so a fifth backend lerobot ships fails here until someone verifies it is attachable, rather than quietly joining an unreachable set. Pins the lazy-registration premise in a subprocess, the discriminator round-trip (`built.type == cam_type`), the stream defaults on every backend, and the per-backend option vocabulary.

On a pristine `main` worktree with only the instrument copied in (the two names the tests import; neither changes how the type is resolved): **19 failed / 180 passed**. After: **199 passed**.

Mutants, each measured over those files (199 green baseline, restored green after):

| mutation | failing cells |
|---|---|
| type resolved from the registry but the option vocabulary still OpenCV's | 15 |
| the stream defaults no longer applied to any backend | 10 |
| registry lookup lands but the lazy subpackage walk is skipped | 9 |
| no did-you-mean, so `realsense` never names `intelrealsense` | 1 |
| `TypeError` dropped, so an unhashable `type` escapes from draccus | 1 |

Two existing tests pinned the defect (`test_hardware_robot_config.py`, `test_robot_factory.py` both asserted `"Unsupported camera type: realsense"`, and the latter's docstring stated "`opencv` is the only backend") -- updated to refuse a genuinely unregistered type. `tests/tools/test_realsense_availability_tracks_the_sdk.py` gains the factory mirror of its own creator case.

Two guards were name-keyed on a symbol this change moves, and both would have passed vacuously:

- `TestThirdPartyPluginGuardIsNarrow` read `inspect.getsource(_ensure_lerobot_robots_registered)` for the narrow `except` tuple. It now *discovers* the single function that calls `register_third_party_plugins()` via `ast` and asserts on that, so the guard cannot be defeated by the call moving one function over.
- `TestEnsureLerobotRobotsRegistered`'s fixture cleared one `functools.cache`. With a second cached helper, whichever plugin-loader case ran first cached the result and the others stopped exercising anything -- the full suite caught this as a real failure. The fixture now discovers every cached `_ensure_lerobot*` helper; reverting it to the name-listed version fails 3 cells. The class is renamed and its two shared branches are parametrized over both walks, plus a cell for a camera backend whose SDK import fails.

`_OPENCV_CAMERA_DEFAULTS` -> `_CAMERA_STREAM_DEFAULTS`: `fps`/`width`/`height` are declared on the `CameraConfig` **base**, so they were never OpenCV-specific and the defaults now apply to a RealSense exactly as to a webcam.

LOC: `strands_robots/hardware_robot.py` +167/-41 raw, **+25 executable statements** (741 -> 766) -- the registry walk, the resolver and its refusal; the docstrings and the derivation comment are the bulk of the raw lines. Tests +457/-40, docs +23/-3.

## Gate

`ruff check` + `ruff format --check` clean on `strands_robots tests tests_integ`; `mypy` Success, 1895 files. Full `MUJOCO_GL=egl pytest tests/` on the rebased branch: **50863 passed / 303 skipped / 0 failed in 29m15s**. Docs: `docs/hardware/robot-control.md` `cameras` row rewritten (it documented the OpenCV-only vocabulary) and `docs/getting-started/robot-factory.md` gains the `intelrealsense` example plus the registry paragraph.

`docs/policies/camera-naming.md`'s `realsense_top` naming convention is untouched -- those are camera *keys*, not types, and they now work.