### PR TITLE
fix(drivers/crazyflie): the telemetry block fits the packet cflib allows

### DIFF
--- a/changelog.d/3427-crazyflie-log-block-fits-a-packet.md
+++ b/changelog.d/3427-crazyflie-log-block-fits-a-packet.md
@@ -1,0 +1,3 @@
+### Fixed: the Crazyflie driver now receives telemetry after it connects
+
+The one log block the driver subscribed to fetched eight variables as `float`, 29 bytes, and cflib refuses any block over `LogConfig.MAX_LEN` (26 bytes, one CRTP packet) at `add_config`. So every real connect logged "telemetry unavailable" and `get_status` reported `None` for pose, imu and battery for as long as the aircraft flew. The block now fetches the three attitude angles as `FP16`, the type cflib provides for fitting a block into its packet, and keeps position and battery voltage at full width, 23 bytes in all. The test fake now enforces the same ceiling with sizes transcribed from cflib, so a block that outgrows the packet fails in CI rather than on the radio.

--- a/strands_robots/drivers/crazyflie.py
+++ b/strands_robots/drivers/crazyflie.py
@@ -187,21 +187,39 @@ LOW_BATTERY_VOLTS: float = 3.2
 #: ``pmStates`` enum order.
 POWER_STATES: tuple[str, ...] = ("battery", "charging", "charged", "low_power", "shutdown")
 
-#: The log variables one telemetry block subscribes to, as ``(name, ctype)``.
+#: The log variables one telemetry block subscribes to, as ``(name, fetch_as)``.
 #: All are core variables present on a bare Crazyflie with no expansion deck -
 #: a block naming an absent variable fails to add entirely, which would take
 #: the pose and battery reads down with whichever deck-specific variable was
 #: optimistically included.
+#:
+#: One block is one CRTP packet, and ``cflib`` refuses a block whose fetched
+#: bytes exceed ``LogConfig.MAX_LEN`` (26; the other four of the 30-byte
+#: payload are the block id and the timestamp) with ``AttributeError`` at
+#: ``add_config``. Eight variables all fetched as ``float`` would be 29 bytes,
+#: so the attitude is fetched as ``FP16`` - the type ``cflib`` provides for
+#: fitting a block into its packet - which keeps the position and the battery
+#: voltage at full width and lands the block at 23 bytes.
+#: :data:`LOG_VARIABLE_BYTES` is the size table a test grades this against.
 LOG_VARIABLES: tuple[tuple[str, str], ...] = (
     ("stateEstimate.x", "float"),
     ("stateEstimate.y", "float"),
     ("stateEstimate.z", "float"),
-    ("stabilizer.roll", "float"),
-    ("stabilizer.pitch", "float"),
-    ("stabilizer.yaw", "float"),
+    ("stabilizer.roll", "FP16"),
+    ("stabilizer.pitch", "FP16"),
+    ("stabilizer.yaw", "FP16"),
     ("pm.vbat", "float"),
     ("pm.state", "uint8_t"),
 )
+
+#: Fetched width in bytes of each ``fetch_as`` type :data:`LOG_VARIABLES` uses,
+#: transcribed from ``cflib.crazyflie.log.LogTocElement.types`` so the budget is
+#: gradable without the GPL dependency installed.
+LOG_VARIABLE_BYTES: dict[str, int] = {"uint8_t": 1, "FP16": 2, "float": 4}
+
+#: ``cflib.crazyflie.log.LogConfig.MAX_LEN``: the most fetched bytes one log
+#: block may carry.
+LOG_BLOCK_MAX_BYTES = 26
 
 #: Name of the telemetry log block, and its period.
 _LOG_NAME = "strands_state"

--- a/tests/drivers/crazyflie/conftest.py
+++ b/tests/drivers/crazyflie/conftest.py
@@ -227,7 +227,27 @@ class _FakeLink:
     every variable up in the downloaded TOC and raises ``KeyError`` for a name it
     has not seen yet. That is what makes "arm and log only after ``connected``"
     a testable ordering rather than a comment.
+
+    It also refuses a block whose fetched bytes exceed ``MAX_LEN`` with the
+    ``AttributeError`` the real one raises: one block is one CRTP packet, and a
+    fake that accepted any size would let the driver subscribe to telemetry no
+    firmware can deliver.
     """
+
+    #: ``cflib.crazyflie.log.LogConfig.MAX_LEN`` and the fetched widths from
+    #: ``LogTocElement.types``, transcribed from cflib rather than read from the
+    #: driver, so the fake grades the driver against the SDK and not itself.
+    MAX_LEN = 26
+    FETCH_BYTES = {
+        "uint8_t": 1,
+        "uint16_t": 2,
+        "uint32_t": 4,
+        "int8_t": 1,
+        "int16_t": 2,
+        "int32_t": 4,
+        "FP16": 2,
+        "float": 4,
+    }
 
     def __init__(self, recorder: _Recorder) -> None:
         self._recorder = recorder
@@ -237,6 +257,8 @@ class _FakeLink:
     def add_config(self, block: _FakeLogConfig) -> None:
         if not self.toc_ready:
             raise KeyError(f"Variable {block.variables[0][0] if block.variables else '?'} not in TOC")
+        if sum(self.FETCH_BYTES[fetch_as] for _, fetch_as in block.variables) > self.MAX_LEN:
+            raise AttributeError("The log configuration is too large or has an invalid parameter")
         self.block = block
         self._recorder.record("log.add_config", (block.name,))
 

--- a/tests/drivers/crazyflie/test_crazyflie_driver_over_a_fake_link.py
+++ b/tests/drivers/crazyflie/test_crazyflie_driver_over_a_fake_link.py
@@ -251,6 +251,21 @@ class TestTelemetryIsCachedForTheMesh:
         assert fake.log.block is not None
         assert tuple(fake.log.block.variables) == module.LOG_VARIABLES
 
+    def test_the_log_block_fits_one_crtp_packet(self, connected) -> None:  # type: ignore[no-untyped-def]
+        """``cflib`` refuses a block over ``LogConfig.MAX_LEN`` (26) fetched bytes.
+
+        The sizes are the fake's transcription of ``LogTocElement.types``, not
+        the driver's own table, so a driver that mis-sized a type is caught too.
+        Eight ``float`` variables were 29 bytes: ``add_config`` raised on every
+        real connect and the pose, imu and battery caches stayed ``None``.
+        """
+        _, fake, _ = connected()
+        size = sum(fake.log.FETCH_BYTES[fetch_as] for _, fetch_as in module.LOG_VARIABLES)
+        assert size <= fake.log.MAX_LEN, (
+            f"telemetry block is {size} bytes; cflib LogConfig.MAX_LEN is {fake.log.MAX_LEN}"
+        )
+        assert fake.log.block is not None, "add_config refused the block, so no telemetry frame can ever arrive"
+
     def test_a_delivered_frame_populates_pose_imu_and_battery(self, connected) -> None:  # type: ignore[no-untyped-def]
         driver, fake, _ = connected()
         assert driver._pose is None, "nothing is cached before a frame arrives"


### PR DESCRIPTION
**What**

The Crazyflie telemetry log block is fetched within the 26 bytes cflib allows one block, so it is accepted and pose, imu and battery are populated after connect.

**Why**

`LOG_VARIABLES` fetched eight variables as `float` (29 bytes). cflib refuses that at `add_config` (`LogConfig.MAX_LEN = 26`, `AttributeError: The log configuration is too large`), the driver logged "telemetry unavailable", and every status read carried `None`. The fake link accepted any size, so no test saw it. On main the new test fails with:

```
AssertionError: telemetry block is 29 bytes; cflib LogConfig.MAX_LEN is 26
```

The attitude is now fetched as `FP16`, the type cflib provides for fitting a block (its `basiclog.py` example); position and battery voltage stay full width. 23 bytes.

**Tests**

`test_the_log_block_fits_one_crtp_packet`; the fake `add_config` enforces MAX_LEN with sizes transcribed from cflib. ruff, mypy clean on touched files.
