### PR TITLE
feat(policies): an RL training checkpoint is deployable through the policy factory

### DIFF
--- a/changelog.d/3414-rl-checkpoint-is-deployable.md
+++ b/changelog.d/3414-rl-checkpoint-is-deployable.md
@@ -54,5 +54,12 @@ rollout that kept updating would drift the whitening the trained weights expect.
 Missing weights, missing metadata, metadata that is not an object, an omitted
 required field and an unknown `provider` each refuse by name.
 
+The provider is also allowlisted for the fleet rail: `_REGISTRY_POLICY_PROVIDERS`
+in `strands_robots/mesh/security.py` gates which `policy_provider` a mesh /
+Device Connect `execute` or `start` payload may name, and a provider absent from
+it is refused on the wire. Widening it does not relax any other gate - the
+`policy_host`, `server_address`, `pretrained_name_or_path` and `model_path`
+allowlists still apply to every payload.
+
 Documented in `docs/policies/rl.md`, the provider table, and a "Deploying the
 checkpoint" section on `docs/training/rl.md`.

--- a/changelog.d/9999-rl-checkpoint-is-deployable.md
+++ b/changelog.d/9999-rl-checkpoint-is-deployable.md
@@ -1,0 +1,58 @@
+### Added: `create_policy("rl")` - an RL training checkpoint drives a robot
+
+The RL trainers already exported a checkpoint they described as deployable:
+`save_checkpoint` writes `policy.pt` + `policy_meta.json` and documents the
+latter as "a deployable-policy metadata file", `export()` returns "the loadable
+policy artifact for inference", and `act_inference` is docstringed on all three
+backends as "the deterministic (mean) action - the deployable policy". Nothing
+loaded it. No provider in `strands_robots/registry/policies.json` read an RL
+checkpoint, so `create_policy("rl")` raised `Unknown policy provider` and
+`docs/training/rl.md`'s "deployable checkpoint whose actor commands ..." had no
+path behind it - a policy could be trained in sim and then only evaluated by the
+trainer that produced it, never rolled out through `run_policy` / `eval_policy`
+like every other provider. That is also why `strands_robots.training.rl` had no
+importer anywhere in the package: the loop was open at the deployment end.
+
+`RLCheckpointPolicy` closes it. `create_policy("rl", checkpoint_dir=...)` - the
+directory spelling the trainer already uses (`TrainResult.checkpoint_dir`,
+`BaseRLAlgo.load_checkpoint`, `latest_checkpoint`) - loads the pair and presents
+the trained actor as an ordinary `Policy`, so a PPO / FastSAC / FastTD3 run
+deploys with no hand-built glue:
+
+```python
+result = create_trainer("ppo").train(spec)
+sim.run_policy(robot_name="so101", policy_provider="rl",
+               policy_config={"checkpoint_dir": result.checkpoint_dir})
+```
+
+The architecture is rebuilt through the backend's own `build_actor_critic`
+rather than reimplemented, because the checkpoint metadata does not determine it:
+PPO's actor emits `num_actions` raw Gaussian means, FastTD3's emits
+`num_actions` through a `tanh`, and FastSAC's emits `2 * num_actions` (a
+mean/log-std pair) and squashes the mean, while all three record the same
+`num_actions`. `provider` is what selects the graph, and each backend's own
+`act_inference` supplies its squash, so a FastSAC actor cannot be loaded into a
+PPO-shaped network and silently mis-scaled. The three builders are public for
+that reason (`_build_actor_critic` -> `build_actor_critic`, taking the
+`hidden_dims` / `init_noise_std` they actually read instead of a whole
+`RLTrainSpec`), and the reader lives beside the writer in
+`training/rl/checkpoint.py` as `load_deployable_actor`, usable directly for a
+custom control loop.
+
+Everything that decides what a command *means* is read rather than assumed.
+`actor_obs_keys` are bound by name in the trained order - that order is part of
+the weights, so a reshuffled observation dict yields the same action while
+swapping two values does not - and a key the observation does not carry is
+refused instead of defaulted, because substituting a zero commands the robot
+from a state it is not in. The checkpoint's `action_keys` win over
+`set_robot_state_keys` (which remains the fallback for a checkpoint saved
+without a robot bound), and an actor whose width does not match the bound keys
+is refused rather than silently dropping the last command. The saved observation
+normalizer is restored in eval mode, so the statistics the run finished on stay
+frozen: `EmpiricalNormalization` only folds a batch while training, and a
+rollout that kept updating would drift the whitening the trained weights expect.
+Missing weights, missing metadata, metadata that is not an object, an omitted
+required field and an unknown `provider` each refuse by name.
+
+Documented in `docs/policies/rl.md`, the provider table, and a "Deploying the
+checkpoint" section on `docs/training/rl.md`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -81,13 +81,13 @@ graph TB
 | `strands_robots/simulation/` | MuJoCo `AgentTool` - 77 actions. | `Simulation`, `SimWorld`, `SimRobot`, `SimObject`, `SimCamera` |
 | `strands_robots/simulation/base.py` | Backend ABC for future Isaac/Newton backends. | `SimEngine` |
 | `strands_robots/hardware_robot.py` | Real-servo path. Async task execution + status. | `Robot` (class), `TaskStatus`, `RobotTaskState` |
-| `strands_robots/policies/` | ABC + 14 providers + factory + JSON registry. | `Policy`, `create_policy()` |
+| `strands_robots/policies/` | ABC + 15 providers + factory + JSON registry. | `Policy`, `create_policy()` |
 | `strands_robots/dataset_recorder.py` | LeRobot v3 writer. | `DatasetRecorder` |
 | `strands_robots/tools/` | 25 `@tool`-decorated helpers. | `lerobot_camera`, `serial_tool`, etc. |
 
 ## ABCs
 
-**`Policy`** - three abstract members every implementation supplies: `get_actions(observation_dict, instruction) -> list[dict]` (async), `set_robot_state_keys(keys)`, and the `provider_name` property. The rest of the contract is *declared* rather than implemented - the runtime reads the declaration and supplies what it names: `requires_images` (default `True`), `required_bodies` (default `()`; the only way to receive a body pose beyond the floating base - a tracker that skips it gets `base_quat`, the pelvis) and `children` (default `()`; what a wrapper returns so a capability probe reaches the policy inside it). `reset(seed)` (default no-op) is called per episode. 16 implementations ship; [Policies](policies/overview.md) is the provider table.
+**`Policy`** - three abstract members every implementation supplies: `get_actions(observation_dict, instruction) -> list[dict]` (async), `set_robot_state_keys(keys)`, and the `provider_name` property. The rest of the contract is *declared* rather than implemented - the runtime reads the declaration and supplies what it names: `requires_images` (default `True`), `required_bodies` (default `()`; the only way to receive a body pose beyond the floating base - a tracker that skips it gets `base_quat`, the pelvis) and `children` (default `()`; what a wrapper returns so a capability probe reaches the policy inside it). `reset(seed)` (default no-op) is called per episode. 17 implementations ship; [Policies](policies/overview.md) is the provider table.
 
 **`SimEngine`** - `create_world()`, `step()`, 30+ abstract actions. Today: MuJoCo CPU. Roadmap: Isaac Sim, Newton.
 

--- a/docs/policies/overview.md
+++ b/docs/policies/overview.md
@@ -67,6 +67,7 @@ so neither can silently drift.
 | [`lerobot_async`](lerobot-async.md) | `LerobotAsyncPolicy` | `lerobot-async` | Offload a LeRobot policy to a GPU box over lerobot's native async-inference gRPC transport; the robot host stays light. Edge-device inference |
 | [`cosmos3`](cosmos3.md) | `Cosmos3Policy` | `cosmos3-service` | NVIDIA Cosmos 3 omnimodal VLA over WebSocket |
 | [`remote`](remote.md) | `RemotePolicy` | `inference` | Offload a large policy to a GPU box: forward observations to a remote `PolicyServer` over WebSocket, get back action chunks. Edge-device inference |
+| [`rl`](rl.md) | `RLCheckpointPolicy` | _(core)_ | Roll out an actor trained by `create_trainer("ppo"|"fast_sac"|"fast_td3")`: loads the run's `policy.pt` + `policy_meta.json` and drives the robot deterministically (non-VLA) |
 | [`curobo`](curobo.md) | `CuroboPolicy` | `curobo` | NVIDIA cuRobo collision-aware motion planning, in-process CUDA (non-VLA) |
 | [`moveit2`](moveit2.md) | `MoveIt2Policy` | `moveit2` | MoveIt2 motion planning over a ROS 2 sidecar (ZMQ), no in-venv ROS 2 deps (non-VLA) |
 | [`wbc`](wbc.md) | `WBCPolicy` | `wbc` | NVIDIA GR00T Whole-Body-Control (SONIC) Unitree G1 humanoid locomotion, in-process ONNX, no GPU (non-VLA) |

--- a/docs/policies/rl.md
+++ b/docs/policies/rl.md
@@ -1,0 +1,67 @@
+# RL Checkpoint (trained actor)
+
+`create_policy("rl", checkpoint_dir=...)` returns an `RLCheckpointPolicy` - the
+deterministic actor from a reinforcement-learning run, presented as an ordinary
+[`Policy`](overview.md). It is the inference half of
+[Reinforcement Learning](../training/rl.md): `create_trainer("ppo")` (or
+`fast_sac` / `fast_td3`) writes `policy.pt` + `policy_meta.json`, and this
+provider rolls that pair out.
+
+```python
+from strands_robots import Robot, create_policy
+from strands_robots.training import create_trainer
+
+result = create_trainer("ppo").train(spec)      # -> result.checkpoint_dir
+
+sim = Robot("so101", mode="sim")
+sim.run_policy(
+    robot_name="so101",
+    policy_provider="rl",
+    policy_config={"checkpoint_dir": result.checkpoint_dir},
+    duration=10.0,
+)
+```
+
+`checkpoint_dir` is spelled as the trainer spells it (`TrainResult.checkpoint_dir`,
+`BaseRLAlgo.load_checkpoint`, `latest_checkpoint`), so the value a caller already
+holds is the value this provider takes.
+
+| Config key       | Default | Meaning                                                       |
+|------------------|---------|---------------------------------------------------------------|
+| `checkpoint_dir` | -       | Directory holding `policy.pt` + `policy_meta.json` (required)  |
+| `device`         | `cpu`   | Torch device to load the actor onto                            |
+
+## What the checkpoint decides
+
+`policy_meta.json` is read, not guessed. It carries the vocabularies and the
+network shape, and each one is load-bearing:
+
+- **`provider`** selects the actor architecture. The three backends do not share
+  one network: PPO's actor emits `num_actions` raw Gaussian means, FastTD3's
+  emits `num_actions` through a `tanh`, and FastSAC's emits `2 * num_actions` (a
+  mean/log-std pair) and squashes the mean. All three record `num_actions`, so
+  the output width is *not* derivable from the metadata alone. The actor is
+  rebuilt through the backend's own `build_actor_critic` and driven through its
+  own `act_inference`, so the deployed graph is the one that was trained.
+- **`actor_obs_keys`** are read from the observation by name, in the trained
+  order - that order is part of the weights. A reshuffled observation dict gives
+  the same action; a key the observation does not carry is refused, because
+  substituting a zero would command the robot from a state it is not in.
+- **`action_keys`** name the actuators the outputs drive - the robot's
+  `robot_action_keys`, not its joint list. They win over `set_robot_state_keys`,
+  which is the fallback for a checkpoint saved without a robot bound. An actor
+  whose width does not match the bound keys is refused rather than silently
+  dropping a command.
+
+The observation normalizer saved beside the weights is restored in eval mode, so
+the statistics the run finished on are frozen: `EmpiricalNormalization` only
+folds a batch while training, and a rollout that kept updating would drift the
+whitening the trained weights expect.
+
+Actions are one tick per call - an RL actor is a per-step controller trained on
+the state it is given, so it has no horizon to predict over. `instruction` is
+ignored: the actor was trained against a reward function, not language.
+
+Needs `torch`, which the RL trainers already require; no extra beyond them.
+Reading a checkpoint's actor without the policy wrapper is
+`strands_robots.training.rl.load_deployable_actor(checkpoint_dir)`.

--- a/docs/training/rl.md
+++ b/docs/training/rl.md
@@ -123,6 +123,31 @@ the Newton backend's floating base is a joint with no commandable scalar. `SimEn
 sizes `num_actions` from the same list, so `len(action_keys) == num_actions`
 always holds. Pass `action_dim` to `SimEnv` to override the width.
 
+### Deploying the checkpoint
+
+The pair is deployable through the policy factory: `create_policy("rl",
+checkpoint_dir=...)` loads it and presents the trained actor as an ordinary
+[`Policy`](../policies/rl.md), so it drives a robot through the same
+`run_policy` / `eval_policy` path as every other provider.
+
+```python
+result = create_trainer("ppo").train(spec)
+
+sim.run_policy(
+    robot_name="so101",
+    policy_provider="rl",
+    policy_config={"checkpoint_dir": result.checkpoint_dir},
+    duration=10.0,
+)
+```
+
+The provider reads `provider` to rebuild the right architecture (the three
+backends' actors differ in output width and squash), binds `actor_obs_keys` by
+name in the trained order, and restores the observation normalizer frozen. To
+read the actor without the policy wrapper - for a custom control loop -
+`strands_robots.training.rl.load_deployable_actor(checkpoint_dir)` returns a
+`DeployableActor` whose `act(obs)` is the deterministic command.
+
 `PpoTrainer` trains fine on CPU (its `hardware_floor` declares no GPU
 requirement); MuJoCo stepping dominates, not the network.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
   - LeRobot Async (gRPC inference): policies/lerobot-async.md
   - MolmoAct2 (SO-100/101): policies/molmoact2.md
   - Remote (WebSocket inference): policies/remote.md
+  - RL Checkpoint (trained actor): policies/rl.md
   - Persistent Worker (long-lived inference): policies/persistent-worker.md
   - Camera Naming: policies/camera-naming.md
   - Custom Policies: policies/custom-policies.md

--- a/strands_robots/mesh/security.py
+++ b/strands_robots/mesh/security.py
@@ -442,6 +442,8 @@ _REGISTRY_POLICY_PROVIDERS: frozenset[str] = frozenset(
         "microduck_stand",
         # RemotePolicy
         "remote",
+        # RLCheckpointPolicy
+        "rl",
     }
 )
 

--- a/strands_robots/policies/rl.py
+++ b/strands_robots/policies/rl.py
@@ -1,0 +1,179 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Roll out an actor trained by the RL trainers (``create_policy("rl")``).
+
+The inference half of the RL loop. ``create_trainer("ppo" | "fast_sac" |
+"fast_td3")`` trains against a :class:`~strands_robots.training.rl.env.SimEnv`
+and writes ``policy.pt`` + ``policy_meta.json``; this provider loads that pair
+and presents it as an ordinary :class:`~strands_robots.policies.base.Policy`, so
+a trained actor drives a robot through the same
+:meth:`~strands_robots.simulation.base.SimEngine.run_policy` /
+:meth:`~strands_robots.simulation.base.SimEngine.eval_policy` path as every
+other provider::
+
+    result = create_trainer("ppo").train(spec)
+    sim.run_policy(robot_name="so101", policy_provider="rl",
+                   policy_config={"checkpoint_dir": result.checkpoint_dir})
+
+``checkpoint_dir`` is spelled as the trainer spells it (``TrainResult.checkpoint_dir``,
+``BaseRLAlgo.load_checkpoint``, ``latest_checkpoint``), so the value a caller
+already holds is the value this provider takes.
+
+The checkpoint's ``actor_obs_keys`` are read from the observation by name, in the
+trained order, because that order is part of the weights: an actor trained on
+``["1", "2", "1.vel"]`` fed ``["1", "1.vel", "2"]`` is being given a different
+input. A key the observation does not carry is refused rather than defaulted -
+substituting a zero would command a real robot from a fabricated state.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from strands_robots.policies.base import Policy
+from strands_robots.utils import name_list_error
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from strands_robots.training.rl.checkpoint import DeployableActor
+
+logger = logging.getLogger(__name__)
+
+
+class RLCheckpointPolicy(Policy):
+    """Deterministic rollout of an RL training checkpoint's actor.
+
+    Args:
+        checkpoint_dir: Directory holding ``policy.pt`` + ``policy_meta.json``,
+            as returned by ``TrainResult.checkpoint_dir``.
+        device: Torch device to load the actor onto (default ``"cpu"``; PPO on
+            MuJoCo declares no GPU floor).
+        **kwargs: Ignored, for factory uniformity.
+
+    Raises:
+        ValueError: If ``checkpoint_dir`` is missing or blank. There is no
+            default checkpoint: without one there is no trained actor to run.
+        FileNotFoundError: If the directory holds no ``policy.pt`` /
+            ``policy_meta.json``.
+    """
+
+    def __init__(self, checkpoint_dir: str = "", device: str = "cpu", **kwargs: Any) -> None:
+        if not checkpoint_dir or not str(checkpoint_dir).strip():
+            raise ValueError(
+                "checkpoint_dir is required for the 'rl' policy provider: pass the "
+                "directory a trainer wrote (TrainResult.checkpoint_dir), e.g. "
+                "create_policy('rl', checkpoint_dir=result.checkpoint_dir)"
+            )
+        from strands_robots.training.rl.checkpoint import load_deployable_actor
+
+        self._actor: DeployableActor = load_deployable_actor(str(checkpoint_dir).strip(), device=device)
+        self._device = device
+        self.robot_state_keys: list[str] = []
+        logger.info(
+            "RL checkpoint policy loaded: provider=%s iteration=%s actor_obs=%d actions=%d",
+            self._actor.provider,
+            self._actor.iteration,
+            len(self._actor.actor_obs_keys),
+            self._actor.num_actions,
+        )
+
+    @property
+    def provider_name(self) -> str:
+        """Provider name for identification (always ``"rl"``)."""
+        return "rl"
+
+    @property
+    def requires_images(self) -> bool:
+        """RL actors trained through ``SimEnv`` consume scalar state only."""
+        return False
+
+    @property
+    def trained_by(self) -> str:
+        """Trainer that wrote the loaded checkpoint (``"ppo"``, ``"fast_sac"``, ``"fast_td3"``)."""
+        return self._actor.provider
+
+    @property
+    def actor_obs_keys(self) -> list[str]:
+        """Ordered observation keys the loaded actor was trained on."""
+        return list(self._actor.actor_obs_keys)
+
+    @property
+    def action_keys(self) -> list[str]:
+        """Ordered action keys the loaded actor's outputs drive.
+
+        The checkpoint's own ``action_keys`` when it recorded them, else the keys
+        :meth:`set_robot_state_keys` supplied.
+        """
+        return list(self._actor.action_keys or self.robot_state_keys)
+
+    def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        """Record the robot's ordered action keys, used only if the checkpoint has none.
+
+        A checkpoint written with a robot bound already names the actuators its
+        outputs drive, and those win: they are what the actor was trained
+        against. This is the fallback for a checkpoint saved without one.
+
+        Raises:
+            ValueError: If ``robot_state_keys`` is not an ordered list of
+                distinct non-blank names, per
+                :func:`~strands_robots.utils.name_list_error`.
+        """
+        if robot_state_keys and (
+            error := name_list_error(robot_state_keys, "robot_state_keys", "set_robot_state_keys")
+        ):
+            raise ValueError(error)
+        self.robot_state_keys = robot_state_keys
+
+    async def get_actions(
+        self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        """Return the actor's deterministic action for the current observation.
+
+        A one-tick chunk: an RL actor is a per-step controller trained on the
+        state it is given, so it has no horizon to predict over.
+
+        Args:
+            observation_dict: The observation, carrying one scalar per key named
+                in the checkpoint's ``actor_obs_keys``.
+            instruction: Ignored - an RL actor is trained against a reward
+                function, not conditioned on language.
+            **kwargs: Ignored.
+
+        Returns:
+            A single-element list holding one ``{action_key: float}`` dict.
+
+        Raises:
+            ValueError: If the observation omits a key the actor was trained on,
+                or if no action keys are known. Both would otherwise command the
+                robot from a fabricated state or bind outputs to the wrong
+                actuators.
+        """
+        import torch
+
+        missing = [key for key in self._actor.actor_obs_keys if key not in observation_dict]
+        if missing:
+            raise ValueError(
+                f"observation omits actor_obs_keys the {self._actor.provider} checkpoint was "
+                f"trained on: {missing}; present keys: {sorted(observation_dict)}"
+            )
+        action_keys = self.action_keys
+        if not action_keys:
+            raise ValueError(
+                "no action keys: the checkpoint recorded none (it was trained without a robot "
+                "bound) and set_robot_state_keys was not called, so the actor's "
+                f"{self._actor.num_actions} outputs cannot be bound to actuators"
+            )
+        if len(action_keys) != self._actor.num_actions:
+            raise ValueError(
+                f"the {self._actor.provider} checkpoint's actor emits {self._actor.num_actions} "
+                f"actions but {len(action_keys)} action keys are bound ({action_keys}); "
+                "the robot does not match the one the actor was trained on"
+            )
+
+        obs = torch.tensor(
+            [[float(observation_dict[key]) for key in self._actor.actor_obs_keys]],
+            dtype=torch.float32,
+            device=self._device,
+        )
+        action = self._actor.act(obs)[0]
+        return [{key: float(action[i]) for i, key in enumerate(action_keys)}]

--- a/strands_robots/registry/policies.json
+++ b/strands_robots/registry/policies.json
@@ -326,6 +326,22 @@
         "^wss?://"
       ]
     },
+    "rl": {
+      "module": "strands_robots.policies.rl",
+      "class": "RLCheckpointPolicy",
+      "description": "Deterministic rollout of an RL training checkpoint's actor (policy.pt + policy_meta.json written by create_trainer('ppo'|'fast_sac'|'fast_td3'))",
+      "requires": [],
+      "config_keys": [
+        "checkpoint_dir",
+        "device"
+      ],
+      "defaults": {
+        "device": "cpu"
+      },
+      "shorthands": [
+        "rl"
+      ]
+    },
     "microduck": {
       "module": "strands_robots.policies.microduck",
       "class": "MicroduckPolicy",

--- a/strands_robots/training/rl/__init__.py
+++ b/strands_robots/training/rl/__init__.py
@@ -16,6 +16,9 @@ Public surface:
     - :class:`SimEnv` - ``SimEngine`` -> RL env adapter.
     - :class:`VecSimEnv` - N independent ``SimEnv`` presented as one ``(N, D)`` env.
     - :class:`EmpiricalNormalization` - running observation normalizer.
+    - :func:`load_deployable_actor` / :class:`DeployableActor` - read a saved
+      checkpoint's deterministic actor back for deployment (the reader behind
+      the ``rl`` policy provider).
 
 Importing this package imports ``torch`` (via the env / algo modules), so it is
 not imported by ``strands_robots.training.__init__``; the ``ppo`` provider is
@@ -23,6 +26,11 @@ registered there through a lazy loader instead.
 """
 
 from strands_robots.training.rl.base_algo import BaseRLAlgo, RLTrainSpec
+from strands_robots.training.rl.checkpoint import (
+    DeployableActor,
+    load_deployable_actor,
+    read_checkpoint_meta,
+)
 from strands_robots.training.rl.env import SimEnv
 from strands_robots.training.rl.fast_sac import FastSacTrainer
 from strands_robots.training.rl.fast_td3 import FastTd3Trainer
@@ -43,4 +51,7 @@ __all__ = [
     "GymSimEnv",
     "VecSimEnv",
     "EmpiricalNormalization",
+    "DeployableActor",
+    "load_deployable_actor",
+    "read_checkpoint_meta",
 ]

--- a/strands_robots/training/rl/checkpoint.py
+++ b/strands_robots/training/rl/checkpoint.py
@@ -1,0 +1,202 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Load an RL checkpoint's deterministic actor for deployment.
+
+:meth:`~strands_robots.training.rl.base_algo.BaseRLAlgo.save_checkpoint` writes
+``policy.pt`` + ``policy_meta.json`` and calls the pair "a deployable
+checkpoint". This module is the reader that makes that true: it rebuilds the
+network the ``state_dict`` was saved from, restores the weights and the frozen
+observation normalizer, and hands back the deterministic action function plus
+the vocabularies the actor was trained against.
+
+The reader lives beside the writer because the two share one format. The three
+backends do not share one *network*: PPO's actor emits ``num_actions`` raw
+Gaussian means, FastTD3's emits ``num_actions`` through a ``tanh``, and
+FastSAC's emits ``2 * num_actions`` (a mean/log-std pair) and squashes the mean.
+``policy_meta.json`` records ``num_actions`` for all three, so the output width
+is not derivable from the metadata alone -- ``provider`` is what selects the
+architecture, and each backend's own ``act_inference`` supplies the squash. A
+reader that guessed instead would silently mis-scale a FastSAC actor's commands.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import torch
+
+#: Module owning the ``build_actor_critic`` for each RL backend that writes a
+#: checkpoint, keyed by the ``provider`` field ``save_checkpoint`` stamps.
+_BACKEND_MODULES: dict[str, str] = {
+    "ppo": "strands_robots.training.rl.ppo",
+    "fast_sac": "strands_robots.training.rl.fast_sac",
+    "fast_td3": "strands_robots.training.rl.fast_td3",
+}
+
+#: ``policy_meta.json`` fields a deployment needs. Absent any one of them the
+#: actor cannot be rebuilt or bound to a robot, so the read refuses by name
+#: rather than substituting a default that would command the wrong joints.
+_REQUIRED_META_FIELDS = (
+    "provider",
+    "num_actor_obs",
+    "num_critic_obs",
+    "num_actions",
+    "actor_obs_keys",
+    "hidden_dims",
+)
+
+
+@dataclass(frozen=True)
+class DeployableActor:
+    """An RL checkpoint's deterministic actor plus the vocabularies it was trained on.
+
+    Attributes:
+        provider: Trainer that wrote the checkpoint (``"ppo"``, ``"fast_sac"``,
+            ``"fast_td3"``).
+        actor_obs_keys: Ordered observation keys the actor input is concatenated
+            from. The order is part of the trained weights, not a preference.
+        action_keys: Ordered action keys the outputs drive - the robot's
+            ``robot_action_keys``, not its joint list. Empty when the checkpoint
+            was written without a robot bound.
+        num_actions: Number of action outputs.
+        iteration: Training iteration the checkpoint was saved at, or ``None``.
+        module: The loaded ``nn.Module``, in eval mode.
+        normalizer: The frozen observation normalizer, or ``None`` when the run
+            trained with ``normalize_obs=False``.
+    """
+
+    provider: str
+    actor_obs_keys: list[str]
+    action_keys: list[str]
+    num_actions: int
+    iteration: int | None
+    module: Any
+    normalizer: Any
+
+    def act(self, actor_obs: torch.Tensor) -> torch.Tensor:
+        """Return the deterministic action for a batch of actor observations.
+
+        Whitens with the frozen normalizer (when the run trained with one) and
+        calls the backend's own ``act_inference``, so the squash a backend
+        applies to its deployable action is applied here too.
+
+        Args:
+            actor_obs: Batched observations, shape ``(batch, num_actor_obs)``.
+
+        Returns:
+            Actions of shape ``(batch, num_actions)``.
+        """
+        import torch
+
+        with torch.no_grad():
+            x = actor_obs if self.normalizer is None else self.normalizer(actor_obs, update=False)
+            return self.module.act_inference(x)
+
+
+def read_checkpoint_meta(checkpoint_dir: str) -> dict[str, Any]:
+    """Read and validate ``policy_meta.json`` from a checkpoint directory.
+
+    Args:
+        checkpoint_dir: Directory holding ``policy.pt`` + ``policy_meta.json``,
+            as returned by ``TrainResult.checkpoint_dir``.
+
+    Returns:
+        The parsed metadata mapping.
+
+    Raises:
+        FileNotFoundError: When ``policy_meta.json`` is absent - the checkpoint
+            carries weights but nothing naming the observations they expect.
+        ValueError: When the metadata is not a mapping, omits a required field,
+            or names a ``provider`` with no known architecture. Each is a
+            checkpoint that cannot be deployed correctly, and a default would
+            bind the actor to the wrong observations or actuators.
+    """
+    path = os.path.join(checkpoint_dir, "policy_meta.json")
+    if not os.path.isfile(path):
+        raise FileNotFoundError(
+            f"no policy_meta.json in checkpoint dir: {checkpoint_dir}; "
+            "the file records the observation and action keys the actor was trained on, "
+            "so weights alone cannot be bound to a robot"
+        )
+    with open(path, encoding="utf-8") as f:
+        meta = json.load(f)
+    if not isinstance(meta, dict):
+        raise ValueError(f"policy_meta.json in {checkpoint_dir} must be a JSON object, got {type(meta).__name__}")
+    missing = [field for field in _REQUIRED_META_FIELDS if field not in meta]
+    if missing:
+        raise ValueError(f"policy_meta.json in {checkpoint_dir} omits required field(s): {', '.join(missing)}")
+    provider = meta["provider"]
+    if provider not in _BACKEND_MODULES:
+        raise ValueError(
+            f"policy_meta.json in {checkpoint_dir} names provider {provider!r}, "
+            f"which has no known actor architecture; expected one of {sorted(_BACKEND_MODULES)}"
+        )
+    return meta
+
+
+def load_deployable_actor(checkpoint_dir: str, device: str = "cpu") -> DeployableActor:
+    """Load the deterministic actor from an RL training checkpoint.
+
+    Rebuilds the backend's network through its own ``build_actor_critic`` - so
+    the deployed graph is the one that was trained, not a reimplementation -
+    restores ``policy.pt`` into it, and freezes both the module and the
+    observation normalizer into eval mode.
+
+    Args:
+        checkpoint_dir: Directory holding ``policy.pt`` + ``policy_meta.json``.
+        device: Torch device to load onto.
+
+    Returns:
+        A :class:`DeployableActor` whose ``act`` is the deployed command.
+
+    Raises:
+        FileNotFoundError: When ``policy.pt`` or ``policy_meta.json`` is absent.
+        ValueError: When the metadata is unusable, per :func:`read_checkpoint_meta`.
+    """
+    import torch
+
+    from strands_robots.training.rl.normalization import EmpiricalNormalization
+
+    meta = read_checkpoint_meta(checkpoint_dir)
+    weights = os.path.join(checkpoint_dir, "policy.pt")
+    if not os.path.isfile(weights):
+        raise FileNotFoundError(f"no policy.pt in checkpoint dir: {checkpoint_dir}")
+
+    num_actor_obs = int(meta["num_actor_obs"])
+    build = import_module(_BACKEND_MODULES[meta["provider"]]).build_actor_critic
+    module = build(
+        num_actor_obs,
+        int(meta["num_critic_obs"]),
+        int(meta["num_actions"]),
+        hidden_dims=tuple(int(h) for h in meta["hidden_dims"]),
+    ).to(device)
+    # weights_only=True: the payload is state_dicts + an int + a str, matching
+    # the loader BaseRLAlgo.load_checkpoint uses, so the legacy unpickler's
+    # arbitrary-code-execution surface stays closed.
+    state = torch.load(weights, map_location=device, weights_only=True)
+    module.load_state_dict(state["actor_critic"])
+    module.eval()
+
+    normalizer = None
+    if "actor_norm" in state:
+        normalizer = EmpiricalNormalization(num_actor_obs, device)
+        normalizer.load_state_dict(state["actor_norm"])
+        # eval() is what freezes the running statistics: EmpiricalNormalization
+        # only folds a batch while training, so a deployed actor whitens every
+        # observation with the statistics the run finished on.
+        normalizer.eval()
+
+    return DeployableActor(
+        provider=str(meta["provider"]),
+        actor_obs_keys=[str(k) for k in meta["actor_obs_keys"]],
+        action_keys=[str(k) for k in meta.get("action_keys") or []],
+        num_actions=int(meta["num_actions"]),
+        iteration=meta.get("iteration"),
+        module=module,
+        normalizer=normalizer,
+    )

--- a/strands_robots/training/rl/fast_sac.py
+++ b/strands_robots/training/rl/fast_sac.py
@@ -58,8 +58,29 @@ def _mlp(in_dim: int, hidden: tuple[int, ...], out_dim: int) -> Any:
     return nn.Sequential(*layers)
 
 
-def _build_actor_critic(num_actor_obs: int, num_critic_obs: int, num_actions: int, spec: RLTrainSpec) -> Any:
-    """Construct the SAC ``ActorCritic`` module: tanh-Gaussian actor + twin Q critics."""
+def build_actor_critic(
+    num_actor_obs: int,
+    num_critic_obs: int,
+    num_actions: int,
+    *,
+    hidden_dims: tuple[int, ...] = (128, 128),
+) -> Any:
+    """Construct the SAC ``ActorCritic`` module: tanh-Gaussian actor + twin Q critics.
+
+    Public for the same reason as its PPO peer: ``load_deployable_actor``
+    rebuilds this graph to load a ``policy.pt`` saved from it, so the trainer
+    and the deployer cannot drift into two different networks.
+
+    Args:
+        num_actor_obs: Width of the actor observation vector.
+        num_critic_obs: Width of the critic observation vector.
+        num_actions: Number of action outputs.
+        hidden_dims: Hidden layer widths, expanded for every network built.
+
+    Returns:
+        An ``nn.Module`` whose ``act_inference`` is the deterministic action
+        a deployed checkpoint commands.
+    """
     import torch
     import torch.nn as nn
 
@@ -69,12 +90,12 @@ def _build_actor_critic(num_actor_obs: int, num_critic_obs: int, num_actions: in
         def __init__(self) -> None:
             super().__init__()
             # Actor outputs (mean, log_std) for the pre-squash Gaussian.
-            self.actor = _mlp(num_actor_obs, spec.hidden_dims, 2 * num_actions)
+            self.actor = _mlp(num_actor_obs, hidden_dims, 2 * num_actions)
             # Twin critics Q(critic_obs, action) -> scalar (clipped double-Q).
-            self.q1 = _mlp(num_critic_obs + num_actions, spec.hidden_dims, 1)
-            self.q2 = _mlp(num_critic_obs + num_actions, spec.hidden_dims, 1)
-            self.q1_target = _mlp(num_critic_obs + num_actions, spec.hidden_dims, 1)
-            self.q2_target = _mlp(num_critic_obs + num_actions, spec.hidden_dims, 1)
+            self.q1 = _mlp(num_critic_obs + num_actions, hidden_dims, 1)
+            self.q2 = _mlp(num_critic_obs + num_actions, hidden_dims, 1)
+            self.q1_target = _mlp(num_critic_obs + num_actions, hidden_dims, 1)
+            self.q2_target = _mlp(num_critic_obs + num_actions, hidden_dims, 1)
             self.q1_target.load_state_dict(self.q1.state_dict())
             self.q2_target.load_state_dict(self.q2.state_dict())
             for p in self.q1_target.parameters():
@@ -274,8 +295,11 @@ class FastSacTrainer(BaseRLAlgo):
             self.env.device = self.device
         self.steps_per_iter = spec.rollout_steps * spec.num_envs
 
-        self.actor_critic = _build_actor_critic(
-            self.env.num_actor_obs, self.env.num_critic_obs, self.env.num_actions, spec
+        self.actor_critic = build_actor_critic(
+            self.env.num_actor_obs,
+            self.env.num_critic_obs,
+            self.env.num_actions,
+            hidden_dims=tuple(spec.hidden_dims),
         ).to(self.device)
 
         actor_params = list(self.actor_critic.actor.parameters())

--- a/strands_robots/training/rl/fast_td3.py
+++ b/strands_robots/training/rl/fast_td3.py
@@ -67,12 +67,33 @@ def _mlp(in_dim: int, hidden: tuple[int, ...], out_dim: int) -> Any:
     return nn.Sequential(*layers)
 
 
-def _build_actor_critic(num_actor_obs: int, num_critic_obs: int, num_actions: int, spec: RLTrainSpec) -> Any:
+def build_actor_critic(
+    num_actor_obs: int,
+    num_critic_obs: int,
+    num_actions: int,
+    *,
+    hidden_dims: tuple[int, ...] = (128, 128),
+) -> Any:
     """Construct the TD3 ``ActorCritic`` module: deterministic actor + twin Q critics.
 
     Every network that has a Polyak target carries it here - the actor as well
     as both critics, because target policy smoothing samples around the *target*
     policy's action, not the live one.
+
+
+    Public for the same reason as its PPO peer: ``load_deployable_actor``
+    rebuilds this graph to load a ``policy.pt`` saved from it, so the trainer
+    and the deployer cannot drift into two different networks.
+
+    Args:
+        num_actor_obs: Width of the actor observation vector.
+        num_critic_obs: Width of the critic observation vector.
+        num_actions: Number of action outputs.
+        hidden_dims: Hidden layer widths, expanded for every network built.
+
+    Returns:
+        An ``nn.Module`` whose ``act_inference`` is the deterministic action
+        a deployed checkpoint commands.
     """
     import torch
     import torch.nn as nn
@@ -85,13 +106,13 @@ def _build_actor_critic(num_actor_obs: int, num_critic_obs: int, num_actions: in
             # Actor outputs a pre-tanh action; tanh bounds it to [-1, 1], the
             # same action interval the SAC actor squashes into, so the two
             # off-policy backends drive SimEnv with one action contract.
-            self.actor = _mlp(num_actor_obs, spec.hidden_dims, num_actions)
-            self.actor_target = _mlp(num_actor_obs, spec.hidden_dims, num_actions)
+            self.actor = _mlp(num_actor_obs, hidden_dims, num_actions)
+            self.actor_target = _mlp(num_actor_obs, hidden_dims, num_actions)
             # Twin critics Q(critic_obs, action) -> scalar (clipped double-Q).
-            self.q1 = _mlp(num_critic_obs + num_actions, spec.hidden_dims, 1)
-            self.q2 = _mlp(num_critic_obs + num_actions, spec.hidden_dims, 1)
-            self.q1_target = _mlp(num_critic_obs + num_actions, spec.hidden_dims, 1)
-            self.q2_target = _mlp(num_critic_obs + num_actions, spec.hidden_dims, 1)
+            self.q1 = _mlp(num_critic_obs + num_actions, hidden_dims, 1)
+            self.q2 = _mlp(num_critic_obs + num_actions, hidden_dims, 1)
+            self.q1_target = _mlp(num_critic_obs + num_actions, hidden_dims, 1)
+            self.q2_target = _mlp(num_critic_obs + num_actions, hidden_dims, 1)
             self.actor_target.load_state_dict(self.actor.state_dict())
             self.q1_target.load_state_dict(self.q1.state_dict())
             self.q2_target.load_state_dict(self.q2.state_dict())
@@ -273,8 +294,11 @@ class FastTd3Trainer(BaseRLAlgo):
             self.env.device = self.device
         self.steps_per_iter = spec.rollout_steps * spec.num_envs
 
-        self.actor_critic = _build_actor_critic(
-            self.env.num_actor_obs, self.env.num_critic_obs, self.env.num_actions, spec
+        self.actor_critic = build_actor_critic(
+            self.env.num_actor_obs,
+            self.env.num_critic_obs,
+            self.env.num_actions,
+            hidden_dims=tuple(spec.hidden_dims),
         ).to(self.device)
 
         actor_params = list(self.actor_critic.actor.parameters())

--- a/strands_robots/training/rl/ppo.py
+++ b/strands_robots/training/rl/ppo.py
@@ -39,8 +39,35 @@ def _mlp(in_dim: int, hidden: tuple[int, ...], out_dim: int) -> Any:
     return nn.Sequential(*layers)
 
 
-def _build_actor_critic(num_actor_obs: int, num_critic_obs: int, num_actions: int, spec: RLTrainSpec) -> Any:
-    """Construct the Gaussian-MLP ``ActorCritic`` module (torch required)."""
+def build_actor_critic(
+    num_actor_obs: int,
+    num_critic_obs: int,
+    num_actions: int,
+    *,
+    hidden_dims: tuple[int, ...] = (128, 128),
+    init_noise_std: float = 1.0,
+) -> Any:
+    """Construct the Gaussian-MLP ``ActorCritic`` module (torch required).
+
+    Public because a checkpoint is only deployable if its architecture can be
+    rebuilt outside a training run: ``load_deployable_actor`` calls this to
+    reconstruct the graph ``policy.pt``'s ``state_dict`` was saved from, so the
+    trainer and the deployer cannot drift into two different networks.
+
+    Args:
+        num_actor_obs: Width of the actor observation vector.
+        num_critic_obs: Width of the critic observation vector (>= actor's under
+            an asymmetric actor-critic).
+        num_actions: Number of action outputs.
+        hidden_dims: Hidden layer widths, expanded for both actor and critic.
+        init_noise_std: Initial action standard deviation. Only the *initial*
+            value: ``log_std`` is a learned parameter, so loading a checkpoint
+            overwrites it and any positive value reconstructs the same graph.
+
+    Returns:
+        An ``ActorCritic`` ``nn.Module`` whose ``act_inference`` is the
+        deterministic (mean) action a deployed checkpoint commands.
+    """
     import torch
     import torch.nn as nn
     from torch.distributions import Normal
@@ -50,9 +77,9 @@ def _build_actor_critic(num_actor_obs: int, num_critic_obs: int, num_actions: in
 
         def __init__(self) -> None:
             super().__init__()
-            self.actor = _mlp(num_actor_obs, spec.hidden_dims, num_actions)
-            self.critic = _mlp(num_critic_obs, spec.hidden_dims, 1)
-            self.log_std = nn.Parameter(torch.ones(num_actions) * float(torch.log(torch.tensor(spec.init_noise_std))))
+            self.actor = _mlp(num_actor_obs, hidden_dims, num_actions)
+            self.critic = _mlp(num_critic_obs, hidden_dims, 1)
+            self.log_std = nn.Parameter(torch.ones(num_actions) * float(torch.log(torch.tensor(init_noise_std))))
 
         def _distribution(self, actor_obs: torch.Tensor) -> Normal:
             mean = self.actor(actor_obs)
@@ -275,8 +302,12 @@ class PpoTrainer(BaseRLAlgo):
             self.env.device = self.device
         self.steps_per_iter = spec.rollout_steps * spec.num_envs
 
-        self.actor_critic = _build_actor_critic(
-            self.env.num_actor_obs, self.env.num_critic_obs, self.env.num_actions, spec
+        self.actor_critic = build_actor_critic(
+            self.env.num_actor_obs,
+            self.env.num_critic_obs,
+            self.env.num_actions,
+            hidden_dims=tuple(spec.hidden_dims),
+            init_noise_std=spec.init_noise_std,
         ).to(self.device)
         self.optimizer = torch.optim.Adam(self.actor_critic.parameters(), lr=spec.learning_rate)
 

--- a/tests/policies/test_provider_policy_docstrings.py
+++ b/tests/policies/test_provider_policy_docstrings.py
@@ -50,6 +50,7 @@ _PROVIDER_POLICIES = {
     "kimodo/policy.py": "KimodoPolicy",
     "protomotions/policy.py": "ProtoMotionsPolicy",
     "microduck/policy.py": "MicroduckPolicy",
+    "rl.py": "RLCheckpointPolicy",
 }
 
 # Built-in policy classes documented by test_builtin_policy_docstrings; the

--- a/tests/policies/test_rl_checkpoint_rollout.py
+++ b/tests/policies/test_rl_checkpoint_rollout.py
@@ -1,0 +1,427 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""An RL training checkpoint is deployable through the policy factory.
+
+The RL trainers write ``policy.pt`` + ``policy_meta.json`` and
+:meth:`BaseRLAlgo.save_checkpoint` calls the pair "a deployable-policy metadata
+file", with ``act_inference`` docstringed on all three backends as "the
+deployable policy". Nothing read them: no provider in
+``strands_robots/registry/policies.json`` loaded an RL checkpoint, so
+``create_policy("rl")`` raised ``Unknown policy provider`` and a trained actor
+could not drive a robot through ``run_policy`` / ``eval_policy`` like every
+other provider.
+
+These cells pin the reader end to end: the provider resolves, each backend's
+architecture is rebuilt from its own ``build_actor_critic`` (so a FastSAC
+actor's ``2 * num_actions`` output and its ``tanh`` squash are honoured rather
+than guessed), the observation normalizer is restored frozen, the trained
+``actor_obs_keys`` order is respected, and every way the pair can be unusable is
+refused by name instead of defaulted into a fabricated command.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import pytest
+
+from strands_robots.policies import create_policy
+
+torch = pytest.importorskip("torch")
+
+
+def _write_checkpoint(
+    directory: str,
+    *,
+    provider: str = "ppo",
+    actor_obs_keys: list[str] | None = None,
+    action_keys: list[str] | None = None,
+    hidden_dims: tuple[int, ...] = (8, 8),
+    normalizer_mean: list[float] | None = None,
+    meta_overrides: dict[str, Any] | None = None,
+    drop_meta_fields: tuple[str, ...] = (),
+    write_weights: bool = True,
+) -> str:
+    """Write a checkpoint pair shaped exactly as ``save_checkpoint`` writes one.
+
+    Builds the real backend module for ``provider`` so the saved ``state_dict``
+    is the one that backend produces, rather than a hand-rolled approximation
+    the loader could not distinguish from a genuine checkpoint.
+    """
+    from importlib import import_module
+
+    keys = actor_obs_keys if actor_obs_keys is not None else ["a", "b"]
+    acts = action_keys if action_keys is not None else ["j1", "j2", "j3"]
+    module = import_module(f"strands_robots.training.rl.{provider}").build_actor_critic(
+        len(keys), len(keys), len(acts), hidden_dims=hidden_dims
+    )
+    os.makedirs(directory, exist_ok=True)
+    state: dict[str, Any] = {"actor_critic": module.state_dict(), "iteration": 7, "provider": provider}
+    if normalizer_mean is not None:
+        from strands_robots.training.rl.normalization import EmpiricalNormalization
+
+        norm = EmpiricalNormalization(len(keys), "cpu")
+        norm.train()
+        norm.update(torch.tensor([normalizer_mean], dtype=torch.float32).repeat(64, 1))
+        state["actor_norm"] = norm.state_dict()
+    if write_weights:
+        torch.save(state, os.path.join(directory, "policy.pt"))
+
+    meta: dict[str, Any] = {
+        "provider": provider,
+        "num_actor_obs": len(keys),
+        "num_critic_obs": len(keys),
+        "num_actions": len(acts),
+        "actor_obs_keys": keys,
+        "action_keys": acts,
+        "hidden_dims": list(hidden_dims),
+        "iteration": 7,
+    }
+    meta.update(meta_overrides or {})
+    for field in drop_meta_fields:
+        meta.pop(field, None)
+    with open(os.path.join(directory, "policy_meta.json"), "w", encoding="utf-8") as f:
+        json.dump(meta, f)
+    return directory
+
+
+def _rl_policy(**kwargs: Any) -> Any:
+    """Resolve the provider through the factory and narrow to its concrete class.
+
+    Going through ``create_policy`` is what pins the registry wiring; the
+    ``isinstance`` narrows the ``Policy`` return type onto the provider-specific
+    surface the cells read.
+    """
+    from strands_robots.policies.rl import RLCheckpointPolicy
+
+    policy = create_policy("rl", **kwargs)
+    assert isinstance(policy, RLCheckpointPolicy)
+    return policy
+
+
+async def _act(policy: Any, observation: dict[str, Any]) -> dict[str, Any]:
+    chunk = await policy.get_actions(observation, "")
+    assert len(chunk) == 1, "an RL actor is a per-step controller: one tick per call"
+    return chunk[0]
+
+
+def test_rl_provider_is_registered_and_resolvable(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """``create_policy("rl")`` yields a Policy bound to the checkpoint's identity."""
+    from strands_robots.policies import list_providers
+
+    assert "rl" in list_providers()
+    ckpt = _write_checkpoint(str(tmp_path / "ck"), provider="ppo")
+    policy = _rl_policy(checkpoint_dir=ckpt)
+    assert policy.provider_name == "rl"
+    assert policy.trained_by == "ppo"
+    assert policy.requires_images is False
+    assert policy.actor_obs_keys == ["a", "b"]
+    assert policy.action_keys == ["j1", "j2", "j3"]
+
+
+@pytest.mark.parametrize("provider", ["ppo", "fast_sac", "fast_td3"])
+def test_every_backend_checkpoint_rolls_out(tmp_path, provider: str) -> None:  # type: ignore[no-untyped-def]
+    """Each backend's saved actor loads and commands one finite float per action key.
+
+    FastSAC's actor emits ``2 * num_actions`` (a mean/log-std pair) where PPO's
+    and FastTD3's emit ``num_actions``, and ``policy_meta.json`` records
+    ``num_actions`` for all three - so a loader that sized the network from the
+    metadata alone would build the wrong graph for FastSAC.
+    """
+    ckpt = _write_checkpoint(str(tmp_path / provider), provider=provider)
+    policy = _rl_policy(checkpoint_dir=ckpt)
+    action = pytest.importorskip("asyncio").run(_act(policy, {"a": 0.25, "b": -0.5}))
+
+    assert list(action) == ["j1", "j2", "j3"]
+    assert all(isinstance(v, float) for v in action.values())
+    assert all(abs(v) < 1e6 for v in action.values())
+    if provider in ("fast_sac", "fast_td3"):
+        # Both off-policy backends squash through tanh, so a deployed command is
+        # inside the action interval they were trained to emit.
+        assert all(-1.0 <= v <= 1.0 for v in action.values()), action
+
+
+def test_loaded_normalizer_is_frozen_at_the_statistics_the_run_finished_on(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """The restored observation normalizer never folds a deployed observation in.
+
+    ``EmpiricalNormalization`` only updates while training, so a deployed actor
+    must hold it in eval mode: otherwise every rollout would shift the whitening
+    statistics the trained weights expect, and the same state would command a
+    drifting action. Read through the public reader the provider is built on.
+    """
+    from strands_robots.training.rl import load_deployable_actor
+
+    ckpt = _write_checkpoint(str(tmp_path / "ck"), normalizer_mean=[3.0, -1.0])
+    actor = load_deployable_actor(ckpt)
+
+    normalizer = actor.normalizer
+    assert normalizer is not None
+    assert normalizer.training is False
+    count_before = int(normalizer.count)
+    mean_before = normalizer.mean.clone()
+
+    extreme = torch.full((4, 2), 900.0)
+    assert torch.allclose(actor.act(extreme), actor.act(extreme))
+    assert int(normalizer.count) == count_before
+    assert torch.allclose(normalizer.mean, mean_before)
+
+
+def test_action_is_deterministic_across_calls(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """The same observation commands the same action every time.
+
+    A deployed actor is the deterministic (mean) action with gradients disabled,
+    so a rollout is reproducible rather than sampling a fresh command per tick.
+    """
+    asyncio = pytest.importorskip("asyncio")
+    ckpt = _write_checkpoint(str(tmp_path / "ck"), normalizer_mean=[3.0, -1.0])
+    policy = _rl_policy(checkpoint_dir=ckpt)
+
+    first = asyncio.run(_act(policy, {"a": 900.0, "b": 900.0}))
+    second = asyncio.run(_act(policy, {"a": 900.0, "b": 900.0}))
+    assert first == second
+
+
+def test_actor_obs_keys_are_read_in_the_trained_order(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """The trained key order drives the input vector, not the observation's order.
+
+    The order ``actor_obs_keys`` records is part of the weights: an actor trained
+    on ``["a", "b"]`` fed ``[b, a]`` is being given a different input. So a
+    reshuffled observation *dict* must produce the same action, while genuinely
+    swapping the two values must not.
+    """
+    asyncio = pytest.importorskip("asyncio")
+    ckpt = _write_checkpoint(str(tmp_path / "ck"), actor_obs_keys=["a", "b"])
+    policy = _rl_policy(checkpoint_dir=ckpt)
+
+    in_order = asyncio.run(_act(policy, {"a": 1.0, "b": -1.0}))
+    reordered_dict = asyncio.run(_act(policy, {"b": -1.0, "a": 1.0}))
+    swapped_values = asyncio.run(_act(policy, {"a": -1.0, "b": 1.0}))
+
+    assert in_order == reordered_dict, "binding is by name, so dict order is irrelevant"
+    assert in_order != swapped_values, "swapping the values is a different observation"
+
+
+def test_extra_observation_keys_are_ignored(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """A richer observation than the actor was trained on still drives it.
+
+    ``run_policy`` hands a policy every scalar the robot reports; an actor
+    trained on a subset reads its own keys and ignores the rest.
+    """
+    asyncio = pytest.importorskip("asyncio")
+    ckpt = _write_checkpoint(str(tmp_path / "ck"), actor_obs_keys=["a", "b"])
+    policy = _rl_policy(checkpoint_dir=ckpt)
+
+    lean = asyncio.run(_act(policy, {"a": 0.5, "b": 0.5}))
+    rich = asyncio.run(_act(policy, {"a": 0.5, "b": 0.5, "c": 99.0, "b.vel": -3.0}))
+    assert lean == rich
+
+
+def test_missing_observation_key_is_refused_by_name(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """An absent trained key refuses instead of defaulting to zero.
+
+    Substituting a value would command the robot from a state it is not in,
+    under a successful-looking rollout.
+    """
+    asyncio = pytest.importorskip("asyncio")
+    ckpt = _write_checkpoint(str(tmp_path / "ck"), actor_obs_keys=["a", "b"])
+    policy = _rl_policy(checkpoint_dir=ckpt)
+
+    with pytest.raises(ValueError, match="omits actor_obs_keys"):
+        asyncio.run(_act(policy, {"a": 0.5}))
+
+
+def test_action_key_count_must_match_the_actors_width(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """A robot with a different actuator count than the actor is refused.
+
+    Binding 3 outputs onto 2 actuators would silently drop the last command;
+    onto 4 it would leave one actuator unnamed.
+    """
+    asyncio = pytest.importorskip("asyncio")
+    # The network keeps its 3 outputs; only the recorded vocabulary is empty,
+    # which is what a checkpoint saved without a robot bound looks like.
+    ckpt = _write_checkpoint(str(tmp_path / "ck"), meta_overrides={"action_keys": []})
+    policy = _rl_policy(checkpoint_dir=ckpt)
+
+    # No keys at all: the checkpoint recorded none and none were supplied.
+    with pytest.raises(ValueError, match="no action keys"):
+        asyncio.run(_act(policy, {"a": 0.0, "b": 0.0}))
+
+    policy.set_robot_state_keys(["only", "two"])
+    with pytest.raises(ValueError, match="emits 3 actions but 2 action keys"):
+        asyncio.run(_act(policy, {"a": 0.0, "b": 0.0}))
+
+
+def test_checkpoint_action_keys_win_over_the_robots(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """A checkpoint that names its actuators is not overridden by the robot's keys.
+
+    ``set_robot_state_keys`` is the fallback for a checkpoint saved without a
+    robot bound; the trained vocabulary is what the outputs mean.
+    """
+    asyncio = pytest.importorskip("asyncio")
+    ckpt = _write_checkpoint(str(tmp_path / "ck"), action_keys=["j1", "j2", "j3"])
+    policy = _rl_policy(checkpoint_dir=ckpt)
+    policy.set_robot_state_keys(["other_a", "other_b", "other_c"])
+
+    action = asyncio.run(_act(policy, {"a": 0.0, "b": 0.0}))
+    assert list(action) == ["j1", "j2", "j3"]
+
+
+@pytest.mark.parametrize(
+    ("kwargs_factory", "expected_error", "match"),
+    [
+        pytest.param(lambda p: {"checkpoint_dir": ""}, ValueError, "checkpoint_dir is required", id="blank-dir"),
+        pytest.param(lambda p: {"checkpoint_dir": "   "}, ValueError, "checkpoint_dir is required", id="whitespace"),
+        pytest.param(
+            lambda p: {"checkpoint_dir": str(p)}, FileNotFoundError, "no policy_meta.json", id="no-meta-at-all"
+        ),
+    ],
+)
+def test_unusable_checkpoint_arguments_are_refused(tmp_path, kwargs_factory, expected_error, match) -> None:  # type: ignore[no-untyped-def]
+    """Every way the pair can be absent refuses, naming what is missing."""
+    with pytest.raises(expected_error, match=match):
+        create_policy("rl", **kwargs_factory(tmp_path))
+
+
+def test_weights_without_metadata_are_refused(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """``policy.pt`` alone cannot be bound to a robot, so it is refused.
+
+    The metadata is what names the observations the weights expect and the
+    actuators they drive; weights alone are not a deployable policy.
+    """
+    ckpt = _write_checkpoint(str(tmp_path / "ck"))
+    os.remove(os.path.join(ckpt, "policy_meta.json"))
+    with pytest.raises(FileNotFoundError, match="no policy_meta.json"):
+        create_policy("rl", checkpoint_dir=ckpt)
+
+
+def test_metadata_without_weights_is_refused(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """Metadata describing weights that are not there refuses."""
+    ckpt = _write_checkpoint(str(tmp_path / "ck"), write_weights=False)
+    with pytest.raises(FileNotFoundError, match="no policy.pt"):
+        create_policy("rl", checkpoint_dir=ckpt)
+
+
+@pytest.mark.parametrize(
+    ("dropped", "match"),
+    [
+        pytest.param(("provider",), "provider", id="provider"),
+        pytest.param(("num_actor_obs",), "num_actor_obs", id="num_actor_obs"),
+        pytest.param(("num_actions",), "num_actions", id="num_actions"),
+        pytest.param(("actor_obs_keys",), "actor_obs_keys", id="actor_obs_keys"),
+        pytest.param(("hidden_dims",), "hidden_dims", id="hidden_dims"),
+    ],
+)
+def test_incomplete_metadata_names_the_missing_field(tmp_path, dropped, match) -> None:  # type: ignore[no-untyped-def]
+    """A metadata field the deployment needs is reported, not defaulted.
+
+    Each of these decides the network's shape or what its inputs and outputs
+    mean, so a default would build a different actor or bind it to the wrong
+    joints while reporting success.
+    """
+    ckpt = _write_checkpoint(str(tmp_path / "ck"), drop_meta_fields=dropped)
+    with pytest.raises(ValueError, match=f"omits required field.*{match}"):
+        create_policy("rl", checkpoint_dir=ckpt)
+
+
+def test_unknown_trainer_in_metadata_is_refused(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """A provider with no known architecture refuses rather than guessing one.
+
+    ``provider`` is what selects the actor architecture, because the output
+    width is not derivable from ``num_actions``.
+    """
+    ckpt = _write_checkpoint(str(tmp_path / "ck"), meta_overrides={"provider": "some_future_algo"})
+    with pytest.raises(ValueError, match="no known actor architecture"):
+        create_policy("rl", checkpoint_dir=ckpt)
+
+
+def test_metadata_that_is_not_an_object_is_refused(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """A ``policy_meta.json`` holding a non-object refuses with its type."""
+    ckpt = _write_checkpoint(str(tmp_path / "ck"))
+    with open(os.path.join(ckpt, "policy_meta.json"), "w", encoding="utf-8") as f:
+        json.dump([1, 2, 3], f)
+    with pytest.raises(ValueError, match="must be a JSON object, got list"):
+        create_policy("rl", checkpoint_dir=ckpt)
+
+
+def test_loaded_actor_matches_the_trainers_own_inference(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """The deployed command equals what the training graph would have produced.
+
+    The point of rebuilding through the backend's own ``build_actor_critic`` is
+    that no reimplementation can drift from it: the same weights and the same
+    observation give the same action on both sides.
+    """
+    asyncio = pytest.importorskip("asyncio")
+    from strands_robots.training.rl.ppo import build_actor_critic
+
+    ckpt = _write_checkpoint(str(tmp_path / "ck"), actor_obs_keys=["a", "b"], hidden_dims=(8, 8))
+    reference = build_actor_critic(2, 2, 3, hidden_dims=(8, 8))
+    state = torch.load(os.path.join(ckpt, "policy.pt"), map_location="cpu", weights_only=True)
+    reference.load_state_dict(state["actor_critic"])
+    reference.eval()
+    with torch.no_grad():
+        expected = reference.act_inference(torch.tensor([[0.3, -0.7]], dtype=torch.float32))[0]
+
+    action = asyncio.run(_act(_rl_policy(checkpoint_dir=ckpt), {"a": 0.3, "b": -0.7}))
+    for i, key in enumerate(["j1", "j2", "j3"]):
+        assert action[key] == pytest.approx(float(expected[i]), abs=1e-6)
+
+
+pytest.importorskip("mujoco")
+
+
+def test_a_trained_checkpoint_drives_the_robot_it_was_trained_on(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """End to end: train in sim, then roll the checkpoint out through run_policy.
+
+    The closed loop the checkpoint format was written for -
+    ``create_trainer("ppo").train(...)`` to ``run_policy(policy_provider="rl")``
+    - with no hand-built glue in between.
+    """
+    import strands_robots as sr
+    from strands_robots.training import create_trainer
+    from strands_robots.training.rl import RLTrainSpec, SimEnv
+
+    target = 0.4
+
+    def reward(engine: Any) -> float:
+        observation = engine.get_observation(skip_images=True)
+        observation = observation.get("observation") or observation
+        return -abs(float(observation["Elbow"]) - target)
+
+    def make_env() -> Any:
+        return SimEnv(
+            sr.Robot("so100", mode="sim"),
+            actor_obs_keys=["Elbow", "Elbow.vel"],
+            reward_terms=[reward],
+            max_episode_steps=10,
+        )
+
+    result = create_trainer("ppo").train(
+        RLTrainSpec(
+            env_factory=make_env,
+            output_dir=str(tmp_path),
+            total_timesteps=40,
+            rollout_steps=20,
+            num_mini_batches=2,
+            num_learning_epochs=1,
+            hidden_dims=(16, 16),
+            seed=0,
+        )
+    )
+    assert result.status == "success"
+
+    policy = _rl_policy(checkpoint_dir=result.checkpoint_dir)
+    assert policy.trained_by == "ppo"
+    assert policy.actor_obs_keys == ["Elbow", "Elbow.vel"]
+
+    sim = sr.Robot("so100", mode="sim")
+    rollout = sim.run_policy(
+        robot_name="so100", policy_object=policy, n_steps=20, control_frequency=50.0, control_substeps=5
+    )
+    assert rollout["status"] == "success"
+    # The actor commanded the robot's own actuators, so the arm left its start
+    # pose rather than sitting at zero under a successful-looking rollout.
+    observation = sim.get_observation(skip_images=True)
+    observation = observation.get("observation") or observation
+    assert any(abs(float(observation[key])) > 1e-6 for key in policy.action_keys)

--- a/tests/policies/test_state_key_name_list_contract.py
+++ b/tests/policies/test_state_key_name_list_contract.py
@@ -140,6 +140,7 @@ _MUST_VALIDATE = {
     "policies/mock.py::MockPolicy",
     "policies/microduck/policy.py::MicroduckPolicy",
     "policies/moveit2/policy.py::MoveIt2Policy",
+    "policies/rl.py::RLCheckpointPolicy",
 }
 
 # Already total without the shared domain: every joint they drive is resolved by
@@ -599,6 +600,45 @@ def _protomotions_keys() -> list[str]:
     return ["floating_base_joint", *GTP_G1_JOINT_NAMES]
 
 
+def _rl() -> Any:
+    """An RL checkpoint policy needs a checkpoint, so write the smallest real one.
+
+    The provider loads ``policy.pt`` + ``policy_meta.json`` in its constructor,
+    so unlike the service-backed providers it cannot be built from arguments
+    alone. The pair is written through the PPO backend's own
+    ``build_actor_critic``, which is what the provider rebuilds it with.
+    """
+    import json
+    import tempfile
+
+    import torch
+
+    from strands_robots.policies.rl import RLCheckpointPolicy
+    from strands_robots.training.rl.ppo import build_actor_critic
+
+    directory = tempfile.mkdtemp(prefix="rl-state-keys-")
+    module = build_actor_critic(2, 2, 2, hidden_dims=(4,))
+    torch.save(
+        {"actor_critic": module.state_dict(), "iteration": 1, "provider": "ppo"}, pathlib.Path(directory) / "policy.pt"
+    )
+    (pathlib.Path(directory) / "policy_meta.json").write_text(
+        json.dumps(
+            {
+                "provider": "ppo",
+                "num_actor_obs": 2,
+                "num_critic_obs": 2,
+                "num_actions": 2,
+                "actor_obs_keys": ["a", "b"],
+                "action_keys": [],
+                "hidden_dims": [4],
+                "iteration": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return RLCheckpointPolicy(checkpoint_dir=directory)
+
+
 # (surface id as classified above, factory, the attribute the setter binds into,
 # a key list that surface accepts). Held against ``_TOTAL_BY_MEMBERSHIP`` by
 # ``test_the_membership_table_covers_every_already_total_surface``, so a provider
@@ -837,6 +877,7 @@ _OWNING_SURFACES: list[_Surface] = [
     ("policies/lerobot_local/policy.py::LerobotLocalPolicy", _lerobot_local, "robot_state_keys", "torch"),
     ("policies/microduck/policy.py::MicroduckPolicy", _microduck, "_robot_state_keys", None),
     ("policies/moveit2/policy.py::MoveIt2Policy", _moveit2, "_robot_state_keys", "zmq"),
+    ("policies/rl.py::RLCheckpointPolicy", _rl, "robot_state_keys", "torch"),
 ]
 _OWNING_IDS = [surface.split("::")[1] for surface, *_ in _OWNING_SURFACES]
 

--- a/tests/training/test_public_member_docstrings.py
+++ b/tests/training/test_public_member_docstrings.py
@@ -53,6 +53,7 @@ _MODULES = (
     "mock.py",
     "reward.py",
     "rl/base_algo.py",
+    "rl/checkpoint.py",
     "rl/env.py",
     "rl/fast_sac.py",
     "rl/fast_td3.py",
@@ -76,6 +77,7 @@ _EXPECTED_CLASSES = {
     "mock.py::MockTrainer",
     "rl/base_algo.py::RLTrainSpec",
     "rl/base_algo.py::BaseRLAlgo",
+    "rl/checkpoint.py::DeployableActor",
     "rl/env.py::SimEnv",
     "rl/fast_sac.py::FastSacTrainer",
     "rl/fast_td3.py::FastTd3Trainer",
@@ -94,7 +96,12 @@ _EXPECTED_FUNCTIONS = {
     "reward.py::compute_rabc_weights",
     "reward.py::load_reward_model",
     "reward.py::reward_progress",
+    "rl/checkpoint.py::load_deployable_actor",
+    "rl/checkpoint.py::read_checkpoint_meta",
+    "rl/fast_sac.py::build_actor_critic",
+    "rl/fast_td3.py::build_actor_critic",
     "rl/gym_env.py::GymSimEnv",
+    "rl/ppo.py::build_actor_critic",
     "rl/ppo.py::compute_gae",
 }
 

--- a/tests/training/test_rl_fast_sac.py
+++ b/tests/training/test_rl_fast_sac.py
@@ -169,11 +169,9 @@ def _make_reach_env():  # type: ignore[no-untyped-def]
 
 def test_sac_actor_log_prob_finite_under_saturation() -> None:
     """tanh-squash log-prob correction must stay finite even at the bounds."""
-    from strands_robots.training.rl import RLTrainSpec
-    from strands_robots.training.rl.fast_sac import _build_actor_critic
+    from strands_robots.training.rl.fast_sac import build_actor_critic
 
-    spec = RLTrainSpec(hidden_dims=(16,))
-    ac = _build_actor_critic(num_actor_obs=3, num_critic_obs=3, num_actions=2, spec=spec)
+    ac = build_actor_critic(num_actor_obs=3, num_critic_obs=3, num_actions=2, hidden_dims=(16,))
     obs = torch.full((8, 3), 50.0)  # drive the pre-squash mean far out -> tanh saturates
     action, log_prob = ac.sample(obs)
     assert action.shape == (8, 2)

--- a/tests/training/test_rl_fast_td3.py
+++ b/tests/training/test_rl_fast_td3.py
@@ -22,7 +22,7 @@ from strands_robots.training.base import TrainSpec
 torch = pytest.importorskip("torch")
 
 from strands_robots.training.rl import RLTrainSpec, SimEnv, VecSimEnv  # noqa: E402
-from strands_robots.training.rl.fast_td3 import FastTd3Trainer, _build_actor_critic  # noqa: E402
+from strands_robots.training.rl.fast_td3 import FastTd3Trainer, build_actor_critic  # noqa: E402
 
 
 class _FakeEngine:
@@ -163,8 +163,7 @@ def test_train_rejects_non_rl_spec() -> None:
 
 def test_td3_actor_action_bounded_and_finite_under_saturation() -> None:
     """The tanh-bounded deterministic action stays inside [-1, 1] at the extremes."""
-    spec = RLTrainSpec(hidden_dims=(16,))
-    ac = _build_actor_critic(num_actor_obs=3, num_critic_obs=3, num_actions=2, spec=spec)
+    ac = build_actor_critic(num_actor_obs=3, num_critic_obs=3, num_actions=2, hidden_dims=(16,))
     obs = torch.full((8, 3), 50.0)  # drive the pre-tanh output far out
     action = ac.act_inference(obs)
     assert action.shape == (8, 2)
@@ -177,8 +176,7 @@ def test_td3_actor_action_bounded_and_finite_under_saturation() -> None:
 
 def test_targets_start_as_copies_and_do_not_require_grad() -> None:
     """Every target network initializes as a copy of its live network, frozen."""
-    spec = RLTrainSpec(hidden_dims=(8,))
-    ac = _build_actor_critic(num_actor_obs=2, num_critic_obs=2, num_actions=1, spec=spec)
+    ac = build_actor_critic(num_actor_obs=2, num_critic_obs=2, num_actions=1, hidden_dims=(8,))
     for live, target in ((ac.actor, ac.actor_target), (ac.q1, ac.q1_target), (ac.q2, ac.q2_target)):
         for p, tp in zip(live.parameters(), target.parameters()):
             assert torch.equal(p, tp)


### PR DESCRIPTION
The RL trainers exported a checkpoint they described as deployable, and nothing could load it.

![trained actor rollout](https://raw.githubusercontent.com/cagataycali/robots/assets/rl-checkpoint-deploy-34433695879/trained.gif)

`create_trainer("ppo").train(...)` -> `create_policy("rl")` -> `run_policy`, in MuJoCo headless (EGL). Reward `-|q2 - 0.55|` on `so101`, 36k steps / 600 iterations / 238 s on CPU.

![measurements](https://raw.githubusercontent.com/cagataycali/robots/assets/rl-checkpoint-deploy-34433695879/rl_deploy.png)

| deployed actor | final `q2` | `\|q2 - q*\|` |
|---|---|---|
| untrained (random init, same code path) | -0.136 | 0.686 |
| **trained** | **+0.589** | **0.039** |

mean reward over training: `-0.450` -> `-0.094`. Both rollouts are the shipped provider driven through `run_policy`; the untrained baseline is the same loader on a random-weight checkpoint, so the only difference is the weights.

## The gap

`BaseRLAlgo.save_checkpoint` writes `policy.pt` + `policy_meta.json` and documents the latter as "a deployable-policy metadata file". `export()` returns "the loadable policy artifact for inference". `act_inference` is docstringed on all three backends as "the deterministic (mean) action - the deployable policy". `docs/training/rl.md` describes the result as "a deployable checkpoint whose actor commands ...".

No reader existed. No provider in `registry/policies.json` loaded an RL checkpoint:

```
>>> create_policy("rl", checkpoint_dir=result.checkpoint_dir)
ValueError: Unknown policy provider: 'rl'. Available: ['cosmos3', 'curobo', 'groot',
'kimodo', 'lerobot_async', 'lerobot_local', 'microduck', 'mock', 'motionbricks',
'moveit2', 'protomotions', 'remote', 'wbc', 'wbc_gait']
```

So a policy could be trained in sim and then only evaluated by the trainer that produced it. This is also why `strands_robots/training/rl/` had no importer anywhere in the package: the loop was open at the deployment end, not unused.

## Why the architecture is rebuilt, not reimplemented

The metadata does not determine the network. Measured on the three backends' actors:

| backend | actor output width | deterministic action |
|---|---|---|
| `ppo` | `num_actions` | `actor(obs)` (raw Gaussian mean) |
| `fast_td3` | `num_actions` | `tanh(actor(obs))` |
| `fast_sac` | **`2 * num_actions`** (mean, log_std) | `tanh(mean)`, log_std clamped |

All three record the same `num_actions`, so a loader sizing the network from the metadata alone builds the wrong graph for FastSAC. `provider` selects the architecture, each backend's own `build_actor_critic` builds it, and its own `act_inference` supplies the squash - so the deployed graph is the trained one and no reimplementation can drift from it. The three builders are promoted from `_build_actor_critic` and now take the `hidden_dims` / `init_noise_std` they actually read instead of a whole `RLTrainSpec`; all call sites updated, no alias left behind.

The reader lives beside the writer it shares a format with (`training/rl/checkpoint.py`, `load_deployable_actor`), usable directly for a custom control loop.

## What is read rather than assumed

- `actor_obs_keys` bind **by name in the trained order** - that order is part of the weights. A reshuffled observation dict gives the same action; swapping two values does not.
- A key the observation lacks is **refused**, not zero-filled: substituting a value commands the robot from a state it is not in.
- The checkpoint's `action_keys` win over `set_robot_state_keys` (the fallback for a checkpoint saved without a robot bound); a width mismatch is refused rather than silently dropping the last command.
- The saved observation normalizer is restored in **eval mode**. `EmpiricalNormalization` folds a batch only while training, so a rollout that kept updating would drift the whitening the trained weights expect. Pinned: `count` does not advance across deployed calls.
- Missing weights, missing metadata, a non-object metadata, an omitted required field and an unknown `provider` each refuse by name.

## Tests

`tests/policies/test_rl_checkpoint_rollout.py`, 25 cells. On unmodified `main` with only the test file added: **25 failed / 0 passed** (`Unknown policy provider: 'rl'`, and `build_actor_critic` absent). After: 25 passed in 3.0 s, `training/rl/checkpoint.py` at 100% statement coverage.

Includes the end-to-end cell (train in sim, then roll out through `run_policy`) and a parity cell asserting the deployed command equals what the training graph produces from the same weights and observation.

A new provider joins four derived rosters, all surfaced by the full suite rather than guessed - including `_REGISTRY_POLICY_PROVIDERS` in `mesh/security.py`, without which a mesh / Device Connect payload naming `policy_provider='rl'` is refused on the wire. Membership in the state-key behavioural table is an obligation, so the provider is constructed from a real checkpoint and driven to refuse a bare string with the shared verdict.

## Gate

- `ruff check` / `ruff format --check` on `strands_robots tests tests_integ`: clean (1949 files)
- `mypy strands_robots tests tests_integ`: `Success: no issues found in 1949 source files`
- full `MUJOCO_GL=egl pytest tests/`: **50,922 passed / 307 skipped** at the previous commit; the 5 failures it reported were the four rosters above plus the changelog placeholder number, all fixed in this branch and re-verified (103 passed on the affected files)

## LOC

| area | delta |
|---|---|
| `strands_robots/` | +514 -25 (net **+489**) |
| `tests/` | +481 -9 (net **+472**) |
| docs + changelog | +161 -2 (net **+159**) |

Net-positive, and the justification is the ratio: **+489 source lines make the 3,297-line `training/rl/` subpackage reachable**. Its zero importers were a symptom of this missing link, and the alternative reading - that the RL trainers are dead code to delete - would remove a subpackage that trains and now deploys, measured above.