### PR TITLE
fix(utils): a guard anywhere in the package answers a value it cannot render

### DIFF
--- a/changelog.d/3415-refusal-rendering-is-package-wide.md
+++ b/changelog.d/3415-refusal-rendering-is-package-wide.md
@@ -1,0 +1,26 @@
+### Fixed: a guard anywhere in the package answers a value it cannot render
+
+`strands_robots.utils` established the rule that a guard must not raise while
+building a refusal: rendering a value can fail - `repr` of an `int` wider than
+`sys.get_int_max_str_digits()` raises `ValueError`, and `numbers.Real` is a
+registration rather than an inheritance, so a scalar that satisfies a type test
+owes the guard nothing else - and a guard exists precisely so a bad value is
+reported through a returned result instead of an exception.
+
+The scan that established the rule read one file, and the same guard shape is
+written in nineteen other modules. Forty-three functions across twenty modules
+interpolated the caller's value straight into their message, and twenty-one of
+them raised when handed a value they had already decided to refuse:
+`randomization_range_error`, `finite_non_negative_error` and six more in
+`simulation/base.py`, all five compositor bounds, three of the MJPEG stream
+guards, the ray-batch and excluded-body coercions, and both training interval
+checks. `_closed_unit_interval_error(Fraction(-10**5000, 10**5000 + 1), ...)`
+raised `ValueError` out of a refusal it had already decided - stdlib only, no
+registered type and no hostile `__repr__`.
+
+Every one of them now renders through `refusal_repr`, `refusal_str` or
+`refusal_container_repr`, which defer to `repr`/`str` wherever those work, so no
+verdict and no existing message text changes. The three renderers are package
+API rather than `utils`-private helpers, because the contract they serve is
+stated over the package: `tests/test_refusal_messages_never_raise.py` now scans
+every module instead of one, which is what closed the other twenty modules.

--- a/strands_robots/drivers/base.py
+++ b/strands_robots/drivers/base.py
@@ -56,6 +56,8 @@ from __future__ import annotations
 import inspect
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
+from ..utils import refusal_repr
+
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Callable, Mapping
 
@@ -377,7 +379,7 @@ def undeclared_verb_error(driver: Any, action: Any) -> dict[str, Any]:
         "content": [
             {
                 "text": (
-                    f"{type(driver).__name__}: unknown action {action!r}; "
+                    f"{type(driver).__name__}: unknown action {refusal_repr(action)}; "
                     f"declared verbs are {declared_verbs(driver.tool_spec)}"
                 )
             }

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -46,6 +46,7 @@ from strands_robots.utils import (
     dds_domain_id_error,
     positive_count_error,
     positive_finite_number_error,
+    refusal_repr,
     require_optional,
     tcp_port_error,
 )
@@ -2149,7 +2150,7 @@ class Robot(TeleopMixin, AgentTool):
                     {
                         "text": (
                             f"{method}: policy_provider={policy_provider!r} declares no policy_port, "
-                            f"so policy_port={policy_port!r} would not be read. Drop the port, or name "
+                            f"so policy_port={refusal_repr(policy_port)} would not be read. Drop the port, or name "
                             f"a provider that reads one ({', '.join(port_reading_providers())})."
                         )
                     }

--- a/strands_robots/policies/kimodo/config.py
+++ b/strands_robots/policies/kimodo/config.py
@@ -39,7 +39,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from strands_robots.utils import positive_finite_number_error, positive_whole_number_error
+from strands_robots.utils import (
+    positive_finite_number_error,
+    positive_whole_number_error,
+    refusal_repr,
+    refusal_str,
+)
 
 _KIMODO_DEFAULT_MODEL_ID = "nvidia/Kimodo-G1-RP-v1"
 _KIMODO_MAX_FRAMES = 196
@@ -146,7 +151,7 @@ def diffusion_steps_error(value: Any, context: str) -> str | None:
         return error
     if value > _KIMODO_MAX_DIFFUSION_STEPS:
         return (
-            f"{context}: diffusion_steps must be <= {_KIMODO_MAX_DIFFUSION_STEPS}, got {value} - "
+            f"{context}: diffusion_steps must be <= {_KIMODO_MAX_DIFFUSION_STEPS}, got {refusal_str(value)} - "
             "the step count multiplies the cost of every sample, so a run this long is a stall "
             "rather than a better motion."
         )
@@ -213,7 +218,7 @@ def sampling_seed_error(value: Any, context: str) -> str | None:
     """
     if value is None:
         return None
-    prefix = f"{context}: seed must be a whole number or None, got {value!r}"
+    prefix = f"{context}: seed must be a whole number or None, got {refusal_repr(value)}"
     if isinstance(value, bool) or not isinstance(value, numbers.Real):
         return f"{prefix} (None draws fresh entropy for every sample)."
     try:
@@ -225,7 +230,7 @@ def sampling_seed_error(value: Any, context: str) -> str | None:
     if whole != value:
         return (
             f"{prefix}: the buffered-motion key rounds a seed to a whole number, so "
-            f"{value!r} would name the sample keyed by {whole!r} and replay it instead of sampling its own."
+            f"{refusal_repr(value)} would name the sample keyed by {whole!r} and replay it instead of sampling its own."
         )
     return None
 

--- a/strands_robots/policies/wbc/config.py
+++ b/strands_robots/policies/wbc/config.py
@@ -24,6 +24,7 @@ from strands_robots.utils import (
     finite_number_error,
     positive_count_error,
     positive_finite_number_error,
+    refusal_repr,
     require_optional,
     sequence_length,
 )
@@ -58,7 +59,7 @@ def _non_negative_number_error(value: Any, param: str, context: str) -> str | No
     """
     if error := finite_number_error(value, param, context):
         return error
-    return None if float(value) >= 0.0 else f"{context}: {param} must be >= 0, got {value!r}."
+    return None if float(value) >= 0.0 else f"{context}: {param} must be >= 0, got {refusal_repr(value)}."
 
 
 # Upstream defaults from the GR00T-WholeBodyControl reference controller

--- a/strands_robots/rendering/compositor.py
+++ b/strands_robots/rendering/compositor.py
@@ -67,7 +67,10 @@ from typing import Any, Protocol
 
 import numpy as np
 
-from ..utils import positive_whole_number_error
+from ..utils import (
+    positive_whole_number_error,
+    refusal_repr,
+)
 from .backgrounds import BackgroundRenderer, PanoramaBackground
 from .camera import CameraParams
 from .color import linear_to_srgb, relative_luminance, srgb_to_linear
@@ -93,7 +96,7 @@ def _feather_pixels_error(value: Any) -> str | None:
     Returns:
         An error message, or ``None`` when the value is usable.
     """
-    message = f"HybridCompositor: feather_pixels must be a whole number of pixels >= 0, got {value!r}."
+    message = f"HybridCompositor: feather_pixels must be a whole number of pixels >= 0, got {refusal_repr(value)}."
     if isinstance(value, bool) or not isinstance(value, numbers.Real):
         return message
     numeric = float(value)
@@ -129,7 +132,7 @@ def _depth_epsilon_error(value: Any) -> str | None:
     Returns:
         An error message, or ``None`` when the value is usable.
     """
-    message = f"HybridCompositor: depth_epsilon must be a finite distance in meters >= 0, got {value!r}."
+    message = f"HybridCompositor: depth_epsilon must be a finite distance in meters >= 0, got {refusal_repr(value)}."
     if isinstance(value, bool) or not isinstance(value, numbers.Real):
         return message
     numeric = float(value)
@@ -154,7 +157,9 @@ def _shadow_plane_z_error(value: Any) -> str | None:
     Returns:
         An error message, or ``None`` when the value is usable.
     """
-    message = f"HybridCompositor: shadow_plane_z must be a finite world-frame height in meters, got {value!r}."
+    message = (
+        f"HybridCompositor: shadow_plane_z must be a finite world-frame height in meters, got {refusal_repr(value)}."
+    )
     if isinstance(value, bool) or not isinstance(value, numbers.Real):
         return message
     if not math.isfinite(float(value)):
@@ -177,7 +182,9 @@ def _shadow_plane_tolerance_error(value: Any) -> str | None:
     Returns:
         An error message, or ``None`` when the value is usable.
     """
-    message = f"HybridCompositor: shadow_plane_tolerance must be a finite distance in meters > 0, got {value!r}."
+    message = (
+        f"HybridCompositor: shadow_plane_tolerance must be a finite distance in meters > 0, got {refusal_repr(value)}."
+    )
     if isinstance(value, bool) or not isinstance(value, numbers.Real):
         return message
     numeric = float(value)
@@ -201,7 +208,7 @@ def _shadow_min_factor_error(value: Any) -> str | None:
     Returns:
         An error message, or ``None`` when the value is usable.
     """
-    message = f"HybridCompositor: shadow_min_factor must be a number in [0, 1], got {value!r}."
+    message = f"HybridCompositor: shadow_min_factor must be a number in [0, 1], got {refusal_repr(value)}."
     if isinstance(value, bool) or not isinstance(value, numbers.Real):
         return message
     numeric = float(value)

--- a/strands_robots/rendering/video.py
+++ b/strands_robots/rendering/video.py
@@ -22,6 +22,8 @@ import numpy as np
 from strands_robots.utils import (
     finite_number_error,
     positive_whole_number_error,
+    refusal_container_repr,
+    refusal_repr,
     require_optional,
     sequence_length,
 )
@@ -145,7 +147,7 @@ def _clip_quality_error(quality: Any) -> str | None:
     if text := finite_number_error(quality, "quality", "encode_clip"):
         return text
     if not _MIN_CLIP_QUALITY <= float(quality) <= _MAX_CLIP_QUALITY:
-        return f"encode_clip: quality must be between {_MIN_CLIP_QUALITY} and {_MAX_CLIP_QUALITY}, got {quality!r}."
+        return f"encode_clip: quality must be between {_MIN_CLIP_QUALITY} and {_MAX_CLIP_QUALITY}, got {refusal_repr(quality)}."
     return None
 
 
@@ -305,7 +307,7 @@ def _stream_rate_error(fps: Any) -> str | None:
     Returns:
         An error message, or ``None`` when the rate is usable.
     """
-    message = f"mjpeg_frames: fps must be a positive finite number, got {fps!r}."
+    message = f"mjpeg_frames: fps must be a positive finite number, got {refusal_repr(fps)}."
     if finite_number_error(fps, "fps", "mjpeg_frames"):
         return message
     if float(fps) <= 0:
@@ -335,7 +337,7 @@ def _jpeg_quality_error(quality: Any) -> str | None:
     """
     message = (
         f"mjpeg_frames: quality must be a whole number between {_MIN_JPEG_QUALITY} "
-        f"and {_MAX_JPEG_QUALITY}, got {quality!r}."
+        f"and {_MAX_JPEG_QUALITY}, got {refusal_repr(quality)}."
     )
     if finite_number_error(quality, "quality", "mjpeg_frames"):
         return message
@@ -365,7 +367,7 @@ def _frame_size_error(size: Any) -> str | None:
     """
     if size is None:
         return None
-    message = f"mjpeg_frames: size must be a (width, height) pair of positive whole numbers, got {size!r}."
+    message = f"mjpeg_frames: size must be a (width, height) pair of positive whole numbers, got {refusal_container_repr(size)}."
     if isinstance(size, str | bytes | Mapping) or not hasattr(size, "__getitem__"):
         return message
     if sequence_length(size) != 2:

--- a/strands_robots/ros_telemetry.py
+++ b/strands_robots/ros_telemetry.py
@@ -36,6 +36,7 @@ from strands_robots.utils import (
     dds_domain_id_error,
     finite_number_error,
     positive_count_error,
+    refusal_repr,
     require_optional,
 )
 
@@ -131,7 +132,7 @@ def _qos_history_depth_error(value: Any, param: str, context: str) -> str | None
         return error
     if value > MAX_QOS_HISTORY_DEPTH:
         return (
-            f"{context}: {param} {value!r} is a positive integer that the rclpy transport "
+            f"{context}: {param} {refusal_repr(value)} is a positive integer that the rclpy transport "
             f"cannot build a publisher with (it carries 1-{MAX_QOS_HISTORY_DEPTH}; the "
             "middleware QoS profile stores the depth as a signed 32-bit integer)"
         )

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -62,6 +62,8 @@ from strands_robots.utils import (
     positive_count_error,
     positive_finite_number_error,
     process_rss_mb,
+    refusal_container_repr,
+    refusal_repr,
     sequence_length,
 )
 
@@ -344,7 +346,11 @@ def _boolean_world_error(method: str, param: str, value: Any) -> dict[str, Any]:
     return {
         "status": "error",
         "content": [
-            {"text": (f"{method}: '{param}' must be a number, not a bool (got {value!r}). {_BOOLEAN_WORLD_REASON}")}
+            {
+                "text": (
+                    f"{method}: '{param}' must be a number, not a bool (got {refusal_repr(value)}). {_BOOLEAN_WORLD_REASON}"
+                )
+            }
         ],
     }
 
@@ -375,7 +381,7 @@ def randomization_range_error(value: Any, param: str, *, allow_zero: bool = True
     """
     # The unpack and the coercion are separate steps so the boolean check can sit
     # between them; both report the same thing to the caller.
-    not_a_pair = f"{param} must be a (lo, hi) pair of numbers, got {value!r}"
+    not_a_pair = f"{param} must be a (lo, hi) pair of numbers, got {refusal_container_repr(value)}"
     try:
         lo, hi = value
     except (TypeError, ValueError):
@@ -384,25 +390,27 @@ def randomization_range_error(value: Any, param: str, *, allow_zero: bool = True
     # (erases the quantity it multiplies), and the sampler cannot tell either
     # from a deliberate one once coerced.
     if is_boolean(lo) or is_boolean(hi):
-        return f"{param} bounds must be numbers, not bools (got {value!r}). {_BOOLEAN_WORLD_REASON}"
+        return (
+            f"{param} bounds must be numbers, not bools (got {refusal_container_repr(value)}). {_BOOLEAN_WORLD_REASON}"
+        )
     try:
         lo, hi = float(lo), float(hi)
     except (TypeError, ValueError):
         return not_a_pair
     if not (math.isfinite(lo) and math.isfinite(hi)):
-        return f"{param} bounds must be finite, got {value!r}"
+        return f"{param} bounds must be finite, got {refusal_container_repr(value)}"
     if lo > hi:
         return f"{param} lower bound {lo} exceeds upper bound {hi}"
     if allow_zero:
         if lo < 0:
-            return f"{param} bounds must be non-negative, got {value!r}"
+            return f"{param} bounds must be non-negative, got {refusal_container_repr(value)}"
     elif lo <= 0:
         detail = (
             "a zero scale erases the quantity it multiplies"
             if lo == 0
             else "a negative scale flips the sign of the quantity it multiplies"
         )
-        return f"{param} bounds must be positive, got {value!r} ({detail})"
+        return f"{param} bounds must be positive, got {refusal_container_repr(value)} ({detail})"
     return None
 
 
@@ -432,13 +440,13 @@ def finite_non_negative_error(value: Any, param: str, context: str) -> str | Non
     # not a flag disabling the noise, which is what a caller passing True
     # would most plausibly have meant.
     if is_boolean(value):
-        return f"{context}: {param} must be a number, not a bool (got {value!r}). {_BOOLEAN_WORLD_REASON}"
+        return f"{context}: {param} must be a number, not a bool (got {refusal_repr(value)}). {_BOOLEAN_WORLD_REASON}"
     try:
         fvalue = float(value)
     except (TypeError, ValueError):
-        return f"{context}: {param} must be a number, got {value!r}"
+        return f"{context}: {param} must be a number, got {refusal_repr(value)}"
     if not math.isfinite(fvalue) or fvalue < 0:
-        return f"{context}: {param} must be a finite non-negative number, got {value!r}"
+        return f"{context}: {param} must be a finite non-negative number, got {refusal_repr(value)}"
     return None
 
 
@@ -548,12 +556,12 @@ def randomization_seed_error(
             "is a global side effect an unseeded rollout must not acquire."
         )
     if isinstance(value, bool) or not isinstance(value, numbers.Integral):
-        return f"{context}: seed must be a non-negative integer{none_clause}, got {value!r}{entropy_hint}"
+        return f"{context}: seed must be a non-negative integer{none_clause}, got {refusal_repr(value)}{entropy_hint}"
     if int(value) < 0:
-        return f"{context}: seed must be a non-negative integer{none_clause}, got {value!r}{entropy_hint}"
+        return f"{context}: seed must be a non-negative integer{none_clause}, got {refusal_repr(value)}{entropy_hint}"
     if max_seed is not None and int(value) > max_seed:
         return (
-            f"{context}: seed must be an integer in [0, {max_seed}]{none_clause}, got {value!r} "
+            f"{context}: seed must be an integer in [0, {max_seed}]{none_clause}, got {refusal_repr(value)} "
             "(a rollout seed is applied to the legacy NumPy global RNG, which refuses a larger value)"
         )
     return None
@@ -594,7 +602,11 @@ def _non_finite_action_error(label: str, value: Any) -> dict[str, Any] | None:
     return {
         "status": "error",
         "content": [
-            {"text": (f"send_action: {label} must be finite (no nan/inf), got {value!r}. {_NON_FINITE_ACTION_REASON}")}
+            {
+                "text": (
+                    f"send_action: {label} must be finite (no nan/inf), got {refusal_repr(value)}. {_NON_FINITE_ACTION_REASON}"
+                )
+            }
         ],
     }
 
@@ -663,7 +675,11 @@ def _boolean_action_error(label: str, value: Any) -> dict[str, Any] | None:
     return {
         "status": "error",
         "content": [
-            {"text": (f"send_action: {label} must be a number, not a bool (got {value!r}). {_BOOLEAN_ACTION_REASON}")}
+            {
+                "text": (
+                    f"send_action: {label} must be a number, not a bool (got {refusal_repr(value)}). {_BOOLEAN_ACTION_REASON}"
+                )
+            }
         ],
     }
 
@@ -2042,7 +2058,7 @@ class SimEngine(ABC):
             A structured ``{"status": "error", ...}`` dict to surface, or
             ``None`` when the value is usable.
         """
-        message = f"{method}: {param} must be a finite positive number, got {timestep!r}."
+        message = f"{method}: {param} must be a finite positive number, got {refusal_repr(timestep)}."
         # is_boolean, not isinstance(timestep, bool): numpy.bool_ is not a bool
         # subclass, so the narrower check refused a hand-typed True and admitted
         # the np.True_ a comparison produces - a 1-second dt under success.
@@ -2094,7 +2110,7 @@ class SimEngine(ABC):
         except (TypeError, ValueError):
             return {
                 "status": "error",
-                "content": [{"text": f"{method}: '{param}' must be a positive number, got {mass!r}"}],
+                "content": [{"text": f"{method}: '{param}' must be a positive number, got {refusal_repr(mass)}"}],
             }
         if not math.isfinite(value) or value <= 0:
             return {

--- a/strands_robots/simulation/ik.py
+++ b/strands_robots/simulation/ik.py
@@ -39,6 +39,7 @@ from ..utils import (
     pose_vector_error,
     positive_count_error,
     positive_finite_number_error,
+    refusal_repr,
 )
 
 if TYPE_CHECKING:
@@ -117,7 +118,7 @@ def _damping_error(value: Any, context: str) -> str | None:
     if float(value) < 0.0:
         return (
             f"{context}: damping must be >= 0 (0.0 is the undamped solve); a negative value makes the "
-            f"QP cost matrix indefinite, got {value!r}."
+            f"QP cost matrix indefinite, got {refusal_repr(value)}."
         )
     return None
 

--- a/strands_robots/simulation/motion_primitives_base.py
+++ b/strands_robots/simulation/motion_primitives_base.py
@@ -28,7 +28,11 @@ from typing import Any
 import numpy as np
 
 from strands_robots.registry.robots import get_robot
-from strands_robots.utils import coerce_orientation_quaternion, coerce_pose_vector
+from strands_robots.utils import (
+    coerce_orientation_quaternion,
+    coerce_pose_vector,
+    refusal_repr,
+)
 
 # Name hints (lowercased substring match on the gripper DOF's name) used to
 # resolve the gripper when the robot registry carries no gripper metadata for
@@ -182,7 +186,13 @@ class MotionPrimitivesCore:
         if quat_err is not None:
             return None, None, 0, None, _err(quat_err)
         if not _is_finite_real(tol) or float(tol) <= 0.0:
-            return None, None, 0, None, _err(f"move_to: 'tol' must be a positive number of meters, got {tol!r}.")
+            return (
+                None,
+                None,
+                0,
+                None,
+                _err(f"move_to: 'tol' must be a positive number of meters, got {refusal_repr(tol)}."),
+            )
         if orientation_tol is not None and orientation is None:
             return (
                 None,
@@ -201,7 +211,9 @@ class MotionPrimitivesCore:
                 None,
                 0,
                 None,
-                _err(f"move_to: 'orientation_tol' must be a positive number of radians, got {orientation_tol!r}."),
+                _err(
+                    f"move_to: 'orientation_tol' must be a positive number of radians, got {refusal_repr(orientation_tol)}."
+                ),
             )
         err = self._validate_step_budget("move_to", "max_steps", max_steps)
         if err is not None:
@@ -218,7 +230,7 @@ class MotionPrimitivesCore:
     def _validate_set_gripper_args(self, state: Any, steps: Any) -> tuple[int, dict[str, Any] | None]:
         """Shared ``set_gripper`` parameter domain: ``(steps, None)`` or ``(0, error)``."""
         if state not in ("open", "close"):
-            return 0, _err(f'set_gripper: \'state\' must be "open" or "close", got {state!r}.')
+            return 0, _err(f'set_gripper: \'state\' must be "open" or "close", got {refusal_repr(state)}.')
         err = self._validate_step_budget("set_gripper", "steps", steps)
         if err is not None:
             return 0, err
@@ -231,9 +243,13 @@ class MotionPrimitivesCore:
         if target_yaw is None:
             return 0.0, 0, _err("rotate_wrist requires 'target_yaw' (wrist joint set-point in radians).")
         if not _is_finite_real(target_yaw):
-            return 0.0, 0, _err(f"rotate_wrist: 'target_yaw' must be a finite number of radians, got {target_yaw!r}.")
+            return (
+                0.0,
+                0,
+                _err(f"rotate_wrist: 'target_yaw' must be a finite number of radians, got {refusal_repr(target_yaw)}."),
+            )
         if not _is_finite_real(tol) or float(tol) <= 0.0:
-            return 0.0, 0, _err(f"rotate_wrist: 'tol' must be a positive number of radians, got {tol!r}.")
+            return 0.0, 0, _err(f"rotate_wrist: 'tol' must be a positive number of radians, got {refusal_repr(tol)}.")
         err = self._validate_step_budget("rotate_wrist", "max_steps", max_steps)
         if err is not None:
             return 0.0, 0, err

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -39,7 +39,14 @@ from strands_robots.simulation.mujoco.scene_ops import (
     refresh_body_inertial_from_geometry,
 )
 from strands_robots.simulation.safe_output import atomic_write_bytes, validate_output_path
-from strands_robots.utils import BOOLEAN_VECTOR_REASON, boolean_flag_error, coerce_rgba, is_boolean
+from strands_robots.utils import (
+    BOOLEAN_VECTOR_REASON,
+    boolean_flag_error,
+    coerce_rgba,
+    is_boolean,
+    refusal_container_repr,
+    refusal_repr,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -110,7 +117,9 @@ def _coerce_finite_vector(
     except TypeError:
         return None, {
             "status": "error",
-            "content": [{"text": f"{method}: '{name}' must be a sequence of numbers, got {values!r}"}],
+            "content": [
+                {"text": f"{method}: '{name}' must be a sequence of numbers, got {refusal_container_repr(values)}"}
+            ],
         }
     out: list[float] = []
     for elem in seq:
@@ -126,7 +135,7 @@ def _coerce_finite_vector(
                 "status": "error",
                 "content": [
                     {
-                        "text": f"{method}: '{name}' elements must be numbers, not a bool (got {values!r}). {BOOLEAN_VECTOR_REASON}"
+                        "text": f"{method}: '{name}' elements must be numbers, not a bool (got {refusal_container_repr(values)}). {BOOLEAN_VECTOR_REASON}"
                     }
                 ],
             }
@@ -135,18 +144,28 @@ def _coerce_finite_vector(
         except (TypeError, ValueError):
             return None, {
                 "status": "error",
-                "content": [{"text": f"{method}: '{name}' elements must be numbers, got {values!r}"}],
+                "content": [
+                    {"text": f"{method}: '{name}' elements must be numbers, got {refusal_container_repr(values)}"}
+                ],
             }
         if not math.isfinite(f):
             return None, {
                 "status": "error",
-                "content": [{"text": f"{method}: '{name}' must contain finite numbers (no nan/inf), got {values!r}"}],
+                "content": [
+                    {
+                        "text": f"{method}: '{name}' must contain finite numbers (no nan/inf), got {refusal_container_repr(values)}"
+                    }
+                ],
             }
         if min_value is not None and ((f <= min_value) if strict_min else (f < min_value)):
             rel = ">" if strict_min else ">="
             return None, {
                 "status": "error",
-                "content": [{"text": f"{method}: '{name}' values must be {rel} {min_value}, got {values!r}"}],
+                "content": [
+                    {
+                        "text": f"{method}: '{name}' values must be {rel} {min_value}, got {refusal_container_repr(values)}"
+                    }
+                ],
             }
         out.append(f)
     if accepted_lengths is not None and len(out) not in accepted_lengths:
@@ -238,7 +257,7 @@ def _coerce_ray_batch(directions: Any, method: str) -> tuple[list[Any] | None, d
                 {
                     "text": (
                         f"{method}: 'directions' must be a sequence of direction vectors, "
-                        f"got {directions!r}. {_RAY_BATCH_HINT}"
+                        f"got {refusal_container_repr(directions)}. {_RAY_BATCH_HINT}"
                     )
                 }
             ],
@@ -287,7 +306,7 @@ def _coerce_excluded_body(value: Any, method: str, nbody: int) -> tuple[int | No
             {
                 "text": (
                     f"{method}: 'exclude_body' must be -1 (exclude nothing) or a body id "
-                    f"in [0, {nbody}), got {value!r}. Read an id from list_bodies()."
+                    f"in [0, {nbody}), got {refusal_repr(value)}. Read an id from list_bodies()."
                 )
             }
         ],

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -49,6 +49,7 @@ from strands_robots.utils import (
     finite_vector_error,
     orientation_quaternion_error,
     pose_vector_error,
+    refusal_repr,
 )
 
 logger = logging.getLogger(__name__)
@@ -2615,7 +2616,7 @@ def _geom_shape_error(shape: Any) -> str | None:
         return None
     accepted = ", ".join(sorted(set(_SIZE_LAYOUT) - _UNSUPPORTED_GEOM_SHAPES))
     return (
-        f"add_geom: 'type' cannot be {shape!r} - this op has no key that names a mesh asset, "
+        f"add_geom: 'type' cannot be {refusal_repr(shape)} - this op has no key that names a mesh asset, "
         "so the geom it would add has no mesh to take its extent from and MuJoCo refuses the "
         'whole scene at recompile. Add a mesh with add_object(shape="mesh", mesh_path=...), '
         f"which registers the asset alongside the body. Accepted 'type' values: {accepted}."

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -74,6 +74,7 @@ from strands_robots.utils import (
     positive_finite_number_error,
     positive_whole_number_error,
     process_rss_mb,
+    refusal_container_repr,
 )
 
 if TYPE_CHECKING:
@@ -738,7 +739,7 @@ def _validate_action_key_map(action_key_map: Any) -> dict[str, Any] | None:
 
     if isinstance(action_key_map, str | bytes):
         return _error(
-            f"action_key_map must be a list of action keys, not a bare string (got {action_key_map!r}); "
+            f"action_key_map must be a list of action keys, not a bare string (got {refusal_container_repr(action_key_map)}); "
             "a string is consumed one character per action index."
         )
     if not isinstance(action_key_map, list | tuple):

--- a/strands_robots/streaming_dataset.py
+++ b/strands_robots/streaming_dataset.py
@@ -30,6 +30,7 @@ from strands_robots.utils import (
     lerobot_version,
     non_negative_count_error,
     positive_count_error,
+    refusal_repr,
 )
 
 logger = logging.getLogger(__name__)
@@ -128,7 +129,7 @@ def _tolerance_error(value: Any) -> str | None:
         return error
     if float(value) < 0.0:
         return (
-            f"open: tolerance_s must be >= 0, got {value!r}. It is the half-width of the "
+            f"open: tolerance_s must be >= 0, got {refusal_repr(value)}. It is the half-width of the "
             "grid-match window, so a negative one is satisfied by no delta at all and "
             "refuses an on-grid delta_timestamps. Pass 0 to require an exact grid match."
         )

--- a/strands_robots/tools/lerobot_camera.py
+++ b/strands_robots/tools/lerobot_camera.py
@@ -68,6 +68,7 @@ from strands_robots.utils import (
     boolean_flag_error,
     positive_finite_number_error,
     positive_whole_number_error,
+    refusal_container_repr,
 )
 
 # The one remedy for an absent RealSense SDK, so every surface that reports it
@@ -442,12 +443,12 @@ def _camera_ids_error(camera_ids: Any) -> str | None:
     )
     if isinstance(camera_ids, str):
         return (
-            f"{prefix} must be {accepted}, not a single string ({camera_ids!r}). A "
-            f"string is read one camera per character, so pass [{camera_ids!r}] to "
+            f"{prefix} must be {accepted}, not a single string ({refusal_container_repr(camera_ids)}). A "
+            f"string is read one camera per character, so pass [{refusal_container_repr(camera_ids)}] to "
             f"name one camera."
         )
     if isinstance(camera_ids, bytes):
-        return f"{prefix} must be {accepted}, not bytes ({camera_ids!r})."
+        return f"{prefix} must be {accepted}, not bytes ({refusal_container_repr(camera_ids)})."
     if isinstance(camera_ids, Mapping):
         return f"{prefix} must be {accepted}, not a mapping - its values would be discarded."
     if not isinstance(camera_ids, Sequence):

--- a/strands_robots/tools/pose_tool.py
+++ b/strands_robots/tools/pose_tool.py
@@ -30,6 +30,7 @@ from strands_robots.utils import (
     finite_number_error,
     positive_count_error,
     positive_finite_number_error,
+    refusal_str,
 )
 
 logger = logging.getLogger(__name__)
@@ -467,7 +468,7 @@ def _joint_target_error(action: str, label: str, motor_name: str | None, value: 
     if not low <= value <= high:
         return (
             f"{action}: {label} must be within [{low}, {high}] {_target_unit(name)} "
-            f"(the configured travel of '{name}'), got {value}."
+            f"(the configured travel of '{name}'), got {refusal_str(value)}."
         )
     return None
 
@@ -513,7 +514,7 @@ def _joint_delta_error(action: str, motor_name: str | None, delta: Any) -> str |
     if abs(delta) > span:
         return (
             f"{action}: delta must be at most {span} {_target_unit(name)} in magnitude "
-            f"(the full travel of '{name}', so no starting position could honor more), got {delta}."
+            f"(the full travel of '{name}', so no starting position could honor more), got {refusal_str(delta)}."
         )
     return None
 

--- a/strands_robots/tools/serial_tool.py
+++ b/strands_robots/tools/serial_tool.py
@@ -64,6 +64,7 @@ from strands_robots.utils import (
     finite_number_error,
     non_negative_count_error,
     positive_count_error,
+    refusal_str,
 )
 
 # Bit index carrying the direction in the two STS/SMS registers this module
@@ -145,7 +146,7 @@ def _register_field_error(value: Any, param: str, action: str) -> str | None:
     if error := floor_error(value, param, action):
         return error
     if value > high:
-        return f"{action}: {param} must be at most {high} ({why}), got {value}."
+        return f"{action}: {param} must be at most {high} ({why}), got {refusal_str(value)}."
     return None
 
 
@@ -170,7 +171,7 @@ def _motor_id_error(value: Any, param: str, action: str) -> str | None:
         return (
             f"{action}: {param} {BROADCAST_ID:#x} is the broadcast, which every servo on the bus "
             f"answers at once, so no single reply can be read back; address one servo in "
-            f"[1, {MAX_UNICAST_ID}], got {value}."
+            f"[1, {MAX_UNICAST_ID}], got {refusal_str(value)}."
         )
     return None
 
@@ -197,7 +198,7 @@ def _read_timeout_error(value: Any, param: str, action: str) -> str | None:
     if error := finite_number_error(value, param, action):
         return error
     if value < 0:
-        return f"{action}: {param} must be at least 0 seconds, got {value}."
+        return f"{action}: {param} must be at least 0 seconds, got {refusal_str(value)}."
     return None
 
 

--- a/strands_robots/training/_validate.py
+++ b/strands_robots/training/_validate.py
@@ -51,6 +51,7 @@ from strands_robots.utils import (
     non_negative_count_error,
     positive_count_error,
     positive_finite_number_error,
+    refusal_repr,
     step_cadence_error,
     torch_device_error,
 )
@@ -251,7 +252,7 @@ def _closed_unit_interval_error(value: Any, param: str, context: str) -> str | N
     if error is not None:
         return error
     if not 0.0 <= float(value) <= 1.0:
-        return f"{context}: {param} must be in [0, 1], got {value!r}."
+        return f"{context}: {param} must be in [0, 1], got {refusal_repr(value)}."
     return None
 
 
@@ -408,7 +409,7 @@ def _half_open_unit_interval_error(value: Any, param: str, context: str) -> str 
     if error is not None:
         return error
     if not 0.0 < float(value) <= 1.0:
-        return f"{context}: {param} must be in (0, 1], got {value!r}."
+        return f"{context}: {param} must be in (0, 1], got {refusal_repr(value)}."
     return None
 
 

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -444,7 +444,7 @@ def sequence_length(value: Any) -> int | None:
         return None
 
 
-def _refusal_repr(value: Any) -> str:
+def refusal_repr(value: Any) -> str:
     """``repr(value)`` for a refusal message, or a description when it cannot be built.
 
     Every scalar guard below renders the value it refuses through this, and none
@@ -482,10 +482,10 @@ def _refusal_repr(value: Any) -> str:
         return _describe_unrenderable(value)
 
 
-def _refusal_str(value: Any) -> str:
+def refusal_str(value: Any) -> str:
     """``str(value)`` for a refusal message, or a description when it cannot be built.
 
-    The :func:`_refusal_repr` counterpart for the two messages that report a
+    The :func:`refusal_repr` counterpart for the two messages that report a
     value plainly rather than quoted, where ``repr`` is not interchangeable:
     NumPy 2 reprs a scalar with its type, so rendering an ``np.float32`` fov
     through ``repr`` would silently turn ``got 200.0`` into
@@ -512,7 +512,7 @@ def _refusal_str(value: Any) -> str:
 def _describe_unrenderable(value: Any) -> str:
     """Describe a value whose own rendering raised.
 
-    Shared by :func:`_refusal_repr` and :func:`_refusal_str` so the two render
+    Shared by :func:`refusal_repr` and :func:`refusal_str` so the two render
     forms cannot describe the same unrenderable value differently.
 
     ``int.bit_length`` needs no decimal conversion, so the value most likely to
@@ -545,7 +545,7 @@ def _describe_failed_read(exc: Exception) -> str:
     refusal degraded on one path must not describe the same failure differently
     from another.
 
-    ``exc`` goes through :func:`_refusal_str` rather than being interpolated: a
+    ``exc`` goes through :func:`refusal_str` rather than being interpolated: a
     value hostile enough to raise from its own read is not one whose exception is
     assumed to have a working ``__str__``, which would be the #1873 escape
     reintroduced inside a message built to avoid it.
@@ -556,7 +556,7 @@ def _describe_failed_read(exc: Exception) -> str:
     Returns:
         Its type name and text, which cannot itself raise.
     """
-    return f"{type(exc).__name__}: {_refusal_str(exc)}"
+    return f"{type(exc).__name__}: {refusal_str(exc)}"
 
 
 def _read_to_quote(value: Any) -> tuple[list[Any] | None, str | None]:
@@ -586,13 +586,13 @@ def _read_to_quote(value: Any) -> tuple[list[Any] | None, str | None]:
         return None, _describe_failed_read(exc)
 
 
-def _refusal_container_repr(value: Any) -> str:
+def refusal_container_repr(value: Any) -> str:
     """``repr(value)`` for a refusal that reports a whole container, elementwise if it must.
 
-    The container counterpart to :func:`_refusal_repr`, and the reason the two
+    The container counterpart to :func:`refusal_repr`, and the reason the two
     cannot be one function. ``repr`` of a list recurses into its elements, so a
     container is unrenderable whenever any *one* of its elements is, and
-    :func:`_refusal_repr`'s whole-value fallback would answer that with
+    :func:`refusal_repr`'s whole-value fallback would answer that with
     ``<unrepresentable list>`` - erasing every element that rendered perfectly
     well, and the element count with them. That count is frequently the entire
     reason for the refusal (``must be a 3-element vector, got 4``), so a
@@ -636,7 +636,7 @@ def _refusal_container_repr(value: Any) -> str:
     Returns:
         Its ``repr``; an elementwise rendering when that raises; or a bracketed
         description when ``value`` cannot be iterated either, which is
-        :func:`_refusal_repr`'s answer for a value that is not a container at
+        :func:`refusal_repr`'s answer for a value that is not a container at
         all - every one of these guards accepts ``Any``, so a scalar reaches
         them too.
     """
@@ -649,12 +649,12 @@ def _refusal_container_repr(value: Any) -> str:
             items = list(value.items())
         except Exception:
             return _describe_unrenderable(value)
-        return "{" + ", ".join(f"{_refusal_repr(key)}: {_refusal_repr(val)}" for key, val in items) + "}"
+        return "{" + ", ".join(f"{refusal_repr(key)}: {refusal_repr(val)}" for key, val in items) + "}"
     try:
         elements = list(value)
     except Exception:
         return _describe_unrenderable(value)
-    return "[" + ", ".join(_refusal_repr(element) for element in elements) + "]"
+    return "[" + ", ".join(refusal_repr(element) for element in elements) + "]"
 
 
 def _beyond_float_range(value: Any) -> bool:
@@ -732,13 +732,13 @@ def positive_finite_number_error(value: Any, param: str, context: str) -> str | 
         An error message, or ``None`` when the value is usable.
     """
     if isinstance(value, bool) or not isinstance(value, numbers.Real):
-        return f"{context}: {param} must be > 0, got {_refusal_repr(value)}."
+        return f"{context}: {param} must be > 0, got {refusal_repr(value)}."
     if _beyond_float_range(value):
         # A real past the float64 range is positive-or-negative and finite, so
         # neither of this guard's own reasons is true of it - hence its own text.
         # Refusing stays right: the value is a divisor (``1 / hz``) or a
         # multiplier evaluated in float64, and no float64 stands for it.
-        return f"{context}: {param} must be within the range of a 64-bit float, got {_refusal_repr(value)}."
+        return f"{context}: {param} must be within the range of a 64-bit float, got {refusal_repr(value)}."
     try:
         # ``isfinite`` before the sign test: ``nan`` is never ``<= 0``, so
         # ordering these the other way lets it through.
@@ -749,7 +749,7 @@ def positive_finite_number_error(value: Any, param: str, context: str) -> str | 
         # the same reason a non-real one is - the message it already had.
         unusable = True
     if unusable:
-        return f"{context}: {param} must be > 0, got {_refusal_repr(value)}."
+        return f"{context}: {param} must be > 0, got {refusal_repr(value)}."
     return None
 
 
@@ -794,19 +794,19 @@ def finite_number_error(value: Any, param: str, context: str) -> str | None:
         An error message, or ``None`` when the value is usable.
     """
     if isinstance(value, bool) or not isinstance(value, numbers.Real):
-        return f"{context}: {param} must be a finite number, got {_refusal_repr(value)}."
+        return f"{context}: {param} must be a finite number, got {refusal_repr(value)}."
     if _beyond_float_range(value):
         # ``10**400`` *is* a finite number, so this guard's own reason would be
         # a false statement about it. Refusing stays right: the docstring above
         # is explicit that an accepted value is serialized onto the wire as an
         # IEEE-754 float64, and this one has no float64 form to serialize.
-        return f"{context}: {param} must be within the range of a 64-bit float, got {_refusal_repr(value)}."
+        return f"{context}: {param} must be within the range of a 64-bit float, got {refusal_repr(value)}."
     try:
         unusable = not math.isfinite(float(value))
     except Exception:
         unusable = True
     if unusable:
-        return f"{context}: {param} must be a finite number, got {_refusal_repr(value)}."
+        return f"{context}: {param} must be a finite number, got {refusal_repr(value)}."
     return None
 
 
@@ -889,7 +889,7 @@ def positive_whole_number_error(value: Any, param: str, context: str) -> str | N
         # ``repr`` raised on an outsized ``int`` ahead of every verdict - the
         # guard failing while preparing a refusal it had not decided to return,
         # and doing it on the accept path too.
-        return f"{context}: {param} must be a positive whole number, got {_refusal_repr(value)}."
+        return f"{context}: {param} must be a positive whole number, got {refusal_repr(value)}."
 
     if isinstance(value, bool) or not isinstance(value, numbers.Real):
         return message()
@@ -897,7 +897,7 @@ def positive_whole_number_error(value: Any, param: str, context: str) -> str | N
         # ``10**400`` is a positive whole number, so ``message()`` would state
         # something false about it. It is refused rather than accepted, and
         # deliberately unlike its ``non_negative`` sibling - see the docstring.
-        return f"{context}: {param} must be within the range of a 64-bit float, got {_refusal_repr(value)}."
+        return f"{context}: {param} must be within the range of a 64-bit float, got {refusal_repr(value)}."
     try:
         numeric = float(value)
     except Exception:
@@ -993,7 +993,7 @@ def non_negative_whole_number_error(value: Any, param: str, context: str) -> str
         # ``sys.get_int_max_str_digits()`` is accepted here, and building the
         # text eagerly made ``repr`` raise on it - the guard failing on the
         # accept path, doing work only the refuse path needs.
-        return f"{context}: {param} must be a non-negative whole number, got {_refusal_repr(value)}."
+        return f"{context}: {param} must be a non-negative whole number, got {refusal_repr(value)}."
 
     if isinstance(value, bool) or not isinstance(value, numbers.Real):
         return message()
@@ -1128,7 +1128,7 @@ def positive_count_error(value: Any, param: str, context: str) -> str | None:
         An error message, or ``None`` when the value is usable.
     """
     if isinstance(value, bool) or not isinstance(value, int) or value < 1:
-        return f"{context}: {param} must be a positive integer, got {_refusal_repr(value)}."
+        return f"{context}: {param} must be a positive integer, got {refusal_repr(value)}."
     return None
 
 
@@ -1178,7 +1178,7 @@ def tcp_port_error(value: Any, param: str, context: str) -> str | None:
         An error message, or ``None`` when the value is usable.
     """
     if isinstance(value, bool) or not isinstance(value, int) or not 1 <= value <= 65535:
-        return f"{context}: invalid {param}: {_refusal_repr(value)} (expected 1-65535)"
+        return f"{context}: invalid {param}: {refusal_repr(value)} (expected 1-65535)"
     return None
 
 
@@ -1276,7 +1276,7 @@ def dial_host_error(value: Any, param: str, context: str) -> str | None:
     Returns:
         An error message, or ``None`` when the value can address a host.
     """
-    shown = _refusal_repr(value)
+    shown = refusal_repr(value)
     if not isinstance(value, str):
         return (
             f"{context}: {param} must be a string hostname or IP literal, got {shown} "
@@ -1293,7 +1293,7 @@ def dial_host_error(value: Any, param: str, context: str) -> str | None:
             "Pass a plain hostname or IP literal, e.g. '127.0.0.1'."
         )
     spelling, body, bad = read
-    would_be = _refusal_repr(f"ws://{spelling}:<port>")
+    would_be = refusal_repr(f"ws://{spelling}:<port>")
     if not body:
         return (
             f"{context}: {param} must name a host to dial, got {shown}; "
@@ -1304,7 +1304,7 @@ def dial_host_error(value: Any, param: str, context: str) -> str | None:
         hint = " Pass a bracketed literal for IPv6 (e.g. '[::1]')." if ":" in bad else ""
         return (
             f"{context}: {param} must be a bare hostname or IP literal, got {shown}; "
-            f"{_refusal_container_repr(bad)} cannot appear in the host half of the websocket URI it "
+            f"{refusal_container_repr(bad)} cannot appear in the host half of the websocket URI it "
             f"is interpolated into (ws://<host>:<port>), so {would_be} names a different URI rather "
             "than a host - a '/' puts the validated port in the path and the client dials :80 "
             f"instead.{hint}"
@@ -1362,7 +1362,7 @@ def non_negative_count_error(value: Any, param: str, context: str) -> str | None
         An error message, or ``None`` when the value is usable.
     """
     if isinstance(value, bool) or not isinstance(value, int) or value < 0:
-        return f"{context}: {param} must be a non-negative integer, got {_refusal_repr(value)}."
+        return f"{context}: {param} must be a non-negative integer, got {refusal_repr(value)}."
     return None
 
 
@@ -1464,7 +1464,7 @@ def step_cadence_error(value: Any, param: str, context: str) -> str | None:
     """
     if isinstance(value, bool) or not isinstance(value, int):
         return (
-            f"{context}: {param} must be an integer number of steps, got {_refusal_repr(value)}. "
+            f"{context}: {param} must be an integer number of steps, got {refusal_repr(value)}. "
             "A fractional, non-finite, boolean or non-numeric cadence cannot be honored - it is "
             "used as the modulus of a step % cadence test; pass a whole number of steps, or a "
             "non-positive one to disable periodic saving."
@@ -1514,7 +1514,7 @@ def torch_device_error(value: Any, param: str, context: str) -> str | None:
     through unguarded, which is the posture every live-sourced domain in this
     module takes when its source cannot be read.
 
-    The refused value is rendered through :func:`_refusal_repr`, as every scalar
+    The refused value is rendered through :func:`refusal_repr`, as every scalar
     guard here is: ``repr`` can itself raise - on an ``int`` wider than
     :func:`sys.get_int_max_str_digits`, or from any third-party ``__repr__`` - and
     a guard that raises while building a refusal fails on exactly the path that
@@ -1542,7 +1542,7 @@ def torch_device_error(value: Any, param: str, context: str) -> str | None:
         torch.device(value)
     except (RuntimeError, ValueError) as e:
         return (
-            f"{context}: {param}={_refusal_repr(value)} is not a torch device string ({e}). "
+            f"{context}: {param}={refusal_repr(value)} is not a torch device string ({e}). "
             "Pass a device type, optionally with an index (e.g. 'cuda', 'cuda:0', 'cpu', 'mps')."
         )
     return None
@@ -1604,7 +1604,7 @@ def dds_domain_id_error(value: Any, param: str, context: str) -> str | None:
         An error message, or ``None`` when the value is usable.
     """
     if isinstance(value, bool) or not isinstance(value, int) or not 0 <= value <= MAX_DDS_DOMAIN_ID:
-        return f"{context}: invalid {param}: {_refusal_repr(value)} (expected 0-{MAX_DDS_DOMAIN_ID})"
+        return f"{context}: invalid {param}: {refusal_repr(value)} (expected 0-{MAX_DDS_DOMAIN_ID})"
     return None
 
 
@@ -1697,7 +1697,7 @@ def coerce_zmq_timeout_ms(method: str, param_name: str, value: Any) -> tuple[int
     if timeout_ms > MAX_ZMQ_TIMEOUT_MS:
         return None, (
             f"{method}: {param_name} must be at most {MAX_ZMQ_TIMEOUT_MS} ms "
-            f"(the largest send/receive timeout ZMQ can store), got {_refusal_repr(value)}."
+            f"(the largest send/receive timeout ZMQ can store), got {refusal_repr(value)}."
         )
     return timeout_ms, None
 
@@ -1753,7 +1753,7 @@ def _read_name_list(value: object, param: str, context: str) -> tuple[list[Any],
     except Exception as exc:
         return [], (
             f"{context}: {param} could not be iterated: "
-            f"{_describe_failed_read(exc)} (got {_refusal_container_repr(value)}). "
+            f"{_describe_failed_read(exc)} (got {refusal_container_repr(value)}). "
             f"Pass a list or tuple of names."
         )
     entries: list[Any] = []
@@ -1770,7 +1770,7 @@ def _read_name_list(value: object, param: str, context: str) -> tuple[list[Any],
         except Exception as exc:
             return entries, (
                 f"{context}: {param}[{len(entries)}] could not be read: "
-                f"{_describe_failed_read(exc)} (got {_refusal_container_repr(value)}). "
+                f"{_describe_failed_read(exc)} (got {refusal_container_repr(value)}). "
                 f"Pass a list or tuple of names."
             )
         entries.append(entry)
@@ -1876,13 +1876,13 @@ def name_list_error(value: Any, param: str, context: str) -> str | None:
         else:
             consequence = (
                 f"A string is iterable per character, so this would be read as "
-                f"{_refusal_container_repr(characters[:6])}{' ...' if len(characters) > 6 else ''} "
+                f"{refusal_container_repr(characters[:6])}{' ...' if len(characters) > 6 else ''} "
                 f"({len(characters)} name(s))."
             )
         return (
             f"{context}: {param} must be a list of names, not a single string, "
-            f"got {_refusal_container_repr(value)}. {consequence} "
-            f"Wrap it in a list: [{_refusal_repr(shown)}]."
+            f"got {refusal_container_repr(value)}. {consequence} "
+            f"Wrap it in a list: [{refusal_repr(shown)}]."
         )
     if isinstance(value, Mapping):
         # The verdict is not in doubt on this branch, so a key read that fails
@@ -1891,17 +1891,17 @@ def name_list_error(value: Any, param: str, context: str) -> str | None:
         remedy = (
             f"pass the names as a list; its own keys could not be read to quote them here ({unquotable})."
             if names is None
-            else f"pass the names as a list: {_refusal_container_repr(names)}."
+            else f"pass the names as a list: {refusal_container_repr(names)}."
         )
         return (
             f"{context}: {param} must be a list of names, not a mapping, "
-            f"got {_refusal_container_repr(value)}. "
+            f"got {refusal_container_repr(value)}. "
             f"A mapping is iterable over its keys, so its values would be discarded - {remedy}"
         )
     if not isinstance(value, Sequence):
         return (
             f"{context}: {param} must be a list of names, got {type(value).__name__} "
-            f"({_refusal_container_repr(value)}). Pass a list or tuple; a one-shot iterator cannot be used "
+            f"({refusal_container_repr(value)}). Pass a list or tuple; a one-shot iterator cannot be used "
             f"because the value is read more than once."
         )
     # One read, and every verdict below is about the list it produced. A
@@ -1913,9 +1913,9 @@ def name_list_error(value: Any, param: str, context: str) -> str | None:
         return unread
     for i, entry in enumerate(entries):
         if not isinstance(entry, str):
-            return f"{context}: {param}[{i}] must be a name (str), got {type(entry).__name__} ({_refusal_repr(entry)})."
+            return f"{context}: {param}[{i}] must be a name (str), got {type(entry).__name__} ({refusal_repr(entry)})."
         if not entry.strip():
-            return f"{context}: {param}[{i}] must be a non-blank name, got {_refusal_repr(entry)}."
+            return f"{context}: {param}[{i}] must be a non-blank name, got {refusal_repr(entry)}."
     seen: set[str] = set()
     repeated: set[str] = set()
     for entry in entries:
@@ -1924,8 +1924,8 @@ def name_list_error(value: Any, param: str, context: str) -> str | None:
         seen.add(entry)
     if repeated:
         return (
-            f"{context}: {param} must not repeat a name, got {_refusal_container_repr(entries)} "
-            f"({_refusal_container_repr(sorted(repeated))} appears more than once)."
+            f"{context}: {param} must not repeat a name, got {refusal_container_repr(entries)} "
+            f"({refusal_container_repr(sorted(repeated))} appears more than once)."
         )
     return None
 
@@ -2039,18 +2039,18 @@ def _read_finite_vector(method: str, param_name: str, vec: Any) -> tuple[list[fl
     # for a stronger reason than the memory it holds: it raises before any element
     # has been examined, so its verdict could not say how far the read got - the
     # one thing that distinguishes a part-way failure from an outright refusal.
-    # ``exc`` is rendered through ``_refusal_str`` rather than interpolated: a
+    # ``exc`` is rendered through ``refusal_str`` rather than interpolated: a
     # value hostile enough to raise a non-``TypeError`` from ``__iter__`` is not
     # a value whose exception is assumed to have a working ``__str__``, and that
     # is the #1873 escape reintroduced inside the fix for this one.
     try:
         elements = iter(vec)
     except TypeError:
-        return floats, f"{method}: '{param_name}' must be a list/tuple of numbers, got {_refusal_container_repr(vec)}"
+        return floats, f"{method}: '{param_name}' must be a list/tuple of numbers, got {refusal_container_repr(vec)}"
     except Exception as exc:
         return floats, (
             f"{method}: '{param_name}' could not be iterated: "
-            f"{type(exc).__name__}: {_refusal_str(exc)} (got {_refusal_container_repr(vec)}). "
+            f"{type(exc).__name__}: {refusal_str(exc)} (got {refusal_container_repr(vec)}). "
             f"Pass a list or tuple of numbers."
         )
     while True:
@@ -2070,7 +2070,7 @@ def _read_finite_vector(method: str, param_name: str, vec: Any) -> tuple[list[fl
         except Exception as exc:
             return floats, (
                 f"{method}: '{param_name}[{len(floats)}]' could not be read: "
-                f"{type(exc).__name__}: {_refusal_str(exc)} (got {_refusal_container_repr(vec)}). "
+                f"{type(exc).__name__}: {refusal_str(exc)} (got {refusal_container_repr(vec)}). "
                 f"Pass a list or tuple of numbers."
             )
         # ``numbers.Real`` accepts a numpy scalar (``np.float32`` / ``np.int64``
@@ -2082,10 +2082,10 @@ def _read_finite_vector(method: str, param_name: str, vec: Any) -> tuple[list[fl
         if is_boolean(_elem):
             return floats, (
                 f"{method}: '{param_name}' elements must be numbers, not a bool "
-                f"(got {_refusal_container_repr(vec)}). {BOOLEAN_VECTOR_REASON}"
+                f"(got {refusal_container_repr(vec)}). {BOOLEAN_VECTOR_REASON}"
             )
         if not isinstance(_elem, numbers.Real):
-            return floats, f"{method}: '{param_name}' elements must be numbers, got {_refusal_container_repr(vec)}"
+            return floats, f"{method}: '{param_name}' elements must be numbers, got {refusal_container_repr(vec)}"
         # An element past the float64 range is a *magnitude* complaint and gets
         # its own reason, exactly as the scalar guards give one (#1874). The
         # order matters: ``_beyond_float_range`` answers only ``OverflowError``,
@@ -2095,15 +2095,15 @@ def _read_finite_vector(method: str, param_name: str, vec: Any) -> tuple[list[fl
         if _beyond_float_range(_elem):
             return floats, (
                 f"{method}: '{param_name}' must contain numbers within the range of a 64-bit float, "
-                f"got {_refusal_container_repr(vec)}"
+                f"got {refusal_container_repr(vec)}"
             )
         try:
             numeric = float(_elem)
         except Exception:
-            return floats, f"{method}: '{param_name}' elements must be numbers, got {_refusal_container_repr(vec)}"
+            return floats, f"{method}: '{param_name}' elements must be numbers, got {refusal_container_repr(vec)}"
         if not math.isfinite(numeric):
             return floats, (
-                f"{method}: '{param_name}' must contain finite numbers (no nan/inf), got {_refusal_container_repr(vec)}"
+                f"{method}: '{param_name}' must contain finite numbers (no nan/inf), got {refusal_container_repr(vec)}"
             )
         floats.append(numeric)
     return floats, None
@@ -2178,7 +2178,7 @@ def finite_vector_error(method: str, param_name: str, vec: Any) -> str | None:
         # The components were read and were finite; what the value cannot supply
         # is a length for the caller to count. Same words as the sibling
         # coercions, because it is the same verdict about the same value.
-        return f"{method}: '{param_name}' must be a list/tuple of numbers, got {_refusal_container_repr(vec)}"
+        return f"{method}: '{param_name}' must be a list/tuple of numbers, got {refusal_container_repr(vec)}"
     return None
 
 
@@ -2244,7 +2244,7 @@ def _read_pose_vector(method: str, param_name: str, vec: Any, expected_len: int)
     if isinstance(vec, str | bytes):
         return [], (
             f"{method}: '{param_name}' must be a list/tuple of {expected_len} numbers, "
-            f"got {type(vec).__name__} {_refusal_container_repr(vec)}. A string carries a "
+            f"got {type(vec).__name__} {refusal_container_repr(vec)}. A string carries a "
             f"length, but it counts characters rather than components, so it cannot be read "
             f"as a pose - pass the {expected_len} numbers themselves."
         )
@@ -2252,12 +2252,12 @@ def _read_pose_vector(method: str, param_name: str, vec: Any, expected_len: int)
     if length is None:
         return [], (
             f"{method}: '{param_name}' must be a list/tuple of {expected_len} numbers, "
-            f"got {_refusal_container_repr(vec)}"
+            f"got {refusal_container_repr(vec)}"
         )
     if length != expected_len:
         return [], (
             f"{method}: '{param_name}' must be a {expected_len}-element vector, "
-            f"got {length} ({_refusal_container_repr(vec)})"
+            f"got {length} ({refusal_container_repr(vec)})"
         )
     floats, err = _read_finite_vector(method, param_name, vec)
     if err is not None:
@@ -2518,7 +2518,7 @@ def coerce_rgba(method: str, param_name: str, color: Any) -> tuple[list[float] |
     # whose components a read would consume before anything could count them. The
     # component count is not taken from it - see below.
     if sequence_length(color) is None:
-        return None, f"{method}: '{param_name}' must be a sequence of numbers, got {_refusal_container_repr(color)}"
+        return None, f"{method}: '{param_name}' must be a sequence of numbers, got {refusal_container_repr(color)}"
     # One read: the floats quoted by the component-count refusal below are the ones
     # the domain checks examined. They used to come from a second, unguarded read,
     # so a colour that answered the checked read and refused this one raised out of
@@ -2610,7 +2610,7 @@ def coerce_size_vector(method: str, param_name: str, size: Any) -> tuple[list[fl
     if sequence_length(size) is None:
         # Reachable only for something iterable but unsized - a generator, which
         # the check above has now consumed, so there is nothing left to store.
-        return None, f"{method}: '{param_name}' must be a list/tuple of numbers, got {_refusal_container_repr(size)}"
+        return None, f"{method}: '{param_name}' must be a list/tuple of numbers, got {refusal_container_repr(size)}"
     # Empty means the read produced no component, not that ``__len__`` reported
     # zero: the two are independent reads (#1909), and it is the absence of an
     # extent to write that makes the value unusable. A value whose length reports
@@ -2619,7 +2619,7 @@ def coerce_size_vector(method: str, param_name: str, size: Any) -> tuple[list[fl
     if not floats:
         return None, (
             f"{method}: '{param_name}' must have at least one component, got an empty "
-            f"vector ({_refusal_container_repr(size)}). An empty '{param_name}' is a component count, not an "
+            f"vector ({refusal_container_repr(size)}). An empty '{param_name}' is a component count, not an "
             f"omission - omit '{param_name}' to take the default extent."
         )
     # The floats the component checks above examined, not a second read of the
@@ -2696,7 +2696,7 @@ def reserved_camera_name_error(method: str, param_name: str, name: Any) -> str |
     # one has narrowed to ``str`` and could interpolate safely: a ``str``
     # subclass owes its ``__repr__`` nothing, and the rule that no guard renders
     # a caller value directly is worth more than the exception would save.
-    rendered = _refusal_repr(name)
+    rendered = refusal_repr(name)
     return (
         f"{method}: {rendered} is reserved; pick a distinct camera name. "
         f"render/get_frame resolve {param_name}={rendered} to the free camera by an "
@@ -2740,10 +2740,10 @@ def camera_fov_error(method: str, param_name: str, value: Any) -> str | None:
     """
 
     def not_a_number() -> str:
-        return f"{method}: '{param_name}' must be a finite number in degrees, got {_refusal_repr(value)}."
+        return f"{method}: '{param_name}' must be a finite number in degrees, got {refusal_repr(value)}."
 
     def outside_interval() -> str:
-        return f"{method}: '{param_name}' must be in the open interval (0, 180) degrees, got {_refusal_str(value)}."
+        return f"{method}: '{param_name}' must be in the open interval (0, 180) degrees, got {refusal_str(value)}."
 
     if isinstance(value, bool) or not isinstance(value, numbers.Real):
         return not_a_number()
@@ -2833,7 +2833,7 @@ def entity_name_error(method: str, param_name: str, name: Any) -> str | None:
     """
     if not isinstance(name, str):
         return (
-            f"{method}: '{param_name}' must be a non-empty string, got {_refusal_repr(name)} "
+            f"{method}: '{param_name}' must be a non-empty string, got {refusal_repr(name)} "
             f"({type(name).__name__}); an entity is addressed by name and every "
             "agent-tool call carries that name as a string."
         )
@@ -2845,7 +2845,7 @@ def entity_name_error(method: str, param_name: str, name: Any) -> str | None:
         )
     if "\x00" in name:
         return (
-            f"{method}: '{param_name}' must not contain a NUL character, got {_refusal_repr(name)}; "
+            f"{method}: '{param_name}' must not contain a NUL character, got {refusal_repr(name)}; "
             "the compiled model reads a name only up to the first NUL, so the registry "
             "and the model would disagree about the entity's name."
         )
@@ -2899,7 +2899,7 @@ def published_string_error(value: Any, param: str, context: str) -> str | None:
     if isinstance(value, str):
         return None
     return (
-        f"{context}: '{param}' must be a string, got {_refusal_repr(value)} "
+        f"{context}: '{param}' must be a string, got {refusal_repr(value)} "
         f"({type(value).__name__}); this tool publishes '{param}' as a string and "
         "every agent-tool call carries it as one."
     )
@@ -3010,7 +3010,7 @@ def validation_split_error(val_episodes: int, total_tasks: Any, context: str, *,
     if declared is None:
         return (
             f"{context}: val_episodes={val_episodes} cannot be checked against a dataset whose "
-            f"meta/info.json declares total_tasks={_refusal_repr(total_tasks)}, which is not a "
+            f"meta/info.json declares total_tasks={refusal_repr(total_tasks)}, which is not a "
             "task count. Whether one global count is expressible depends on how many tasks the "
             "dataset holds - lerobot holds out ceil(episodes_in_task * eval_split) from every "
             "task - so a header declaring no usable count is neither single-task nor multi-task, "
@@ -3022,7 +3022,7 @@ def validation_split_error(val_episodes: int, total_tasks: Any, context: str, *,
         return None
     return (
         f"{context}: val_episodes={val_episodes} cannot be reserved exactly on a "
-        f"dataset with {_refusal_str(declared)} tasks. A validation split is a per-task "
+        f"dataset with {refusal_str(declared)} tasks. A validation split is a per-task "
         "fraction in lerobot (it holds out ceil(episodes_in_task * eval_split) "
         "from every task), so a single global count is not expressible: the "
         "ceiling would be applied once per task. Pass the fraction directly, "
@@ -3050,7 +3050,7 @@ def optional_callable_error(value: Any, param: str, context: str) -> str | None:
     """
     if value is None or callable(value):
         return None
-    return f"{context}: {param} must be callable or None, got {_refusal_repr(value)}."
+    return f"{context}: {param} must be callable or None, got {refusal_repr(value)}."
 
 
 def boolean_flag_error(value: Any, param: str, context: str) -> str | None:
@@ -3105,7 +3105,7 @@ def boolean_flag_error(value: Any, param: str, context: str) -> str | None:
     if is_boolean(value):
         return None
     return (
-        f"{context}: {param} must be a boolean, got {_refusal_repr(value)}. "
+        f"{context}: {param} must be a boolean, got {refusal_repr(value)}. "
         "It selects a posture rather than scaling a quantity, so it is checked "
         "rather than parsed - a truthy spelling of off, such as 'false', would "
         "otherwise select the opposite posture from the one it reads as."

--- a/tests/test_container_refusals_render_elementwise.py
+++ b/tests/test_container_refusals_render_elementwise.py
@@ -1,7 +1,7 @@
 """A container guard must not raise while rendering the container it refuses (#1875).
 
 ``strands_robots.utils``' scalar guards were made total in two passes: #1873 gave
-them a rendering that cannot raise (``_refusal_repr`` / ``_refusal_str``), and
+them a rendering that cannot raise (``refusal_repr`` / ``refusal_str``), and
 #1874 gave them a *conversion* that cannot raise. Both passes deliberately
 stopped at the container guards - ``finite_vector_error``, ``pose_vector_error``,
 ``coerce_pose_vector``, ``coerce_rgba`` and ``name_list_error`` - and this module
@@ -10,7 +10,7 @@ is the pass that finishes them.
 Why a container could not simply reuse the scalar fallback
 ----------------------------------------------------------
 ``repr`` of a list recurses into its elements, so a container is unrenderable
-whenever any *one* of its elements is. Applying ``_refusal_repr`` to the whole
+whenever any *one* of its elements is. Applying ``refusal_repr`` to the whole
 container answers that with ``<unrepresentable list>``, which erases:
 
 * every element that rendered perfectly well, and
@@ -18,7 +18,7 @@ container answers that with ``<unrepresentable list>``, which erases:
   ``must be a 3-element vector, got 4``.
 
 So a container needs a *rendering* rather than a fallback:
-``_refusal_container_repr`` describes it component by component and substitutes
+``refusal_container_repr`` describes it component by component and substitutes
 only the components that cannot print, keeping the shape legible::
 
     raycast: 'origin' must contain finite numbers (no nan/inf), got
@@ -81,14 +81,14 @@ import pytest
 from strands_robots import utils
 from strands_robots.utils import (
     _describe_unrenderable,
-    _refusal_container_repr,
-    _refusal_repr,
     coerce_pose_vector,
     coerce_rgba,
     coerce_size_vector,
     finite_vector_error,
     name_list_error,
     pose_vector_error,
+    refusal_container_repr,
+    refusal_repr,
 )
 
 # --------------------------------------------------------------------------- #
@@ -189,7 +189,7 @@ class UniterableContainer:
 
     The floor of the rendering: with no ``repr`` and no elements to walk, the only
     honest answer left is the whole-value description, which is what
-    :func:`_refusal_repr` would have given.
+    :func:`refusal_repr` would have given.
 
     ``__iter__`` raises ``TypeError``, which is what "not iterable" means in
     Python and what every guard here already routes to a refusal. A ``__iter__``
@@ -456,7 +456,7 @@ class TestTheConversionEscapeIsClosedToo:
 # The renderer's own contract                                                 #
 # --------------------------------------------------------------------------- #
 class TestTheElementwiseRenderer:
-    """``_refusal_container_repr``: ``repr`` where it works, elementwise where it cannot."""
+    """``refusal_container_repr``: ``repr`` where it works, elementwise where it cannot."""
 
     @pytest.mark.parametrize(
         "value",
@@ -481,10 +481,10 @@ class TestTheElementwiseRenderer:
         trying the whole container first is not merely an optimisation - it is what
         keeps those containers reported in their own notation.
         """
-        assert _refusal_container_repr(value) == repr(value)
+        assert refusal_container_repr(value) == repr(value)
 
     def test_only_the_components_that_cannot_print_are_substituted(self) -> None:
-        assert _refusal_container_repr([1.0, UNRENDERABLE_INT, 3.0]) == f"[1.0, {UNRENDERABLE_INT_SHOWN}, 3.0]"
+        assert refusal_container_repr([1.0, UNRENDERABLE_INT, 3.0]) == f"[1.0, {UNRENDERABLE_INT_SHOWN}, 3.0]"
 
     def test_the_offending_component_is_located_by_position_not_by_an_index(self) -> None:
         """A decision #1875 asked to be settled, so it is stated rather than implied.
@@ -495,7 +495,7 @@ class TestTheElementwiseRenderer:
         disagree, and would not match the ``repr`` this stands in for. Position
         alone locates the component, so position is what is used.
         """
-        rendered = _refusal_container_repr([1.0, UNRENDERABLE_INT])
+        rendered = refusal_container_repr([1.0, UNRENDERABLE_INT])
         assert rendered == f"[1.0, {UNRENDERABLE_INT_SHOWN}]"
         assert "[0]" not in rendered and "[1]" not in rendered
 
@@ -512,7 +512,7 @@ class TestTheElementwiseRenderer:
         """
         values: list[Any] = [float(i) for i in range(50)]
         values[25] = UNRENDERABLE_INT
-        rendered = _refusal_container_repr(values)
+        rendered = refusal_container_repr(values)
         assert rendered.count(",") == 49
         assert rendered.startswith("[0.0, 1.0,") and rendered.endswith("49.0]")
         assert UNRENDERABLE_INT_SHOWN in rendered
@@ -523,7 +523,7 @@ class TestTheElementwiseRenderer:
         message = pose_vector_error("add_object", "position", [1.0, UNRENDERABLE_INT], 3)
         assert message is not None
         assert "must be a 3-element vector, got 2" in message
-        assert _refusal_container_repr([UNRENDERABLE_INT] * 4).count(UNRENDERABLE_INT_SHOWN) == 4
+        assert refusal_container_repr([UNRENDERABLE_INT] * 4).count(UNRENDERABLE_INT_SHOWN) == 4
 
     def test_a_mapping_is_rendered_as_a_mapping(self) -> None:
         """``name_list_error`` refuses a mapping *for* discarding its values.
@@ -531,20 +531,20 @@ class TestTheElementwiseRenderer:
         Rendering it as the list of its keys would perform, in the message, the
         very discarding the message is complaining about.
         """
-        rendered = _refusal_container_repr({UNRENDERABLE_INT: "camera"})
+        rendered = refusal_container_repr({UNRENDERABLE_INT: "camera"})
         assert rendered == f"{{{UNRENDERABLE_INT_SHOWN}: 'camera'}}"
 
     def test_an_unrenderable_value_inside_a_mapping_is_substituted_too(self) -> None:
-        assert _refusal_container_repr({"k": Unprintable()}) == "{'k': <unrepresentable Unprintable>}"
+        assert refusal_container_repr({"k": Unprintable()}) == "{'k': <unrepresentable Unprintable>}"
 
     def test_a_container_whose_own_repr_fails_still_reports_every_element(self) -> None:
-        assert _refusal_container_repr(UnprintableContainer([1.0, 2.0])) == "[1.0, 2.0]"
+        assert refusal_container_repr(UnprintableContainer([1.0, 2.0])) == "[1.0, 2.0]"
 
     def test_a_value_that_cannot_be_walked_falls_back_to_the_whole_value_description(self) -> None:
         """With no repr and no elements, the scalar answer is the only honest one."""
         value = UniterableContainer()
-        assert _refusal_container_repr(value) == _describe_unrenderable(value)
-        assert _refusal_container_repr(value) == "<unrepresentable UniterableContainer>"
+        assert refusal_container_repr(value) == _describe_unrenderable(value)
+        assert refusal_container_repr(value) == "<unrepresentable UniterableContainer>"
 
     def test_an_arbitrary_iteration_failure_is_recovered_too(self) -> None:
         """``TypeError`` is what "not iterable" means, but the renderer promises more.
@@ -552,7 +552,7 @@ class TestTheElementwiseRenderer:
         It runs on a path that must not raise, so it recovers any ``Exception`` from
         the walk rather than only the one a well-behaved type would raise.
         """
-        assert _refusal_container_repr(HostileIteration()) == "<unrepresentable HostileIteration>"
+        assert refusal_container_repr(HostileIteration()) == "<unrepresentable HostileIteration>"
 
     def test_a_mapping_whose_items_cannot_be_walked_is_described(self) -> None:
         class HostileMapping(dict):  # type: ignore[type-arg]
@@ -562,12 +562,12 @@ class TestTheElementwiseRenderer:
             def items(self) -> Any:
                 raise RuntimeError("no items for you")
 
-        assert _refusal_container_repr(HostileMapping()) == "<unrepresentable HostileMapping>"
+        assert refusal_container_repr(HostileMapping()) == "<unrepresentable HostileMapping>"
 
     def test_a_non_container_is_answered_as_the_scalar_renderer_would(self) -> None:
         """Every one of these guards accepts ``Any``, so a scalar reaches them."""
-        assert _refusal_container_repr(UNRENDERABLE_INT) == _refusal_repr(UNRENDERABLE_INT)
-        assert _refusal_container_repr(UNRENDERABLE_INT) == UNRENDERABLE_INT_SHOWN
+        assert refusal_container_repr(UNRENDERABLE_INT) == refusal_repr(UNRENDERABLE_INT)
+        assert refusal_container_repr(UNRENDERABLE_INT) == UNRENDERABLE_INT_SHOWN
 
     def test_the_rendering_is_one_level_deep(self) -> None:
         """A nested container is described, not recursed into, and that is deliberate.
@@ -583,7 +583,7 @@ class TestTheElementwiseRenderer:
         terminate. The whole-value description is the right answer for an inner
         element, because at that point the element *is* the value.
         """
-        assert _refusal_container_repr([[UNRENDERABLE_INT], 2.0]) == "[<unrepresentable list>, 2.0]"
+        assert refusal_container_repr([[UNRENDERABLE_INT], 2.0]) == "[<unrepresentable list>, 2.0]"
         assert finite_vector_error("m", "p", [[UNRENDERABLE_INT], 2.0]) == (
             "m: 'p' elements must be numbers, got [<unrepresentable list>, 2.0]"
         )
@@ -592,14 +592,14 @@ class TestTheElementwiseRenderer:
         """The fast path handles it, which is the other reason not to recurse."""
         cyclic: list[Any] = []
         cyclic.append(cyclic)
-        assert _refusal_container_repr(cyclic) == "[[...]]"
+        assert refusal_container_repr(cyclic) == "[[...]]"
 
     def test_it_does_not_swallow_a_base_exception(self) -> None:
         """``KeyboardInterrupt`` is not an error to recover from."""
         with pytest.raises(KeyboardInterrupt):
-            _refusal_container_repr([InterruptingRepr()])
+            refusal_container_repr([InterruptingRepr()])
         with pytest.raises(KeyboardInterrupt):
-            _refusal_container_repr({"k": InterruptingRepr()})
+            refusal_container_repr({"k": InterruptingRepr()})
 
 
 class TestTheWholeValueFallbackWouldHaveBeenWrong:
@@ -613,14 +613,14 @@ class TestTheWholeValueFallbackWouldHaveBeenWrong:
 
     def test_the_scalar_renderer_erases_the_elements_that_print(self) -> None:
         container = [1.0, UNRENDERABLE_INT, 3.0]
-        assert _refusal_repr(container) == "<unrepresentable list>"
-        assert "1.0" not in _refusal_repr(container)
-        assert "1.0" in _refusal_container_repr(container)
+        assert refusal_repr(container) == "<unrepresentable list>"
+        assert "1.0" not in refusal_repr(container)
+        assert "1.0" in refusal_container_repr(container)
 
     def test_the_scalar_renderer_erases_the_element_count(self) -> None:
         """And the count is frequently the entire reason for the refusal."""
-        assert _refusal_repr([UNRENDERABLE_INT] * 4) == _refusal_repr([UNRENDERABLE_INT])
-        assert _refusal_container_repr([UNRENDERABLE_INT] * 4) != _refusal_container_repr([UNRENDERABLE_INT])
+        assert refusal_repr([UNRENDERABLE_INT] * 4) == refusal_repr([UNRENDERABLE_INT])
+        assert refusal_container_repr([UNRENDERABLE_INT] * 4) != refusal_container_repr([UNRENDERABLE_INT])
 
     def test_no_guard_message_shows_the_whole_value_form_for_a_container(self) -> None:
         """The negative form, over every guard: none of them took the shortcut."""
@@ -839,7 +839,7 @@ class TestEveryContainerGuardRoutesThroughTheRenderer:
         called = self._calls(name)
         for helper in called & self.READ_HELPERS:
             called |= self._calls(helper)
-        assert "_refusal_container_repr" in called
+        assert "refusal_container_repr" in called
 
     @pytest.mark.parametrize("name", RENDERING_GUARDS)
     def test_the_guard_renders_no_parameter_directly(self, name: str) -> None:
@@ -989,7 +989,7 @@ class TestTheIterationIsAnsweredNotEscaped:
 
     def test_the_rendering_half_was_already_closed(self) -> None:
         """The renderer was never what left this open, and still is not."""
-        assert _refusal_container_repr(HostileIteration()) == "<unrepresentable HostileIteration>"
+        assert refusal_container_repr(HostileIteration()) == "<unrepresentable HostileIteration>"
 
 
 class LazySizedVector:

--- a/tests/test_refusal_messages_never_raise.py
+++ b/tests/test_refusal_messages_never_raise.py
@@ -59,7 +59,7 @@ Those two keep ``str`` rather than moving to ``repr``: NumPy 2 reprs a scalar
 with its type, so a documented-as-accepted ``np.float32`` fov would start
 reporting ``got np.float32(200.0)`` in text an agent reads.
 
-The fix routes all of them through ``_refusal_repr`` / ``_refusal_str``, which
+The fix routes all of them through ``refusal_repr`` / ``refusal_str``, which
 defer to ``repr`` / ``str`` wherever those work. So no verdict and no
 agent-visible text changes, which is what
 :class:`TestTheTextIsUnchangedForAValueThatCanBeRendered` pins.
@@ -101,8 +101,6 @@ import pytest
 import strands_robots.utils as utils
 from strands_robots.utils import (
     _describe_unrenderable,
-    _refusal_repr,
-    _refusal_str,
     camera_fov_error,
     entity_name_error,
     finite_number_error,
@@ -114,6 +112,8 @@ from strands_robots.utils import (
     positive_count_error,
     positive_finite_number_error,
     positive_whole_number_error,
+    refusal_repr,
+    refusal_str,
     tcp_port_error,
     validation_split_error,
 )
@@ -320,21 +320,21 @@ CONVERTING_IDS = tuple(g.name for g in CONVERTING_GUARDS)
 # The shared renderers                                                        #
 # --------------------------------------------------------------------------- #
 class TestTheSharedRenderers:
-    """``_refusal_repr`` / ``_refusal_str`` are the only ways a refused value is rendered."""
+    """``refusal_repr`` / ``refusal_str`` are the only ways a refused value is rendered."""
 
     def test_a_renderable_value_renders_exactly_as_repr(self) -> None:
         """The whole reason no message text changes: it defers wherever it can."""
         for value in (-1, -1.0, None, "3", [3], True, np.float32(-1.0), np.int64(-1), NAN):
-            assert _refusal_repr(value) == repr(value)
+            assert refusal_repr(value) == repr(value)
 
     def test_a_renderable_value_renders_exactly_as_str(self) -> None:
         for value in (-1, -1.0, None, "3", [3], True, np.float32(200.0), np.int64(200)):
-            assert _refusal_str(value) == str(value)
+            assert refusal_str(value) == str(value)
 
     def test_the_two_forms_are_not_interchangeable(self) -> None:
         """Why the ``str`` sites keep ``str``: NumPy 2 reprs a scalar with its type."""
-        assert _refusal_str(np.float32(200.0)) == "200.0"
-        assert _refusal_repr(np.float32(200.0)) == "np.float32(200.0)"
+        assert refusal_str(np.float32(200.0)) == "200.0"
+        assert refusal_repr(np.float32(200.0)) == "np.float32(200.0)"
 
     def test_an_outsized_integer_is_described_by_its_magnitude(self) -> None:
         """``int.bit_length`` needs no decimal conversion, so this stays possible."""
@@ -343,14 +343,14 @@ class TestTheSharedRenderers:
             repr(BEYOND_INT_STR_LIMIT)
         with pytest.raises(ValueError):
             str(BEYOND_INT_STR_LIMIT)
-        assert _refusal_repr(BEYOND_INT_STR_LIMIT) == expected
-        assert _refusal_str(BEYOND_INT_STR_LIMIT) == expected
+        assert refusal_repr(BEYOND_INT_STR_LIMIT) == expected
+        assert refusal_str(BEYOND_INT_STR_LIMIT) == expected
 
     def test_both_forms_describe_an_unrenderable_value_identically(self) -> None:
         """One describer, so the two render forms cannot disagree about one value."""
         for value in (BEYOND_INT_STR_LIMIT, Unprintable(), UnrenderableReal()):
-            assert _refusal_repr(value) == _describe_unrenderable(value)
-            assert _refusal_str(value) == _describe_unrenderable(value)
+            assert refusal_repr(value) == _describe_unrenderable(value)
+            assert refusal_str(value) == _describe_unrenderable(value)
 
     def test_the_description_of_an_outsized_integer_does_not_carry_its_sign(self) -> None:
         """A known limit of the description, pinned rather than left to be discovered.
@@ -367,10 +367,10 @@ class TestTheSharedRenderers:
         assert "must be a positive integer" in refusal
 
     def test_a_value_that_cannot_render_itself_is_described_by_its_type(self) -> None:
-        assert _refusal_repr(Unprintable()) == "<unrepresentable Unprintable>"
-        assert _refusal_repr(UnrenderableReal()) == "<unrepresentable UnrenderableReal>"
-        assert _refusal_str(UnrenderableFov()) == "<unrepresentable UnrenderableFov>"
-        assert _refusal_repr(UnrenderableName("arm")) == "<unrepresentable UnrenderableName>"
+        assert refusal_repr(Unprintable()) == "<unrepresentable Unprintable>"
+        assert refusal_repr(UnrenderableReal()) == "<unrepresentable UnrenderableReal>"
+        assert refusal_str(UnrenderableFov()) == "<unrepresentable UnrenderableFov>"
+        assert refusal_repr(UnrenderableName("arm")) == "<unrepresentable UnrenderableName>"
 
     def test_the_fallback_is_unconditional_rather_than_a_known_exception_list(self) -> None:
         """A third-party type may raise anything, so the guarantee cannot enumerate."""
@@ -383,18 +383,18 @@ class TestTheSharedRenderers:
             def __repr__(self) -> str:
                 raise KeyboardInterrupt
 
-        assert _refusal_repr(RaisesUnusual()) == "<unrepresentable RaisesUnusual>"
+        assert refusal_repr(RaisesUnusual()) == "<unrepresentable RaisesUnusual>"
         # ``except Exception`` does not cover a ``BaseException`` and must not:
         # swallowing a ``KeyboardInterrupt`` to render an error message would be a
         # worse failure than the one being reported. Pinned so the boundary is a
         # decision rather than an oversight.
         with pytest.raises(KeyboardInterrupt):
-            _refusal_repr(RaisesBaseException())
+            refusal_repr(RaisesBaseException())
 
     def test_every_rendering_is_ascii(self) -> None:
         for value in (-1, NAN, None, [3], BEYOND_INT_STR_LIMIT, Unprintable()):
-            _refusal_repr(value).encode("ascii")
-            _refusal_str(value).encode("ascii")
+            refusal_repr(value).encode("ascii")
+            refusal_str(value).encode("ascii")
 
 
 # --------------------------------------------------------------------------- #
@@ -644,7 +644,7 @@ class TestTheContainerGuardsAnswerAnUnrenderableElement:
     ``repr`` of a container recurses into its elements, so a container was
     unrenderable whenever any one element was, and these guards raised out of a
     refusal they had already decided. They now answer, through
-    ``_refusal_container_repr``: the container is rendered elementwise and only
+    ``refusal_container_repr``: the container is rendered elementwise and only
     the components that cannot print are substituted, so the shape and the
     element count - often the refusal's entire reason - survive.
 
@@ -700,7 +700,7 @@ def _scan_direct_renders(source: str) -> dict[str, tuple[tuple[str, str], ...]]:
         Every function that renders a caller value directly, mapped to
         ``(parameter, form)`` pairs where form is ``"!r"`` or ``"plain"``. A guard
         on the shared renderers contributes nothing, because
-        ``_refusal_repr(value)`` is a call rather than a bare name.
+        ``refusal_repr(value)`` is a call rather than a bare name.
     """
     tree = ast.parse(source)
     found: dict[str, tuple[tuple[str, str], ...]] = {}
@@ -721,12 +721,49 @@ def _scan_direct_renders(source: str) -> dict[str, tuple[tuple[str, str], ...]]:
     return found
 
 
-#: Empty, and that is the assertion: **no** function in ``utils.py`` renders a
-#: caller value directly any more. The five container guards that used to be
-#: listed here were #1875 and now route through ``_refusal_container_repr``, so
-#: the table has nothing left to hold. Any entry appearing here is a new guard
-#: that skipped the shared renderers.
-KNOWN_DIRECT_RENDERS: dict[str, tuple[tuple[str, str], ...]] = {}
+#: The guards that still render a caller value directly, keyed by the module they
+#: live in. The rule is stated over the **package**, not over ``utils.py``: the
+#: renderers were private to that module while the same guard shape was written
+#: in nineteen others, so a scan of one file reported an empty table while
+#: forty-three functions elsewhere interpolated the value straight into their text.
+#: Widening the population is what closed them, and it is why the renderers are
+#: package API rather than ``utils``-private helpers.
+#:
+#: The two left are in the Isaac backend, which an in-flight rewrite owns, so they
+#: are recorded rather than edited here. The relation asserted below is ``<=``
+#: rather than ``==`` for exactly that reason: a recorded guard that gets fixed -
+#: or whose file is deleted, as a third entry's was - must not fail this file.
+KNOWN_DIRECT_RENDERS: dict[str, dict[str, tuple[tuple[str, str], ...]]] = {
+    "simulation/isaac/config.py": {"_stage_path_error": (("value", "!r"), ("value", "plain"))},
+    "simulation/isaac/simulation.py": {"_mesh_path_error": (("mesh_path", "!r"),)},
+}
+
+#: The modules the package-wide scan must reach, so an empty result cannot be a
+#: scanner that stopped looking. Each held at least one guard that raised out of a
+#: refusal it had already decided; ``simulation/base.py`` held sixteen renders.
+REWRITTEN_MODULES = frozenset(
+    {
+        "drivers/base.py",
+        "hardware_robot.py",
+        "policies/kimodo/config.py",
+        "policies/wbc/config.py",
+        "rendering/compositor.py",
+        "rendering/video.py",
+        "ros_telemetry.py",
+        "simulation/base.py",
+        "simulation/ik.py",
+        "simulation/motion_primitives_base.py",
+        "simulation/mujoco/physics.py",
+        "simulation/mujoco/scene_ops.py",
+        "simulation/policy_runner.py",
+        "streaming_dataset.py",
+        "tools/lerobot_camera.py",
+        "tools/pose_tool.py",
+        "tools/serial_tool.py",
+        "training/_validate.py",
+        "utils.py",
+    }
+)
 
 #: The guards that render a *container*, which need the elementwise renderer
 #: rather than the whole-value one. Named so the scan below is shown to reach
@@ -783,9 +820,9 @@ GUARDED_READERS = frozenset(
         "_read_name_list",
         "_read_pose_vector",
         "_read_to_quote",
-        "_refusal_container_repr",
-        "_refusal_repr",
-        "_refusal_str",
+        "refusal_container_repr",
+        "refusal_repr",
+        "refusal_str",
         "sequence_length",
     }
 )
@@ -796,7 +833,7 @@ def _scan_unguarded_message_reads(source: str) -> dict[str, tuple[tuple[str, str
 
     The companion to :func:`_scan_direct_renders`, and the escape that scan is
     blind to. It reports a caller value *rendered* without a shared renderer,
-    which is why ``_refusal_container_repr(list(value))`` satisfied it: the value
+    which is why ``refusal_container_repr(list(value))`` satisfied it: the value
     reaching the renderer is a ``list`` the guard built, and building it ran the
     caller's ``__iter__``. So the render was guarded and the read feeding it was
     not, and the whole of #1903 lived in that gap - as did the four escapes on
@@ -810,10 +847,13 @@ def _scan_unguarded_message_reads(source: str) -> dict[str, tuple[tuple[str, str
     ordinary value - so a local bound from one is no longer the caller's object
     and reading it cannot run their code.
 
-    Only public functions are scanned. The private helpers below them are the
-    guarded layer a guard is built from, so a read inside one is the point rather
-    than a defect, and reporting them would make the table a list of the fixes
-    instead of a list of the escapes.
+    The guarded layer itself is not scanned: a read inside one of those is the
+    point rather than a defect, and reporting them would make the table a list of
+    the fixes instead of a list of the escapes. Membership is
+    :data:`GUARDED_READERS` plus the private helpers - named explicitly rather than
+    inferred from the leading underscore, because the shared renderers are package
+    API now that the contract is stated over the package, and a name is not what
+    makes one of them safe to read from.
 
     Args:
         source: The contents of a Python module.
@@ -826,7 +866,7 @@ def _scan_unguarded_message_reads(source: str) -> dict[str, tuple[tuple[str, str
     tree = ast.parse(source)
     found: dict[str, tuple[tuple[str, str], ...]] = {}
     for fn in [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef | ast.AsyncFunctionDef)]:
-        if fn.name.startswith("_"):
+        if fn.name.startswith("_") or fn.name in GUARDED_READERS:
             continue
         args = fn.args.posonlyargs + fn.args.args + fn.args.kwonlyargs
         tainted = {arg.arg for arg in args if arg.annotation is not None and ast.unparse(arg.annotation) == "Any"}
@@ -912,18 +952,71 @@ class TestNoGuardRendersACallerValueDirectly:
     """A guard must render a refused value through a shared renderer.
 
     A fixed list of guards would not survive a tenth being added, so this scans
-    the module instead: the assertion is over the whole file, and a new function
-    that renders a value it returns shows up as a new entry.
+    for them: the assertion is over every module in the package, and a new
+    function that renders a value it returns shows up as a new entry.
+
+    The population is the package because the guard shape is. ``utils.py`` is
+    where the rule was established, and the scan that established it read that one
+    file - so it reported an empty table while the same
+    ``(value: Any, param: str, context: str) -> str | None`` guard was written in
+    nineteen other modules, forty-three of them interpolating the value directly.
     """
 
     def _source(self) -> str:
+        """``utils.py``'s own text, for the assertions that are about that module."""
         return pathlib.Path(inspect.getfile(utils)).read_text(encoding="utf-8")
 
-    def test_no_scalar_guard_renders_a_caller_value_directly(self) -> None:
-        found = _scan_direct_renders(self._source())
-        adrift = {name: sites for name, sites in found.items() if name not in KNOWN_DIRECT_RENDERS}
+    def _package_sources(self) -> dict[str, str]:
+        """Every module in the installed package, keyed by its path within it."""
+        root = pathlib.Path(inspect.getfile(utils)).parent
+        return {str(f.relative_to(root)): f.read_text(encoding="utf-8") for f in sorted(root.rglob("*.py"))}
+
+    def test_no_guard_in_the_package_renders_a_caller_value_directly(self) -> None:
+        found = {
+            module: sites
+            for module, source in self._package_sources().items()
+            if (sites := _scan_direct_renders(source))
+        }
+        adrift = {
+            module: {name: at for name, at in sites.items() if name not in KNOWN_DIRECT_RENDERS.get(module, {})}
+            for module, sites in found.items()
+        }
+        adrift = {module: sites for module, sites in adrift.items() if sites}
         assert adrift == {}, f"these render a caller value without a shared renderer: {adrift}"
-        assert found == KNOWN_DIRECT_RENDERS, f"the set of direct renders changed: {found}"
+
+    def test_the_recorded_guards_are_a_subset_of_what_was_recorded(self) -> None:
+        """``<=`` rather than ``==``: fixing a recorded guard must not fail here.
+
+        The three recorded modules are being rewritten elsewhere, so the table is a
+        record of what was deferred rather than a count to keep matching. What may
+        not happen is a *new* module appearing, which is the assertion above.
+        """
+        found = {
+            module: sites
+            for module, source in self._package_sources().items()
+            if (sites := _scan_direct_renders(source))
+        }
+        assert set(found) <= set(KNOWN_DIRECT_RENDERS), (
+            f"a new module renders directly: {set(found) - set(KNOWN_DIRECT_RENDERS)}"
+        )
+
+    def test_the_package_scan_reaches_the_modules_it_is_asserted_over(self) -> None:
+        """An empty result and a scanner reading nothing are the same table.
+
+        A relative path resolved from the wrong working directory globs nothing and
+        passes this file vacuously, so the module count is asserted too.
+        """
+        sources = self._package_sources()
+        assert len(sources) > 100, f"the package scan read only {len(sources)} modules"
+        missing = REWRITTEN_MODULES - set(sources)
+        assert missing == set(), f"the scan never reached: {missing}"
+        for module in sorted(REWRITTEN_MODULES):
+            planted = sources[module] + _PLANTED_DIRECT_RENDER
+            assert "new_guard_error" in _scan_direct_renders(planted), f"the scan does not reach into {module}"
+
+    def test_no_scalar_guard_renders_a_caller_value_directly(self) -> None:
+        """The original statement, still made about ``utils.py`` on its own."""
+        assert _scan_direct_renders(self._source()) == {}
 
     def test_the_scan_actually_reaches_the_guards_this_change_owns(self) -> None:
         """An empty scan would satisfy the assertion above just as well."""
@@ -956,7 +1049,7 @@ class TestNoGuardRendersACallerValueDirectly:
         tree = ast.parse(self._source())
         defined = {n.name: n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef)}
         owned = set(GUARD_IDS) | CONTAINER_GUARDS | {"validation_split_error"}
-        renderers = {"_refusal_repr", "_refusal_str", "_refusal_container_repr"}
+        renderers = {"refusal_repr", "refusal_str", "refusal_container_repr"}
         for name in sorted(owned & set(defined)):
             reached: set[str] = set()
             pending = [name]
@@ -1005,7 +1098,7 @@ class TestNoGuardRendersACallerValueDirectly:
             """
             def new_guard_error(value: Any, param: str, context: str) -> str | None:
                 if value < 0:
-                    return f"{context}: {param} must be positive, got {_refusal_repr(value)}."
+                    return f"{context}: {param} must be positive, got {refusal_repr(value)}."
                 return None
             """
         )
@@ -1039,7 +1132,7 @@ class TestNoGuardReadsACallerValueOutsideATry:
     ``TestNoGuardRendersACallerValueDirectly`` above holds the *rendering* of a
     refused value, and that is not the same property. Its table is empty because
     every guard renders through a shared renderer - and
-    ``_refusal_container_repr(list(value))`` satisfied it completely, because the
+    ``refusal_container_repr(list(value))`` satisfied it completely, because the
     value handed to the renderer was a ``list`` the guard had already built. The
     render could not raise; building its argument ran the caller's ``__iter__``,
     which could.
@@ -1074,7 +1167,7 @@ class TestNoGuardReadsACallerValueOutsideATry:
                 """
                 def new_guard_error(value: Any, param: str, context: str) -> str | None:
                     if isinstance(value, Mapping):
-                        return f"{param} must be a list: {_refusal_container_repr(list(value))}."
+                        return f"{param} must be a list: {refusal_container_repr(list(value))}."
                     return None
                 """
             )
@@ -1093,7 +1186,7 @@ class TestNoGuardReadsACallerValueOutsideATry:
                     shown = value.decode(errors="replace") if isinstance(value, bytes) else value
                     return (
                         f"{param}: read as {[c for c in shown][:6]} ({len(shown)} name(s)). "
-                        f"Wrap it in a list: [{_refusal_repr(shown)}]."
+                        f"Wrap it in a list: [{refusal_repr(shown)}]."
                     )
                 """
             )
@@ -1116,7 +1209,7 @@ class TestNoGuardReadsACallerValueOutsideATry:
                             names = list(value)
                         except Exception:
                             return f"{param}: could not be read."
-                        return f"{param} must be a list: {_refusal_container_repr(names)}."
+                        return f"{param} must be a list: {refusal_container_repr(names)}."
                     """
                 )
             )
@@ -1473,6 +1566,17 @@ class TestTheCoercionsCountTheComponentsTheyRead:
         assert len(nothing) == 3
         assert list(nothing) == []
 
+
+#: A guard that renders the caller's value straight into its message, appended to
+#: each module the package-wide scan is asserted over, so the scan is shown to
+#: reach into every one of them rather than into the first.
+_PLANTED_DIRECT_RENDER = textwrap.dedent(
+    """
+
+def new_guard_error(value: Any, param: str, context: str) -> str | None:
+    return f"{context}: {param} is out of range, got {value!r}."
+"""
+)
 
 #: A guard that reads the caller's value straight into its message, appended to
 #: ``utils.py``'s own source so the scan is shown to reach a function it has never

--- a/tests/test_refusals_outside_utils_answer_a_value_they_cannot_render.py
+++ b/tests/test_refusals_outside_utils_answer_a_value_they_cannot_render.py
@@ -1,0 +1,337 @@
+"""Every guard in the package answers a value it cannot render, not only ``utils``'.
+
+``strands_robots.utils`` established the rule: a guard's whole purpose is to
+report a caller's bad value through a returned ``{status, content}`` result or a
+refusal string, so building that answer must not raise. Rendering a value can
+raise - ``repr`` of an ``int`` wider than :func:`sys.get_int_max_str_digits`
+raises ``ValueError``, and :class:`numbers.Real` is a registration rather than an
+inheritance, so a scalar that satisfies a guard's type test owes it nothing else.
+:func:`~strands_robots.utils.refusal_repr` and its two siblings exist for that,
+and ``tests/test_refusal_messages_never_raise.py`` pins them.
+
+That scan read one file, and the same guard shape - a value annotated ``Any``
+beside the ``str`` labels its call site supplies - is written in nineteen other
+modules. Measured on ``4e73dc0f``, forty-three functions across twenty modules
+interpolated the caller's value straight into their text, and **twenty-one of them
+raised** when called with a value they had already decided to refuse:
+
+| module | guards | raised |
+| --- | --- | --- |
+| ``simulation/base.py`` | 8 | 5 |
+| ``simulation/mujoco/physics.py`` | 3 | 3 |
+| ``rendering/compositor.py`` | 5 | 5 |
+| ``rendering/video.py`` | 4 | 3 |
+| ``simulation/motion_primitives_base.py`` | 3 | 0 |
+| ``tools/serial_tool.py`` | 3 | 2 |
+| ... 14 more | 17 | 3 |
+
+The other twenty-two offend the rule without this probe reaching them: they lead
+with a ``utils`` guard, so a value refused on its *type* is answered by the shared
+renderer before their own range branch renders anything. Their own branch is
+reached by a value that passes the delegate and fails the range - which is
+:class:`TestAStdlibFractionReachesTheRangeBranch`, and needs no third-party type
+at all.
+
+The structural half of this - that no guard in the package renders a caller value
+directly - is stated over the package in
+``tests/test_refusal_messages_never_raise.py``. What is pinned here is the
+behaviour that rule is for: each module answers.
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Callable
+from fractions import Fraction
+from typing import Any, NamedTuple, cast
+
+import pytest
+
+from strands_robots import hardware_robot, ros_telemetry, streaming_dataset
+from strands_robots.drivers import base as drivers_base
+from strands_robots.policies.kimodo import config as kimodo_config
+from strands_robots.policies.wbc import config as wbc_config
+from strands_robots.rendering import compositor, video
+from strands_robots.simulation import base as sim_base
+from strands_robots.simulation import ik, motion_primitives_base, policy_runner
+from strands_robots.simulation.mujoco import physics, scene_ops
+from strands_robots.training import _validate
+
+# ``strands_robots.tools.__init__`` binds each tool module's name to the
+# ``@tool``-decorated callable it exports, so ``from ... import serial_tool``
+# yields the tool rather than the module these guards live in.
+lerobot_camera = importlib.import_module("strands_robots.tools.lerobot_camera")
+pose_tool = importlib.import_module("strands_robots.tools.pose_tool")
+serial_tool = importlib.import_module("strands_robots.tools.serial_tool")
+
+
+class UnrenderableText(str):
+    """A ``str`` subclass whose ``repr`` raises.
+
+    The probe for a guard whose render sits behind a ``str`` test - refusing a
+    string *for being* a string, because it would be consumed one character per
+    entry. A ``str`` subclass passes that test, so "a ``str``'s ``repr`` cannot
+    raise" is true of ``str`` and not of the branch guarding it. It also carries a
+    value, so it satisfies a membership test against a set of refused spellings.
+    """
+
+    def __repr__(self) -> str:
+        raise RuntimeError("this text cannot render itself")
+
+
+class _Driver:
+    """The minimum a verb refusal reads: a tool spec declaring one verb."""
+
+    tool_spec = {"name": "fake_driver", "inputSchema": {"json": {"properties": {"action": {"enum": ["wave"]}}}}}
+
+
+class Unprintable:
+    """A plain object whose ``repr`` raises.
+
+    Refused by every guard below on type alone, so it reaches each one's message
+    without depending on that guard's domain. The reason the guarantee is
+    unconditional rather than a list of the exceptions known today: a third-party
+    type may raise anything at all from its own ``__repr__``.
+    """
+
+    def __repr__(self) -> str:
+        raise RuntimeError("this type cannot render itself")
+
+
+#: A ``Fraction`` that does not reduce, because consecutive integers are coprime.
+#: ``float()`` of it is ``-1.0`` - finite, inside the float64 range and a
+#: ``numbers.Real`` - so it passes the ``utils`` guard a range check leads with,
+#: and reaches the range branch. Its ``repr`` renders two 5001-digit integers,
+#: which is past :func:`sys.get_int_max_str_digits`, so it raises ``ValueError``.
+#: Stdlib only: no registered type and no hostile ``__repr__``.
+UNRENDERABLE_FRACTION = Fraction(-(10**5000), 10**5000 + 1)
+
+
+class Guard(NamedTuple):
+    """One guard outside ``utils``, with everything needed to probe it.
+
+    Attributes:
+        module: Its module path within the package, which is the test ID.
+        call: The guard with its label arguments already bound, so a probe can be
+            sent to the position that carries the caller's value.
+        probe: The value to send. Usually :class:`Unprintable`, refused on type by
+            every guard that leads with one; :class:`UnrenderableText` for the
+            three whose render sits behind a ``str`` test, which turns that one
+            away before it reaches any text.
+        shows: What the answer must say about the value it could not render. A
+            container guard renders elementwise, so a refused string is reported as
+            its characters - which is the refusal's own reason - rather than as one
+            opaque description.
+    """
+
+    module: str
+    call: Callable[[Any], Any]
+    probe: Any
+    shows: str
+
+
+def _text(answer: Any) -> str:
+    """The refusal text, whether the guard returns a string or an envelope.
+
+    These guards answer in three shapes - a refusal string the caller wraps, a
+    ``{status, content}`` envelope already wrapped, or a ``(value, error)`` pair
+    from a coercion - and the property pinned is the same for all three, so it is
+    read out of any of them rather than split into three tables.
+    """
+    assert answer is not None, "an unrenderable value is not a usable one"
+    if isinstance(answer, tuple):
+        assert answer[0] in (None, 0), f"an unrenderable value was coerced to {answer[0]!r}"
+        answer = answer[1]
+        assert answer is not None, "a coercion refused without saying why"
+    if isinstance(answer, str):
+        return answer
+    assert answer["status"] == "error", answer
+    return " ".join(block["text"] for block in answer["content"])
+
+
+OPAQUE = "<unrepresentable Unprintable>"
+
+GUARDS: tuple[Guard, ...] = (
+    Guard(
+        "drivers/base.py",
+        lambda v: drivers_base.undeclared_verb_error(_Driver(), v),
+        Unprintable(),
+        OPAQUE,
+    ),
+    Guard(
+        "hardware_robot.py",
+        lambda v: hardware_robot.Robot._policy_port_error(v, "start_task", "mock"),
+        Unprintable(),
+        OPAQUE,
+    ),
+    Guard(
+        "policies/kimodo/config.py",
+        lambda v: kimodo_config.sampling_seed_error(v, "KimodoConfig"),
+        Unprintable(),
+        OPAQUE,
+    ),
+    Guard(
+        "policies/wbc/config.py",
+        lambda v: wbc_config._non_negative_number_error(v, "gain", "WbcConfig"),
+        Unprintable(),
+        OPAQUE,
+    ),
+    Guard("rendering/compositor.py", lambda v: compositor._depth_epsilon_error(v), Unprintable(), OPAQUE),
+    Guard("rendering/video.py", lambda v: video._stream_rate_error(v), Unprintable(), OPAQUE),
+    Guard(
+        "ros_telemetry.py",
+        lambda v: ros_telemetry._qos_history_depth_error(v, "depth", "QoS"),
+        Unprintable(),
+        OPAQUE,
+    ),
+    Guard(
+        "simulation/base.py",
+        lambda v: sim_base.finite_non_negative_error(v, "mass", "set_mass"),
+        Unprintable(),
+        OPAQUE,
+    ),
+    Guard("simulation/ik.py", lambda v: ik._damping_error(v, "solve_ik"), Unprintable(), OPAQUE),
+    Guard(
+        "simulation/motion_primitives_base.py",
+        # Called unbound: this guard refuses ``state`` before it reads ``self``,
+        # so probing it needs no live simulation - and a probe that needed one
+        # would be measuring the backend rather than the refusal.
+        lambda v: cast(Any, motion_primitives_base.MotionPrimitivesCore._validate_set_gripper_args)(None, v, 1),
+        Unprintable(),
+        OPAQUE,
+    ),
+    Guard(
+        "simulation/mujoco/physics.py",
+        lambda v: physics._coerce_excluded_body(v, "raycast", 8),
+        Unprintable(),
+        OPAQUE,
+    ),
+    Guard(
+        "simulation/mujoco/scene_ops.py",
+        lambda v: scene_ops._geom_shape_error(v),
+        UnrenderableText("mesh"),
+        "<unrepresentable UnrenderableText>",
+    ),
+    Guard(
+        "simulation/policy_runner.py",
+        lambda v: policy_runner._validate_action_key_map(v),
+        UnrenderableText("ab"),
+        "['a', 'b']",
+    ),
+    Guard("streaming_dataset.py", lambda v: streaming_dataset._tolerance_error(v), Unprintable(), OPAQUE),
+    Guard(
+        "tools/lerobot_camera.py",
+        lambda v: lerobot_camera._camera_ids_error(v),
+        UnrenderableText("ab"),
+        "['a', 'b']",
+    ),
+    Guard(
+        "tools/pose_tool.py",
+        lambda v: pose_tool._joint_target_error("wave", "target", "elbow", v),
+        Unprintable(),
+        OPAQUE,
+    ),
+    Guard("tools/serial_tool.py", lambda v: serial_tool._motor_id_error(v, "motor_id", "read"), Unprintable(), OPAQUE),
+    Guard(
+        "training/_validate.py",
+        lambda v: _validate._closed_unit_interval_error(v, "gamma", "train"),
+        Unprintable(),
+        OPAQUE,
+    ),
+)
+
+GUARD_IDS = tuple(guard.module for guard in GUARDS)
+
+
+class TestEveryModuleAnswersAValueItCannotRender:
+    """One guard per rewritten module, called with a value it refuses on type.
+
+    Every row raises the probe's own ``RuntimeError`` on pre-fix code, in place of
+    the answer the guard had already decided to return.
+    """
+
+    @pytest.mark.parametrize("guard", GUARDS, ids=GUARD_IDS)
+    def test_an_unrenderable_value_is_answered(self, guard: Guard) -> None:
+        text = _text(guard.call(guard.probe))
+        assert guard.shows in text, "the answer must say what it could not render"
+        text.encode("ascii")
+
+    def test_every_module_that_was_rewritten_has_a_row(self) -> None:
+        """The table is the module list, so a module cannot be dropped silently."""
+        from tests.test_refusal_messages_never_raise import REWRITTEN_MODULES
+
+        assert {guard.module for guard in GUARDS} == REWRITTEN_MODULES - {"utils.py"}
+
+    def test_the_probes_still_refuse_to_render_themselves(self) -> None:
+        """Non-vacuity: a probe that had started rendering would pass every row."""
+        with pytest.raises(RuntimeError, match="cannot render itself"):
+            repr(Unprintable())
+        with pytest.raises(RuntimeError, match="cannot render itself"):
+            repr(UnrenderableText("mesh"))
+        assert UnrenderableText("mesh") == "mesh", "the text probe must still carry its value"
+
+
+class TestAStdlibFractionReachesTheRangeBranch:
+    """The other half of the family: a guard that delegates, then checks a range.
+
+    These lead with a ``utils`` guard, so a value refused on its *type* never
+    reaches their own text and the probe above passes them unchanged. Their own
+    branch is reached by a value the delegate **accepts** - finite, real, inside the
+    float64 range - and the range then refuses. ``Fraction`` is stdlib, so this
+    needs no registered type and no hostile ``__repr__``: the escape is reachable
+    with two integer literals.
+    """
+
+    def test_a_fraction_outside_the_closed_unit_is_answered(self) -> None:
+        answer = _validate._closed_unit_interval_error(UNRENDERABLE_FRACTION, "gamma", "train")
+        assert answer == "train: gamma must be in [0, 1], got <unrepresentable Fraction>."
+
+    def test_a_fraction_outside_the_half_open_unit_is_answered(self) -> None:
+        answer = _validate._half_open_unit_interval_error(UNRENDERABLE_FRACTION, "tau", "train")
+        assert answer == "train: tau must be in (0, 1], got <unrepresentable Fraction>."
+
+    def test_the_delegate_accepts_the_probe_so_the_range_branch_is_what_answers(self) -> None:
+        """The reason this probe reaches a branch ``Unprintable`` cannot.
+
+        Without this the two rows above would also pass if the delegate had started
+        refusing it - a different branch answering, and the range branch still
+        unreached.
+        """
+        from strands_robots.utils import finite_number_error
+
+        assert finite_number_error(UNRENDERABLE_FRACTION, "gamma", "train") is None
+        assert float(UNRENDERABLE_FRACTION) == -1.0
+
+    def test_the_probe_is_stdlib_and_cannot_render_itself(self) -> None:
+        """Non-vacuity, and the claim that no third-party type is needed."""
+        assert type(UNRENDERABLE_FRACTION) is Fraction
+        with pytest.raises(ValueError, match="Exceeds the limit"):
+            repr(UNRENDERABLE_FRACTION)
+
+
+class TestTheComponentsThatRenderAreNotErasedWithTheOneThatCannot:
+    """A container guard needs a rendering, not a whole-value fallback.
+
+    ``repr`` of a list recurses into its elements, so a container is unrenderable
+    whenever any *one* element is, and answering that with
+    ``<unrepresentable list>`` erases every element that printed fine - along with
+    the element count, which is frequently the refusal's entire reason. The
+    container guards outside ``utils`` route through ``refusal_container_repr`` for
+    that reason, and this is the property that distinguishes it from the scalar
+    renderer.
+    """
+
+    def test_a_randomization_range_keeps_the_bound_that_renders(self) -> None:
+        answer = sim_base.randomization_range_error([0.5, Unprintable()], "mass_range")
+        assert answer is not None
+        assert "[0.5, <unrepresentable Unprintable>]" in answer
+
+    def test_a_ray_batch_keeps_the_directions_that_render(self) -> None:
+        _, error = physics._coerce_finite_vector([1.0, Unprintable(), 3.0], "origin", "raycast")
+        assert "[1.0, <unrepresentable Unprintable>, 3.0]" in _text((None, error))
+
+    def test_a_frame_size_keeps_the_dimensions_that_render(self) -> None:
+        """Three components is the refusal, so the count must survive the rendering."""
+        answer = video._frame_size_error([1.0, Unprintable(), 3.0])
+        assert answer is not None
+        assert "[1.0, <unrepresentable Unprintable>, 3.0]" in answer


### PR DESCRIPTION
![measured](https://raw.githubusercontent.com/cagataycali/robots/assets/refusal-rendering-package-wide-34433696331/docs/assets/refusal-rendering-package-wide.png)

## The rule was right; its population was one file

`utils.py` pins that a guard must not raise while building a refusal — a guard exists so a bad value is reported through a returned result instead of an exception, and rendering a value can fail. `refusal_repr` / `refusal_str` / `refusal_container_repr` exist for that, and `tests/test_refusal_messages_never_raise.py` pins them. **That scan read `inspect.getfile(utils)` — one file** — so it reported an empty table while the same guard shape (`value: Any` beside the `str` labels the call site supplies) was written in nineteen other modules.

On `4e73dc0f`: **43 guards across 20 modules interpolated the caller's value directly, and 21 of them raised** on a value they had already decided to refuse.

## Reachable with stdlib only

The 22 that do not raise on a type probe lead with a `utils` guard, so their *own* range branch is reached by a value the delegate **accepts**. `Fraction` is stdlib — consecutive integers are coprime, so this does not reduce, `float()` is `-1.0` (finite, in range, a `numbers.Real`), and its `repr` renders two 5001-digit integers:

```python
>>> _closed_unit_interval_error(Fraction(-10**5000, 10**5000 + 1), "gamma", "train")
ValueError: Exceeds the limit (4300 digits) for integer string conversion
#   File ".../lib/python3.13/fractions.py", line 425, in __repr__
```

The traceback terminates inside CPython's own `fractions.py`. No registered type, no hostile `__repr__` — two integer literals.

| module | guards | raised |
|---|--:|--:|
| `simulation/base.py` | 8 | 5 |
| `rendering/compositor.py` | 5 | 5 |
| `rendering/video.py` | 4 | 3 |
| `simulation/mujoco/physics.py` | 3 | 3 |
| `tools/serial_tool.py` | 3 | 2 |
| `simulation/motion_primitives_base.py` | 3 | 0 |
| 14 more | 17 | 3 |
| **total** | **43** | **21** |

## Change

All 58 render sites in 18 modules go through a shared renderer, which defers to `repr`/`str` wherever those work — so **no verdict and no existing message text changes**. Chosen per site: `refusal_container_repr` where the value is a container (a `(lo, hi)` range, a ray batch, a `(width, height)` pair), since a whole-value fallback would erase the elements that print fine along with the element count that is often the refusal's entire reason.

The three renderers become package API rather than `utils`-private, because the contract they serve is stated over the package. Renamed in place, no aliases. That also corrected the read-side scan's population predicate, which used "starts with `_`" as its proxy for "is the guarded layer"; it now names `GUARDED_READERS` explicitly, since a name is not what makes a reader safe to read from.

Two guards in `simulation/isaac/*` are recorded rather than edited, because #3343 owns those files. The table's relation is `<=`, not `==`, so a recorded guard being fixed cannot fail this file — which already paid off: a third recorded entry (`policies/lerobot_local/norm_stats.py`) had its file deleted by #3411 during this work and needed no edit.

## Verification

**Pre-fix (this main + the two test files only, guards pristine): 17 failed / 115 passed.** 10 module rows and 3 container rows raise the probe's own `RuntimeError`; 2 raise `ValueError` from the stdlib `Fraction`; 2 are the structural scan.

Mutants, to show the pins are load-bearing:

| mutant | failed |
|---|--:|
| shipped (control) | **0** / 132 passed |
| revert `simulation/base.py` alone | 4 |
| `refusal_repr` stops deferring to `repr` | 67 |
| container renderer → scalar in `base.py` | 1 |
| scan root resolved relatively, run from `/tmp` | 1 (the `>100`-module floor catches the vacuous scan) |
| restored | **0** / 132 passed |

**Over-reach control** (bottom of the figure): `simulation/base.py` takes 16 of the edits and `mujoco/physics.py` 7, so an 80-step scripted `so101` rollout was run in both trees, headless `egl`, each asserting its own `strands_robots.__file__`. Joint trace **bitwise identical** (max |difference| 0.0 over 80x6 samples); rendered frame **0 of 172,800 pixels differ**, identical md5.

Full suite on this branch: **50,913 passed / 307 skipped / 0 failed** (30m14s). `ruff check` + `ruff format --check` clean; `mypy strands_robots tests` 0 errors.

## LOC

+758 / -213 (net +545): `strands_robots/` +210/-132, `tests/` +522/-81, changelog +26. The source line delta is almost entirely import statements being reformatted from one line to parenthesized — **executable statements in `strands_robots/` go 8059 → 8060 (+1)**, the single new import in `drivers/base.py`. The additions are the regression pin, which is the point of the change.
