### PR TITLE
fix(simulation): add_camera names the same cause for the same request on every backend

### DIFF
--- a/changelog.d/3439-camera-name-rule-has-one-owner.md
+++ b/changelog.d/3439-camera-name-rule-has-one-owner.md
@@ -1,0 +1,31 @@
+### Fixed: `add_camera` names the same cause for the same camera request on every backend
+
+The two halves of the camera-name rule - `entity_name_error` (a value that cannot
+be a registry key) and `reserved_camera_name_error` (a `str` the backend's own
+`render` / `get_frame` resolve to the free camera) - were applied separately at
+each `add_camera`, and the sites disagreed about where the name rule sits
+relative to the *value* rules. MuJoCo judged the name first; Newton judged it
+after `position`, `target`, `fov` and the pixel dimensions. Both refused the same
+request, which is all the cross-backend parity pin compared, while naming
+different causes:
+
+```
+add_camera("default", fov=0.0)              mujoco: 'default' is reserved
+                                            newton: 'fov' must be in (0, 180)
+add_camera("default", position=[nan, 1, 1]) mujoco: 'default' is reserved
+                                            newton: 'position' must contain finite numbers
+add_camera("free", width=0)                 mujoco: 'free' is reserved
+                                            newton: width must be a positive integer
+```
+
+A reserved name is the one fault no change of value can clear, so a caller
+following Newton's message fixed a value and learned the name was unusable on the
+round trip after it. `reserved_camera_name_error` already documented its
+dependence on the order ("that guard runs first at every call site"), an
+assumption no single site owned.
+
+The rule and its order now live in `strands_robots.utils.camera_name_error`,
+which every backend's `add_camera` reads. Isaac passes
+`routes_free_camera_tokens=False`, so its documented `"default"` signature default
+keeps working and that divergence is a stated property of the call rather than a
+guard one site omits. No MuJoCo message changed.

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -48,6 +48,7 @@ from strands_robots.simulation.terrain import validate_difficulty
 from strands_robots.utils import (
     FREE_CAMERA_TOKENS,
     camera_fov_error,
+    camera_name_error,
     coerce_orientation_quaternion,
     coerce_pose_vector,
     coerce_rgba,
@@ -5266,17 +5267,21 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
                 return {"status": "error", "content": [{"text": "No world created."}]}
 
             # Refuse a name that cannot address the camera this call creates, on
-            # the shared ``entity_name_error`` domain the MuJoCo and Newton
-            # backends' ``add_camera`` already applies, so a name one backend
-            # refuses is refused by all three - the same invariant this method
-            # already honours for ``position`` / ``target`` / ``fov`` / ``width``
-            # / ``height`` below. An empty name is worse than unaddressable for a
-            # camera: ``render`` routes ``camera_name in (None, "", "default",
-            # "free")`` to the free camera by an explicit token check, so a
-            # camera created as ``""`` could never be rendered from, while the
-            # prim landed at ``/World/Cameras/`` - the container scope shared by
-            # every camera on the stage.
-            if (name_err := entity_name_error("add_camera", "name", name)) is not None:
+            # the shared ``camera_name_error`` rule every backend's
+            # ``add_camera`` reads, so a name one backend refuses is refused by
+            # all three - the same invariant this method already honours for
+            # ``position`` / ``target`` / ``fov`` / ``width`` / ``height``
+            # below. An empty name is worse than unaddressable for a camera: the
+            # prim would land at ``/World/Cameras/``, the container scope shared
+            # by every camera on the stage.
+            #
+            # ``routes_free_camera_tokens=False``: unlike the MuJoCo and Newton
+            # backends, this one's ``get_frame`` looks a camera up in
+            # ``self._cameras`` directly with no token check, so ``"default"``
+            # here is an ordinary addressable name - and is this signature's
+            # documented default. Stating the flag keeps that divergence a
+            # property of the call rather than a guard this site omits.
+            if (name_err := camera_name_error("add_camera", "name", name, routes_free_camera_tokens=False)) is not None:
                 return {"status": "error", "content": [{"text": name_err}]}
 
             # Validate the pose and the field of view on the shared domains the

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -139,6 +139,7 @@ from strands_robots.simulation.terrain import SUPPORTED_TERRAINS, validate_diffi
 from strands_robots.teleop_mixin import TeleopMixin
 from strands_robots.utils import (
     camera_fov_error,
+    camera_name_error,
     coerce_orientation_quaternion,
     coerce_pose_vector,
     entity_name_error,
@@ -4173,12 +4174,15 @@ class MuJoCoSimEngine(
         so a camera created under any of them could never be rendered from even
         though it is registered, compiled into the model and listed by
         ``list_cameras``; a non-string name is additionally not addressable
-        through the agent-tool surface. This is the same set the Newton backend's
-        ``add_camera`` refuses, on the shared
-        :func:`~strands_robots.utils.reserved_camera_name_error` domain, because
-        that backend routes the same tokens. The Isaac backend does not route
-        them - its ``get_frame`` looks the name up directly - so ``"default"``
-        there is an ordinary camera name and stays accepted. ``position`` and ``target``
+        through the agent-tool surface. Both halves of the name rule come from
+        the shared :func:`~strands_robots.utils.camera_name_error`, which every
+        backend's ``add_camera`` reads, so the rule and its order are stated
+        once: the name is judged BEFORE any value, because a reserved name is
+        the one fault no change of value can clear. The Newton backend refuses
+        the same set because it routes the same tokens; the Isaac backend does
+        not route them - its ``get_frame`` looks the name up directly - so it
+        passes ``routes_free_camera_tokens=False`` and ``"default"`` there is an
+        ordinary camera name. ``position`` and ``target``
         must each be 3 finite numbers (a list, tuple or NumPy array; NumPy
         scalar elements accepted). Omit a vector to take its default - an empty
         vector is a wrong-length request and is rejected rather than silently
@@ -4195,35 +4199,18 @@ class MuJoCoSimEngine(
         if err := self._require_no_running_policy("add_camera"):
             return err
 
-        # Refuse a name that cannot address the camera this call creates, on the
-        # shared ``entity_name_error`` domain. An empty name is worse here than
-        # for an object: ``render``/``get_frame`` route ``camera_name in (None,
-        # "", "default", "free")`` to the FREE camera by an explicit token
-        # check, so a camera registered as "" could never be rendered from. It
-        # precedes the duplicate-name test for the same reason it does in
-        # ``add_object`` - that test is partial for an unhashable name.
-        if (name_err := entity_name_error("add_camera", "name", name)) is not None:
+        # The whole name rule, in the one order ``camera_name_error`` owns: a
+        # value that cannot be a registry key at all, then a ``str`` this
+        # backend's render entry points (``render`` / ``render_depth`` /
+        # ``get_frame``) resolve past. It precedes every value rule below, and
+        # the duplicate-name test, because a reserved name is the one fault no
+        # change of value can clear - and because that test answered for
+        # ``"default"`` misleadingly: ``create_world`` registers the built-in
+        # free view under that name, so the refusal was "already exists. Remove
+        # it first.", and following that prescription succeeded, leaving the
+        # scene with an unreachable camera where the free-view alias had been.
+        if (name_err := camera_name_error("add_camera", "name", name, routes_free_camera_tokens=True)) is not None:
             return {"status": "error", "content": [{"text": name_err}]}
-
-        # Refuse a name this backend's own render entry points resolve past. The
-        # three of them (``render`` / ``render_depth`` / ``get_frame``) select the
-        # free camera for every ``FREE_CAMERA_TOKENS`` member by an explicit token
-        # check, so claiming one produced a camera that is registered, compiled
-        # into the model and offered by ``list_cameras`` - and that every render
-        # of silently answers with the free view instead, under a success result.
-        # ``entity_name_error`` above covers only the two falsy tokens, which is
-        # why this is a second guard rather than a widening of that domain: the
-        # other two are perfectly addressable *names* that this backend alone
-        # cannot address as *cameras*.
-        #
-        # It precedes the duplicate-name test because that test answered for
-        # ``"default"`` and answered misleadingly: ``create_world`` registers the
-        # built-in free view under that name, so the refusal was "already exists.
-        # Remove it first." - and following that prescription succeeded, leaving
-        # the scene with an unreachable camera where the advertised free-view
-        # alias had been.
-        if (reserved_err := reserved_camera_name_error("add_camera", "name", name)) is not None:
-            return {"status": "error", "content": [{"text": reserved_err}]}
 
         # Validate position / target shape before we bake them into XML.
         # Membership, not truthiness: ``position or <default>`` raised a bare

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -74,6 +74,7 @@ from strands_robots.simulation.terrain import validate_difficulty
 from strands_robots.utils import (
     FREE_CAMERA_TOKENS,
     camera_fov_error,
+    camera_name_error,
     coerce_orientation_quaternion,
     coerce_pose_vector,
     coerce_rgba,
@@ -1398,9 +1399,11 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         there is no upper cap.
 
         Args:
-            name: Unique camera name; a non-empty ``str`` containing no NUL, the
-                same domain the MuJoCo backend's ``add_camera`` accepts
-                (:func:`~strands_robots.utils.entity_name_error`). Duplicate
+            name: Unique camera name; a non-empty ``str`` containing no NUL and
+                not a free-camera routing token, the same rule and the same
+                order the MuJoCo backend's ``add_camera`` applies
+                (:func:`~strands_robots.utils.camera_name_error`, judged before
+                any value below). Duplicate
                 names are rejected; remove the existing camera with
                 :meth:`remove_camera` first.
             position: Camera eye ``[x, y, z]`` (world frame, or the parent
@@ -1423,10 +1426,15 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         if self._world is None or self._model is None:
             return {"status": "error", "content": [{"text": "No world. Call create_world first."}]}
 
-        # Refuse a name that cannot address the camera this call creates, on the
-        # shared ``entity_name_error`` domain the MuJoCo backend's ``add_camera``
-        # uses, so a camera name one backend refuses is refused by both.
-        if (name_err := entity_name_error("add_camera", "name", name)) is not None:
+        # The whole name rule, in the one order ``camera_name_error`` owns and
+        # the MuJoCo backend's ``add_camera`` reads too: a value that cannot be
+        # a registry key, then a ``str`` this backend's render entry points
+        # resolve past. Both guards precede every value rule below, so the two
+        # backends name the same cause for the same request - the reserved-name
+        # test used to sit after the pose, fov and pixel-dimension rules here,
+        # and a request with a routing token AND a bad value was refused by both
+        # backends for different reasons.
+        if (name_err := camera_name_error("add_camera", "name", name, routes_free_camera_tokens=True)) is not None:
             return {"status": "error", "content": [{"text": name_err}]}
 
         # Validate shape, element type AND finiteness with the shared helpers the
@@ -1484,11 +1492,6 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         for _param, _value in (("width", width), ("height", height)):
             if (e := positive_count_error(_value, _param, "add_camera")) is not None:
                 return {"status": "error", "content": [{"text": e}]}
-        # Refuse a name this backend's own render entry points would resolve past.
-        # Shared with the MuJoCo sibling, which routes the same tokens and until
-        # now refused none of them, so the two cannot state the rule differently.
-        if (reserved_err := reserved_camera_name_error("add_camera", "name", name)) is not None:
-            return {"status": "error", "content": [{"text": reserved_err}]}
         if name in self._world.cameras:
             return {
                 "status": "error",

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -2899,6 +2899,63 @@ def entity_name_error(method: str, param_name: str, name: Any) -> str | None:
     return None
 
 
+def camera_name_error(method: str, param_name: str, name: Any, *, routes_free_camera_tokens: bool) -> str | None:
+    """Return an error message if ``name`` cannot address the camera it claims.
+
+    The whole name rule for a camera creation site, in one place and in one
+    order: :func:`entity_name_error` first (a value that cannot be a registry
+    key at all), then :func:`reserved_camera_name_error` (a ``str`` this
+    backend's own render entry points resolve past). Every ``add_camera``
+    reads it, so the order is a property of the rule rather than of whichever
+    body a caller reached.
+
+    That order was the defect this composition removes. The two guards had been
+    applied separately at each site, and the sites disagreed about where the
+    name rule sits relative to the *value* rules: MuJoCo refused a routing token
+    before validating ``position`` / ``target`` / ``fov`` / the pixel
+    dimensions, Newton refused it after all four. Both refused the same request
+    -- which is all the cross-backend parity test compared -- while naming
+    different causes. Measured on this tree, one ``create_world`` on each
+    backend::
+
+        add_camera("default", fov=0.0)          mujoco: 'default' is reserved
+                                                newton: 'fov' must be in (0, 180)
+        add_camera("default", position=[nan,1,1]) mujoco: 'default' is reserved
+                                                newton: 'position' must contain finite numbers
+        add_camera("free", width=0)             mujoco: 'free' is reserved
+                                                newton: width must be a positive integer
+
+    A caller fixing what the message names learns the name is unusable only on
+    the round trip after it, and the reserved-name refusal is the one fault no
+    change of value can clear. :func:`reserved_camera_name_error` documents its
+    own dependence on the order ("that guard runs first at every call site, so
+    this one is only ever reached with a genuine ``str``") - an assumption no
+    single site owned until this one did.
+
+    Args:
+        method: The calling method, for the message prefix (e.g. ``"add_camera"``).
+        param_name: The parameter being validated, for the message.
+        name: The claimed camera name. Anything at all; a value that is not a
+            ``str`` is refused by the first guard.
+        routes_free_camera_tokens: Whether this backend's render entry points
+            resolve :data:`FREE_CAMERA_TOKENS` to the free camera. Only a backend
+            that routes them may refuse them as names - the Isaac backend's
+            ``get_frame`` looks a name up directly, so ``"default"`` there is an
+            ordinary camera name and is that backend's documented signature
+            default. Passing the flag makes that divergence a stated property of
+            the call rather than a guard one site happens to omit.
+
+    Returns:
+        The first refusal in the documented order, or ``None`` when *name* can
+        address a camera on this backend.
+    """
+    if (err := entity_name_error(method, param_name, name)) is not None:
+        return err
+    if routes_free_camera_tokens:
+        return reserved_camera_name_error(method, param_name, name)
+    return None
+
+
 def published_string_error(value: Any, param: str, context: str) -> str | None:
     """Return an error message if a field published as a string did not arrive as one.
 

--- a/tests/simulation/test_reserved_camera_name_at_creation.py
+++ b/tests/simulation/test_reserved_camera_name_at_creation.py
@@ -68,7 +68,7 @@ from typing import Any, cast
 import pytest
 
 from strands_robots.simulation.newton.simulation import NewtonSimEngine
-from strands_robots.utils import FREE_CAMERA_TOKENS, reserved_camera_name_error
+from strands_robots.utils import FREE_CAMERA_TOKENS, camera_name_error, reserved_camera_name_error
 
 #: The tokens that are also *addressable* strings, so only the reserved-name rule
 #: can refuse them. ``None`` and ``""`` are refused earlier by
@@ -248,7 +248,7 @@ def _newton_stub() -> types.SimpleNamespace:
     )
 
 
-def _newton_add_camera(stub: types.SimpleNamespace, name: Any) -> dict[str, Any]:
+def _newton_add_camera(stub: types.SimpleNamespace, name: Any, **kwargs: Any) -> dict[str, Any]:
     """Call the unbound ``add_camera`` with the stand-in for ``self``.
 
     The stand-in is deliberately not a ``NewtonSimEngine``: the point is to reach
@@ -263,9 +263,9 @@ def _newton_add_camera(stub: types.SimpleNamespace, name: Any) -> dict[str, Any]
     # ``add_camera`` up on the namespace, which does not carry it. The ``cast`` is
     # a no-op at runtime and only tells the checker what the argument stands in
     # for, which keeps the boundary explicit without suppressing the check.
-    return NewtonSimEngine.add_camera(
-        cast(NewtonSimEngine, stub), name, position=[1.0, 1.0, 1.0], target=[0.0, 0.0, 0.0]
-    )
+    request: dict[str, Any] = {"position": [1.0, 1.0, 1.0], "target": [0.0, 0.0, 0.0]}
+    request.update(kwargs)
+    return NewtonSimEngine.add_camera(cast(NewtonSimEngine, stub), name, **request)
 
 
 class TestSameVerdictAsTheNewtonSibling:
@@ -450,3 +450,133 @@ class TestTheTokenSetHasOneDefinition:
             blob = "\n".join(p.read_text(encoding="utf-8") for p in files)
             assert "FREE_CAMERA_TOKENS" in blob, f"{backend} no longer routes the tokens"
             assert "reserved_camera_name_error" in blob, f"{backend} routes the tokens but does not refuse them"
+
+
+# --------------------------------------------------------------------------- #
+# The rule's ORDER, which is what a second copy of the rule diverged on        #
+# --------------------------------------------------------------------------- #
+#: Requests that carry a second fault beside the reserved name. Each value is
+#: independently refused by both backends, so a single-fault probe cannot tell
+#: which rule a body reaches first - and that is what the earlier parity test
+#: (status only, one fault at a time) missed.
+def _request(**kwargs: Any) -> dict[str, Any]:
+    """A valid camera request with *kwargs* overriding a field, not repeating it."""
+    request: dict[str, Any] = {"position": [1.0, 1.0, 1.0], "target": [0.0, 0.0, 0.0]}
+    request.update(kwargs)
+    return request
+
+
+_SECOND_FAULTS: tuple[tuple[str, dict[str, Any]], ...] = (
+    ("fov", {"fov": 0.0}),
+    ("non_finite_position", {"position": [float("nan"), 1.0, 1.0]}),
+    ("non_finite_target", {"target": [float("inf"), 0.0, 0.0]}),
+    ("short_position", {"position": [1.0, 1.0]}),
+    ("width", {"width": 0}),
+    ("height", {"height": -5}),
+)
+
+
+class TestTheNameRuleIsJudgedBeforeAnyValue:
+    """A reserved name is the fault no change of value can clear, so it is named.
+
+    Both backends refused every request below before this fix, which is all the
+    cross-backend pins compared - and they named different causes. MuJoCo applied
+    the name rule first; Newton applied it after the pose, ``fov`` and
+    pixel-dimension rules, so ``add_camera("default", fov=0.0)`` was reported as
+    a ``fov`` problem there and as a reserved-name problem here. A caller fixing
+    what the message named learned the name was unusable one round trip later,
+    and only on one of the two engines.
+
+    :func:`~strands_robots.utils.camera_name_error` now owns both halves of the
+    name rule, so its position relative to the value rules is a property of the
+    rule rather than of whichever body a caller reached.
+    """
+
+    @pytest.mark.parametrize("second", _SECOND_FAULTS, ids=[i for i, _ in _SECOND_FAULTS])
+    @pytest.mark.parametrize("name", _ADDRESSABLE_TOKENS)
+    def test_mujoco_names_the_reserved_name(self, sim, name: str, second: tuple[str, dict[str, Any]]) -> None:
+        result = sim.add_camera(name, **_request(**second[1]))
+        assert result["status"] == "error"
+        assert "reserved" in result["content"][0]["text"], result
+
+    @pytest.mark.parametrize("second", _SECOND_FAULTS, ids=[i for i, _ in _SECOND_FAULTS])
+    @pytest.mark.parametrize("name", _ADDRESSABLE_TOKENS)
+    def test_newton_names_the_reserved_name_too(self, name: str, second: tuple[str, dict[str, Any]]) -> None:
+        stub = _newton_stub()
+        result = _newton_add_camera(stub, name, **second[1])
+        assert result["status"] == "error"
+        assert "reserved" in result["content"][0]["text"], result
+        assert stub._world.cameras == {}
+
+    @pytest.mark.parametrize("second", _SECOND_FAULTS, ids=[i for i, _ in _SECOND_FAULTS])
+    @pytest.mark.parametrize("name", _ADDRESSABLE_TOKENS)
+    def test_the_two_backends_name_the_same_cause(self, sim, name: str, second: tuple[str, dict[str, Any]]) -> None:
+        """The whole point: one request, one diagnosis, whichever engine is held."""
+        newton = _newton_add_camera(_newton_stub(), name, **second[1])
+        mujoco_result = sim.add_camera(name, **_request(**second[1]))
+        assert newton["status"] == mujoco_result["status"] == "error"
+        assert newton["content"][0]["text"] == mujoco_result["content"][0]["text"]
+
+    @pytest.mark.parametrize("second", _SECOND_FAULTS, ids=[i for i, _ in _SECOND_FAULTS])
+    def test_a_value_fault_under_a_good_name_still_names_the_value(
+        self, sim, second: tuple[str, dict[str, Any]]
+    ) -> None:
+        """The control: promoting the name rule must not swallow the value rules.
+
+        Each backend keeps its own dimension bound (MuJoCo caps at the offscreen
+        framebuffer, Newton ray-traces and has no cap), so this asserts the
+        refusal is about the value rather than comparing the two sentences.
+        """
+        for result in (
+            sim.add_camera("wrist", **_request(**second[1])),
+            _newton_add_camera(_newton_stub(), "wrist", **second[1]),
+        ):
+            assert result["status"] == "error", (second, result)
+            assert "reserved" not in result["content"][0]["text"], (second, result)
+
+
+class TestTheComposedRuleIsTheOnlyNameGuard:
+    """One owner for the rule, so no site can re-spell it in another order."""
+
+    def test_the_unaddressable_half_still_wins_over_the_routing_half(self) -> None:
+        """``None`` is not a name at all, so the addressability message is right.
+
+        Both halves match it (``None`` is in :data:`FREE_CAMERA_TOKENS` too), and
+        the composed order is what decides which one a caller reads.
+        """
+        message = camera_name_error("add_camera", "name", None, routes_free_camera_tokens=True)
+        assert message is not None
+        assert "reserved" not in message
+
+    @pytest.mark.parametrize("name", _ADDRESSABLE_TOKENS)
+    def test_a_backend_that_does_not_route_does_not_refuse(self, name: str) -> None:
+        assert camera_name_error("add_camera", "name", name, routes_free_camera_tokens=False) is None
+        assert camera_name_error("add_camera", "name", name, routes_free_camera_tokens=True) is not None
+
+    def test_every_add_camera_reads_the_composed_rule_and_none_re_spells_it(self) -> None:
+        """Structural pin: the two halves are not applied separately any more.
+
+        Applying them separately is exactly how the order came to differ, so a
+        site that calls either half directly is the defect returning, not a style
+        preference. Scoped to ``add_camera`` bodies: ``remove_camera`` legitimately
+        applies the routing half alone (removing a token is a lookup, not a claim).
+        """
+        readers, offenders = [], []
+        for path in sorted(_package_root().rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if not (isinstance(node, ast.FunctionDef) and node.name == "add_camera"):
+                    continue
+                called = {
+                    call.func.id
+                    for call in ast.walk(node)
+                    if isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
+                }
+                where = f"{path.relative_to(_package_root())}:{node.lineno}"
+                if "camera_name_error" in called:
+                    readers.append(where)
+                for half in ("entity_name_error", "reserved_camera_name_error"):
+                    if half in called:
+                        offenders.append(f"{where} calls {half} directly")
+        assert len(readers) >= 3, f"expected every backend add_camera to read the rule, found {readers}"
+        assert offenders == [], offenders


### PR DESCRIPTION
![the cause each backend names](https://raw.githubusercontent.com/cagataycali/robots/assets/camera-name-rule/img/camera_name_rule.png)

**What** `add_camera` applied the two halves of the camera-name rule (`entity_name_error`, `reserved_camera_name_error`) separately at each backend, and the sites disagreed on where the name rule sits relative to the *value* rules: MuJoCo judged the name 2nd, Newton 7th. Both refused the same request - all the cross-backend pin compared - while naming different causes (4 of 7 probes above). A reserved name is the one fault no change of value can clear.

**Why** `reserved_camera_name_error` already documents its dependence on that order ("that guard runs first at every call site"); no single site owned it. `camera_name_error` now does, and every `add_camera` reads it. Isaac passes `routes_free_camera_tokens=False`, so its documented `"default"` default keeps working. No MuJoCo message changed.

**Tests** 25 of 103 cells in `test_reserved_camera_name_at_creation.py` fail pre-fix (12 newton diagnosis, 12 cross-backend agreement, 1 one-owner structural pin) and pass after; 4 mutants fire 28/3/5/29 cells. Full `tests/` 50,465 passed / 305 skipped; ruff + mypy clean. `strands_robots/` +3 executable statements (the +54 lines are the shared rule's docstring, minus two guards at three sites).