### PR TITLE
fix(policies/lerobot_local): override stats of the wrong width are refused where both widths are known

### DIFF
--- a/changelog.d/3422-normalization-stats-width.md
+++ b/changelog.d/3422-normalization-stats-width.md
@@ -1,0 +1,34 @@
+### Fixed: `lerobot_local` refuses override stats of the wrong width where both widths are known
+
+`ProcessorBridge.inert_normalization_features` reports stats that are ABSENT,
+which LeRobot answers by returning the tensor unchanged. Stats that are PRESENT
+at the wrong width are the opposite failure: LeRobot reaches the arithmetic and
+raises `RuntimeError: The size of tensor a (6) must match the size of tensor b
+(7) at non-singleton dimension 0` from the broadcast, naming neither the
+feature, the step, nor either width -- and it raises on the first inference,
+after a rollout has started and the robot has been commanded. `create_policy`
+returned a policy whose `inert_normalization_features()` was `[]`, so nothing
+reported a problem until the arm was already moving.
+
+Both widths are known when the policy loads, on the same step object: the
+step's `features` declares `observation.state (6,)` while its `_tensor_stats`
+holds `(7,)`. A new `mismatched_normalization_widths` reads that pair and the
+load refuses, naming each affected feature, the declared width and the
+supplied width. Supplying stats is exactly what the inert-pipeline diagnostic
+tells a caller to do, and width is what differs between embodiments -- a 6-DOF
+SO-101, a 7-DOF arm and a 14-DOF bimanual all declare `observation.state` and
+`action` -- so reaching for the wrong dataset's stats is a routine mistake.
+
+The scoping rule that decides which declared normalization a transition
+actually exercises (the preprocessor transition carries only the observation,
+the postprocessor only the action, so only the feature type matching a
+pipeline's position is ever touched) was owned by the inert detector. It is now
+spelled once in `_declared_normalization_targets` and read by both checks, so
+the two cannot disagree about which normalization a rollout performs -- a
+preprocessor's `action` entry is never exercised at inference and is therefore
+flagged by neither.
+
+VISUAL features are exempt. LeRobot reshapes a flat `(C,)` visual stat to
+`(C, 1, 1)` in `_reshape_visual_stats` on purpose, so a channel-wide stat is
+correct for a `(C, H, W)` feature and comparing it to the flattened feature
+width would refuse a working checkpoint.

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -358,6 +358,26 @@ Naming only one leaves the other inert, and the diagnostic keeps reporting
 whichever half is still unnormalized. Fine-tuning the checkpoint writes stats
 under the canonical keys and needs no override at all.
 
+Supplied stats have to be as WIDE as the features the checkpoint declares. Width
+is what differs between embodiments -- a 6-DOF SO-101, a 7-DOF arm and a 14-DOF
+bimanual all have `observation.state` and `action` -- so reaching for the wrong
+dataset's stats is easy. A mismatch is refused when the policy loads, naming the
+feature and both widths:
+
+```
+ValueError: lerobot_local: lerobot/smolvla_base was given normalization stats
+that do not match the widths the checkpoint declares: ["observation.state
+(STATE/MEAN_STD): feature declares width 6, stats 'observation.state.mean'
+supply 7", ...]
+```
+
+LeRobot itself would reach the arithmetic and raise from the tensor broadcast
+(`The size of tensor a (6) must match the size of tensor b (7)`) on the FIRST
+inference instead -- naming neither the feature nor either width, and only after
+a rollout has started and the robot has been commanded. Visual stats are exempt:
+LeRobot reshapes a flat `(C,)` channel stat to `(C, 1, 1)`, so a 3-wide stat is
+correct for a `(3, H, W)` image feature.
+
 ## State routing
 
 `observation.state` is composed from `robot_state_keys` (set explicitly with

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -1184,6 +1184,20 @@ class LerobotLocalPolicy(Policy):
         # misleading "no policy_postprocessor.json" message for that case.
         if self.use_processor and not self._embodiment_config_failed:
             bridge = self._processor_bridge
+            # Stats present at the wrong width raise from inside LeRobot's
+            # broadcast on the FIRST inference - after the rollout started and
+            # the robot was commanded - naming neither the feature nor either
+            # width. Both widths are known here, so refuse now and name them.
+            mismatched = [] if bridge is None else bridge.mismatched_normalization_widths()
+            if mismatched:
+                raise ValueError(
+                    f"lerobot_local: {self.pretrained_name_or_path or '<model>'} was given "
+                    f"normalization stats that do not match the widths the checkpoint "
+                    f"declares: {mismatched}. LeRobot would raise from the tensor broadcast "
+                    f"on the first inference instead. Supply stats whose width matches the "
+                    f"checkpoint's declared features (they are usually the stats of the "
+                    f"dataset this checkpoint was trained on, for the same robot)."
+                )
             if bridge is None or not bridge.has_postprocessor:
                 logger.warning(
                     "lerobot_local: %s loaded WITHOUT an action postprocessor "

--- a/strands_robots/policies/lerobot_local/processor.py
+++ b/strands_robots/policies/lerobot_local/processor.py
@@ -239,6 +239,19 @@ def _register_policy_processor_steps(policy_type: str | None) -> None:
             logger.debug("Could not import %s for processor-step registration: %s", mod, exc)
 
 
+# The per-dimension stats each NormalizationMode's arithmetic reads
+# (lerobot HEAD: processor/normalize_processor.py). A dataset's stats also
+# carry per-feature scalars such as ``count`` (shape (1,)), which never meet
+# the feature tensor, so they are not a width mismatch.
+_STAT_NAMES_READ_BY_MODE: dict[str, tuple[str, ...]] = {
+    "MEAN_STD": ("mean", "std"),
+    "MIN_MAX": ("min", "max"),
+    "QUANTILES": ("q01", "q99"),
+    "QUANTILE10": ("q10", "q90"),
+}
+_STAT_NAMES_READ_BY_ANY_MODE: tuple[str, ...] = ("mean", "std", "min", "max", "q01", "q99", "q10", "q90")
+
+
 class ProcessorBridge:
     """Bridge between strands-robots observation/action format and LeRobot's processor pipeline.
 
@@ -926,7 +939,10 @@ class ProcessorBridge:
                 continue
             lookup = ACTION if ftype == FeatureType.ACTION else key
             stats = (getattr(step, "_tensor_stats", None) or {}).get(lookup) or {}
-            for stat_name, value in stats.items():
+            for stat_name in _STAT_NAMES_READ_BY_MODE.get(mode.value, _STAT_NAMES_READ_BY_ANY_MODE):
+                value = stats.get(stat_name)
+                if value is None:
+                    continue
                 width = tuple(getattr(value, "shape", None) or ())
                 if len(width) == 1 and width[0] != shape[0]:
                     descriptor = (

--- a/strands_robots/policies/lerobot_local/processor.py
+++ b/strands_robots/policies/lerobot_local/processor.py
@@ -813,12 +813,45 @@ class ProcessorBridge:
         canonical ``action`` / ``observation.state`` keys.
         """
         try:
-            from lerobot.configs.types import FeatureType, NormalizationMode
+            from lerobot.configs.types import FeatureType
             from lerobot.utils.constants import ACTION
         except ImportError:
             return []
 
         inert: list[str] = []
+        for _step, key, _feature, ftype, mode, stat_keys in self._declared_normalization_targets():
+            lookup = ACTION if ftype == FeatureType.ACTION else key
+            if lookup not in stat_keys:
+                descriptor = f"{key} ({ftype.value}/{mode.value})"
+                if descriptor not in inert:
+                    inert.append(descriptor)
+        return inert
+
+    def _declared_normalization_targets(self) -> list[tuple[Any, str, Any, Any, Any, set[str]]]:
+        """Declared normalizations a pipeline transition actually exercises.
+
+        ``NormalizerProcessorStep`` and ``UnnormalizerProcessorStep`` each
+        process BOTH observation and action when present, but at inference the
+        preprocessor transition carries only the observation (action is
+        ``None``) and the postprocessor only the action, so only the feature
+        type matching the pipeline's position is ever touched. That scoping
+        rule is spelled once, here, and both
+        :meth:`inert_normalization_features` (stats absent -> silent
+        passthrough) and :meth:`mismatched_normalization_widths` (stats present
+        at the wrong width -> guaranteed raise) read it, so the two cannot
+        disagree about which normalization a rollout will really perform.
+
+        Returns:
+            ``(step, key, feature, feature_type, mode, stat_keys)`` per declared,
+            non-IDENTITY normalization that the transition exercises. Empty when
+            lerobot cannot be imported.
+        """
+        try:
+            from lerobot.configs.types import FeatureType, NormalizationMode
+        except ImportError:
+            return []
+
+        targets: list[tuple[Any, str, Any, Any, Any, set[str]]] = []
         for is_post_pipeline, pipeline in ((False, self._preprocessor), (True, self._postprocessor)):
             if pipeline is None:
                 continue
@@ -850,12 +883,59 @@ class ProcessorBridge:
                         continue
                     if not is_post_pipeline and ftype == FeatureType.ACTION:
                         continue
-                    lookup = ACTION if ftype == FeatureType.ACTION else key
-                    if lookup not in stat_keys:
-                        descriptor = f"{key} ({ftype.value}/{mode.value})"
-                        if descriptor not in inert:
-                            inert.append(descriptor)
-        return inert
+                    targets.append((step, key, feature, ftype, mode, stat_keys))
+        return targets
+
+    def mismatched_normalization_widths(self) -> list[str]:
+        """Declared normalizations whose supplied stats cannot broadcast onto the feature.
+
+        The sibling :meth:`inert_normalization_features` reports stats that are
+        ABSENT, which LeRobot answers by returning the tensor unchanged. Stats
+        that are PRESENT at the wrong width are the opposite failure: LeRobot
+        reaches the arithmetic and raises ``RuntimeError`` from the tensor
+        broadcast, naming neither the feature, the step, nor either width -
+        and it raises on the first inference, after a rollout has started and
+        the robot has been commanded. The widths are both known at load, on the
+        same step object, so a mismatch is reported here instead.
+
+        Width is exactly what varies between embodiments, and supplying stats
+        is what the inert-pipeline warning tells a caller to do, so stats for a
+        6-DOF arm reaching a 7-DOF checkpoint is a routine mistake.
+
+        Only flat, one-dimensional features are compared. VISUAL features are
+        exempt because LeRobot reshapes a flat ``(C,)`` visual stat to
+        ``(C, 1, 1)`` on purpose (``_reshape_visual_stats``), so a channel-wide
+        stat is correct for a ``(C, H, W)`` feature.
+
+        Returns:
+            One descriptor per mismatch, naming the feature, the declared width
+            and the supplied width. Empty when every present stat matches.
+        """
+        try:
+            from lerobot.configs.types import FeatureType
+            from lerobot.utils.constants import ACTION
+        except ImportError:
+            return []
+
+        bad: list[str] = []
+        for step, key, feature, ftype, mode, _stat_keys in self._declared_normalization_targets():
+            if ftype == FeatureType.VISUAL:
+                continue
+            shape = tuple(getattr(feature, "shape", None) or ())
+            if len(shape) != 1:
+                continue
+            lookup = ACTION if ftype == FeatureType.ACTION else key
+            stats = (getattr(step, "_tensor_stats", None) or {}).get(lookup) or {}
+            for stat_name, value in stats.items():
+                width = tuple(getattr(value, "shape", None) or ())
+                if len(width) == 1 and width[0] != shape[0]:
+                    descriptor = (
+                        f"{key} ({ftype.value}/{mode.value}): feature declares width "
+                        f"{shape[0]}, stats '{lookup}.{stat_name}' supply {width[0]}"
+                    )
+                    if descriptor not in bad:
+                        bad.append(descriptor)
+        return bad
 
     def preprocess(self, observation: dict[str, Any], instruction: str | None = None) -> dict[str, Any]:
         """Preprocess a raw observation dict through the pipeline.

--- a/tests/policies/lerobot_local/test_embodiment_config_failure_diagnostics.py
+++ b/tests/policies/lerobot_local/test_embodiment_config_failure_diagnostics.py
@@ -52,6 +52,7 @@ def _fake_bridge(*, active: bool, has_postprocessor: bool) -> MagicMock:
     bridge.is_active = active
     bridge.has_postprocessor = has_postprocessor
     bridge.inert_normalization_features.return_value = []
+    bridge.mismatched_normalization_widths.return_value = []
     return bridge
 
 

--- a/tests/policies/lerobot_local/test_inert_normalization_detection.py
+++ b/tests/policies/lerobot_local/test_inert_normalization_detection.py
@@ -168,3 +168,62 @@ def test_import_drift_degrades_to_empty(monkeypatch):
     # Force the in-method import to raise ImportError.
     monkeypatch.setitem(sys.modules, "lerobot.configs.types", None)
     assert bridge.inert_normalization_features() == []
+
+
+# --- stats present at the WRONG WIDTH: the opposite failure to an absent stat ---
+#
+# Absent stats make LeRobot return the tensor unchanged (silent). Stats present
+# at the wrong width make it reach the arithmetic and raise from the broadcast,
+# naming neither feature nor width, on the FIRST inference - after a rollout has
+# started. Both widths are known at load, so a mismatch is reported there.
+
+_MS7 = {"mean": [0.0] * 7, "std": [1.0] * 7}
+
+
+def test_mismatched_stat_width_is_flagged_naming_both_widths():
+    bridge = _bridge(
+        {"observation.state": dict(_MS7), "action": dict(_MS7)},
+        {"action": dict(_MS7)},
+    )
+    flagged = bridge.mismatched_normalization_widths()
+    assert flagged, "7-wide stats on a 6-wide checkpoint were not reported"
+    joined = " | ".join(flagged)
+    assert "observation.state" in joined and "action" in joined
+    assert "6" in joined and "7" in joined, f"neither width named: {joined}"
+
+
+def test_matching_stat_width_is_not_flagged():
+    bridge = _bridge({"observation.state": dict(_MS), "action": dict(_MS)}, {"action": dict(_MS)})
+    assert bridge.mismatched_normalization_widths() == []
+
+
+def test_absent_stats_are_the_inert_case_not_a_width_mismatch():
+    """The two detectors report disjoint failures, so neither masks the other."""
+    bridge = _bridge({"so100.buffer.action": dict(_MS)}, {"so100.buffer.action": dict(_MS)})
+    assert bridge.inert_normalization_features(), "premise: absent stats are the inert case"
+    assert bridge.mismatched_normalization_widths() == []
+
+
+def test_visual_channel_stats_are_not_a_width_mismatch():
+    """LeRobot reshapes a flat ``(C,)`` visual stat to ``(C, 1, 1)`` on purpose."""
+    feats = {"observation.image": PolicyFeature(type=FeatureType.VISUAL, shape=(3, 256, 256))}
+    norm = NormalizerProcessorStep(
+        features=feats,
+        norm_map={FeatureType.VISUAL: NormalizationMode.MEAN_STD},
+        stats={"observation.image": {"mean": [0.0] * 3, "std": [1.0] * 3}},
+    )
+    bridge = ProcessorBridge(preprocessor=DataProcessorPipeline(steps=[norm]), postprocessor=None, device="cpu")
+    assert bridge.mismatched_normalization_widths() == []
+
+
+def test_both_detectors_read_one_scoping_rule():
+    """A preprocessor's ``action`` entry is never exercised, so neither flags it."""
+    bridge = _bridge({"action": dict(_MS7)}, {"action": dict(_MS)})
+    assert bridge.mismatched_normalization_widths() == []
+    assert bridge.inert_normalization_features() == ["observation.state (STATE/MEAN_STD)"]
+
+
+def test_width_check_degrades_to_empty_on_import_drift(monkeypatch):
+    bridge = _bridge({"observation.state": dict(_MS7)}, {"action": dict(_MS7)})
+    monkeypatch.setitem(sys.modules, "lerobot.utils.constants", None)
+    assert bridge.mismatched_normalization_widths() == []

--- a/tests/policies/lerobot_local/test_inert_normalization_detection.py
+++ b/tests/policies/lerobot_local/test_inert_normalization_detection.py
@@ -216,6 +216,15 @@ def test_visual_channel_stats_are_not_a_width_mismatch():
     assert bridge.mismatched_normalization_widths() == []
 
 
+def test_a_datasets_count_scalar_is_not_a_width_mismatch():
+    """``LeRobotDataset.meta.stats`` carries ``count`` as shape ``(1,)`` per
+    feature; the normalizer never reads it, so a 6-wide checkpoint fed its own
+    dataset's stats must load (the recorded->trained->loaded round trip)."""
+    with_count = {**dict(_MS), "count": [1]}
+    bridge = _bridge({"observation.state": with_count}, {"action": with_count})
+    assert bridge.mismatched_normalization_widths() == []
+
+
 def test_both_detectors_read_one_scoping_rule():
     """A preprocessor's ``action`` entry is never exercised, so neither flags it."""
     bridge = _bridge({"action": dict(_MS7)}, {"action": dict(_MS)})

--- a/tests/policies/lerobot_local/test_policy.py
+++ b/tests/policies/lerobot_local/test_policy.py
@@ -1954,6 +1954,7 @@ def _load_model_with_mocks(policy, *, param_device="cpu", has_postprocessor=True
         bridge = MagicMock()
         bridge.is_active = True
         bridge.has_postprocessor = has_postprocessor
+        bridge.mismatched_normalization_widths.return_value = []
 
     with (
         patch.object(


### PR DESCRIPTION
## What

Override normalization stats are checked against the widths the checkpoint declares, **at load**. Before, a mismatch reached LeRobot's broadcast on the *first inference* — naming neither feature nor either width — while `inert_normalization_features()` reported `[]`.

```mermaid
graph LR
  subgraph before
    A1[create_policy<br/>stats 7-wide] --> A2[load OK<br/>inert = empty] --> A3[rollout starts<br/>robot commanded] -.-> A4["RuntimeError: size of tensor a 6<br/>must match tensor b 7"]
  end
  subgraph after
    B1[create_policy<br/>stats 7-wide] --> B2["ValueError: observation.state declares<br/>width 6, stats supply 7"]
  end
  style A4 fill:#f8d7da,stroke:#c0392b
  style B2 fill:#d4efdf,stroke:#148f77
```

Measured on `lerobot/smolvla_base`, which declares `observation.state (6,)` / `action (6,)`, given 7-wide stats:

| | load | reported | failure |
|---|---|---|---|
| before | succeeds | `inert = []` | first inference, names nothing |
| after | refused, names each feature + both widths + remedy | — | none |

Correct-width stats still load unchanged (`inert = []`, `mismatches = []`).

## Why

Supplying stats is what the inert-pipeline diagnostic tells a caller to do, and width is what differs between embodiments — a 6-DOF SO-101, a 7-DOF arm and a 14-DOF bimanual all declare `observation.state` and `action`. Both widths already sit on the same step object at load.

The rule for which normalization a transition actually exercises was owned by the inert detector; it now lives once in `_declared_normalization_targets`, read by both, so they cannot disagree. VISUAL is exempt — LeRobot reshapes a flat `(C,)` stat to `(C, 1, 1)` deliberately.

## Tests

`tests/policies/lerobot_local/` 1284 passed. Six cells against **real** LeRobot steps (no network), all failing without the change: mismatch flagged with both widths; matching width not flagged; absent stats stay the inert case; a `(C,)` visual stat is not a mismatch (over-reach control); one shared scoping rule; import drift degrades to empty.

+34 executable statements (AST). `ruff`, `mypy` clean over 1945 files.
