### PR TITLE
docs(policies): four policy pages keep their contract facts and lose the essays

### DIFF
--- a/docs/policies/cosmos3.md
+++ b/docs/policies/cosmos3.md
@@ -44,28 +44,16 @@ Cosmos3Policy(
 )
 ```
 
-`host` and `port` are the two halves of the one address this client dials
-(`ws://<host>:<port>`), and both are refused before the endpoint is built rather
-than surfacing later as an unreachable server. `host` must be a bare hostname or
-IP literal - no `/`, `:`, scheme or credentials, IPv6 bracketed as `"[::1]"` -
-because the URI parse gives a delimiter to a later component and takes the port
-with it: `host="localhost/foo"` reads as port **80**, so the configured `8000`
-lands in the path. Both are read only when this constructor builds the client; an
-injected `client=` owns its own address. `host="0.0.0.0"` reaches a server bound
-on every interface.
-
-The client's own `read_timeout` - `Cosmos3WebsocketClient(host, port, read_timeout=1800)`,
-injected as `client=` - bounds every read off the live connection - the metadata handshake
-and each action chunk - as a positive finite number of seconds (default 600).
-`websockets`' `recv()` has no deadline of its own, so without it a server that
-accepted the connection and then went quiet, with a checkpoint still loading onto
-the GPU or a wedged forward pass, held the calling thread indefinitely: the
-`ConnectionError` that tells an operator how to start the server is raised from
-`except OSError`, and a listening server never produces one. A read that expires
-reports `accepted the connection but sent no ... within read_timeout=Ns` - kept
-distinct from the "start it first" hint, which is the wrong advice for a server
-that is already running - and discards the connection, so the reply it missed
-cannot be read as the answer to the next observation.
+`host` and `port` form the one address this client dials (`ws://<host>:<port>`)
+and are refused before the endpoint is built: `host` must be a bare hostname or
+IP literal (IPv6 bracketed as `"[::1]"`), because `host="localhost/foo"` would
+parse as port **80** with the configured `8000` in the path. An injected
+`client=` owns its own address, and its `read_timeout`
+(`Cosmos3WebsocketClient(host, port, read_timeout=1800)`, default 600 s, positive
+and finite) bounds every read off the live connection - `websockets`' `recv()`
+has no deadline, so a server that accepted the connection and then went quiet
+would otherwise hold the caller forever. An expired read is reported as a
+timeout, not as "start the server first", and discards the connection.
 
 ## Embodiments
 
@@ -79,8 +67,8 @@ cannot be read as the answer to the next observation.
 
 ### Action spaces
 
-An embodiment serves its action under one or more `action_space` names, and each
-one names its own columns:
+An embodiment serves its action under one or more `action_space` names, each with
+its own columns:
 
 | `action_space` | Columns | Notes |
 |----------------|---------|-------|
@@ -88,39 +76,22 @@ one names its own columns:
 | `joint_pos` | `joint_0..joint_6` + `gripper` (DROID only) | The one space the RoboLab server post-processes, converting the effector pose into joint targets |
 
 `action_mapping` renames a column to one of your robot's actuator names, so its
-keys must be columns of the active space. Mapping the gripper is therefore
-`{"grasp": ...}` under `midtrain` and `{"gripper": ...}` under `joint_pos`; a key
-that names no column is refused, listing the ones that are valid.
+keys must be columns of the active space (`{"grasp": ...}` under `midtrain`,
+`{"gripper": ...}` under `joint_pos`); a key naming no column is refused listing
+the valid ones. It has to be a rename: two columns arriving at one actuator name
+would collapse into one step-dict entry and drop a command, so both spellings of
+that collision are refused at construction (renaming *every* column is a
+bijection and is accepted).
 
-It has to be a rename, so two columns may not arrive at one actuator name. A
-step dict holds one entry per column, so a merge would collapse two columns into
-one entry and drop a command - the actuator that lost would hold position while
-the model asked it to move. Both spellings are refused at construction, naming
-the columns and the target they collide on: two entries sharing a target, and a
-single entry aimed at another column's own name (`{"joint_0": "joint_1"}` on
-`joint_pos` names only real columns and still costs a joint). Renaming *every*
-column is a bijection and is accepted.
-
-`joint_pos` needs seven joint values plus a gripper, and it reads them in the
-order you declare with `set_robot_state_keys()`. Declaring that order is what
-every example here does, and it is what binds the request to the joints you mean.
-
-Without it the order is inferred from the observation's own scalar keys, and that
-inferred ordering is **position-only**: a `<joint>.vel` entry is dropped when the
-observation also carries its `<joint>` position companion. Every sim backend
-emits a velocity sibling beside each joint position, so taking the keys in
-observation order would otherwise put a velocity in every other slot of the
-seven and truncate the trailing joints away. A `.vel` key with no position
-companion is kept, because some embodiments legitimately declare velocity state
-(LeKiwi's body-frame base velocities `x.vel` / `y.vel` / `theta.vel`). Explicit
-`robot_state_keys` are never filtered - naming `elbow.vel` there states the
-model's input. This is the same rule the LeRobot provider applies to its own
-inferred ordering, so one observation reads as one state vector whichever
-provider consumes it.
+`joint_pos` reads seven joint values plus a gripper in the order you declare with
+`set_robot_state_keys()`, as every example here does. Without it the order is
+inferred from the observation's scalar keys, **position-only**: a `<joint>.vel`
+entry is dropped when its `<joint>` companion is present (every sim backend
+emits one), a `.vel` key with no companion is kept (LeKiwi's `x.vel` /
+`theta.vel`), and explicit `robot_state_keys` are never filtered - the same rule
+the LeRobot provider applies.
 
 ## Backends
-
-Cosmos3Policy can run Cosmos 3 two ways. The default is unchanged.
 
 | backend | how it runs | install | extra outputs |
 |---------|-------------|---------|---------------|
@@ -132,28 +103,23 @@ Cosmos3Policy can run Cosmos 3 two ways. The default is unchanged.
 uv pip install "strands-robots[cosmos3-diffusers]"
 ```
 
-`Cosmos3OmniPipeline` and `CosmosActionCondition` first ship in diffusers 0.39.0,
-which the extra floors. A checkpoint newer than that floor can need a newer
-diffusers still - `nvidia/Cosmos3-Edge` is built against 0.40.0.dev0, which at the
-time of writing ships only from source:
+`Cosmos3OmniPipeline` and `CosmosActionCondition` first ship in diffusers
+0.39.0, which the extra floors; `nvidia/Cosmos3-Edge` is built against
+0.40.0.dev0, which at the time of writing ships only from source:
 
 ```bash
 uv pip install 'diffusers @ git+https://github.com/huggingface/diffusers'
 ```
 
-Loading a checkpoint the installed diffusers cannot build is refused, naming the
-tensors it could not fill - `from_pretrained` itself only warns and leaves them
-uninitialized, so without that check the pipeline would run on random weights.
-
-The `cosmos3-diffusers` extra is native `diffusers` + `torch` + `transformers`
-(no extra wrapper package). It composes with `numpy>=2` (and therefore with
-`lerobot` dataset recording in the same env), so it is co-installable with
-`cosmos3-service`.
+Loading a checkpoint the installed diffusers cannot build is refused naming the
+tensors it could not fill - `from_pretrained` itself only warns and would run on
+random weights. The extra is native `diffusers` + `torch` + `transformers`,
+`numpy>=2`-compatible and co-installable with `cosmos3-service`.
 
 > **Action layout note.** The `diffusers` backend returns the model's **raw
 > unified action** (DROID = 9D end-effector pose `tx,ty,tz,r0..r5` + 1D `grasp`
-> = 10D), named by the embodiment `raw_action_layout`. This is the pipeline's
-> native output, *before* the RoboLab server's `joint_pos` (8D) conversion. Use
+> = 10D), named by the embodiment `raw_action_layout` - the pipeline's native
+> output, *before* the RoboLab server's `joint_pos` (8D) conversion. Use
 > `backend="service"` when you need joint-position commands.
 
 > **Safety checker / `cosmos_guardrail`.** `Cosmos3OmniPipeline` builds a
@@ -188,9 +154,8 @@ The `cosmos3-diffusers` extra is native `diffusers` + `torch` + `transformers`
 ### `backend="diffusers"` — world video alongside the action chunk
 
 One in-process forward pass returns the predicted world video, optional sound,
-**and** the robot action chunk. The action chunk is returned through the normal
-`get_actions` -> `list[dict]` contract; the world video/sound are surfaced on
-`policy.last_rollout` (the Policy ABC return type is unchanged).
+**and** the action chunk. The chunk comes back through the normal `get_actions`
+-> `list[dict]` contract; video and sound are surfaced on `policy.last_rollout`:
 
 ```python
 from strands_robots.policies import create_policy
@@ -215,8 +180,8 @@ print(policy.last_rollout["sound"])   # path to a .wav, or None
 ### Action modes (diffusers only)
 
 The diffusers backend exposes Cosmos 3's full physics loop via the `mode` kwarg
-(`CosmosActionCondition.mode`). These do **not** exist in service mode — passing
-a non-`policy` mode under `backend="service"` raises a clear error.
+(`CosmosActionCondition.mode`). These do **not** exist in service mode - a
+non-`policy` mode under `backend="service"` raises.
 
 | `mode` | conditioning | predicts | `get_actions` returns |
 |--------|--------------|----------|------------------------|
@@ -224,7 +189,8 @@ a non-`policy` mode under `backend="service"` raises a clear error.
 | `forward_dynamics` | first frame + given `raw_actions` | future video | `[]` (world video on `last_rollout`) |
 | `inverse_dynamics` | an observed video | the actions between frames | action chunk (`list[dict]`) |
 
-All three modes are verified live on real `nvidia/Cosmos3-Nano` weights (Thor, bf16/CUDA): `policy` → 32-step action chunk + world video; `forward_dynamics` → world video only (`get_actions` returns `[]`); `inverse_dynamics` → 32-step action chunk recovered from an observed video. See `docs/assets/cosmos3/live_modes_metrics.json`.
+All three modes are verified live on real `nvidia/Cosmos3-Nano` weights (Thor,
+bf16/CUDA); metrics in `docs/assets/cosmos3/live_modes_metrics.json`.
 
 ```python
 # forward dynamics: "what world results if I run these actions?"
@@ -241,26 +207,22 @@ steps = inv.get_actions_sync(observation, "", video="observed.mp4")
 
 ### Closing the sim loop: de-normalize → IK → MuJoCo
 
-The `diffusers` backend returns the model's **raw unified action** — for the
-DROID/Franka domain that is `[tx, ty, tz, r0..r5, grasp]`, **quantile-normalized
-to `[-1, 1]`** and encoding a *relative end-effector pose delta* per step, **not
-joint radians**. Feeding it straight into MuJoCo joint actuators is physically
-meaningless (the normalized columns land arbitrarily inside/outside real joint
-limits; MuJoCo silently clamps and the arm doesn't track). Three honest
-geometric steps (`cosmos3-sim` extra) turn it into joint targets a MuJoCo arm
-actually follows:
+The `diffusers` backend's raw unified action is **quantile-normalized to
+`[-1, 1]`** and encodes a *relative end-effector pose delta* per step, **not
+joint radians** - fed straight to MuJoCo joint actuators it is meaningless.
+Three geometric steps (`cosmos3-sim` extra: `mink` + `mujoco`, numpy>=2,
+co-installable with the other extras) turn it into joint targets:
 
-1. **De-normalize** — invert the quantile transform with the embodiment's
+1. **De-normalize** - invert the quantile transform with the embodiment's
    bundled `q01`/`q99` action stats:
-   `denorm = 0.5 * (a + 1) * (q99 - q01) + q01`
-   (`denormalize_quantile`; stats bundled under `policies/cosmos3/stats/`).
-2. **Decode poses** — integrate the per-step `[translation(3), rot6d(6)]` deltas
+   `denorm = 0.5 * (a + 1) * (q99 - q01) + q01` (`denormalize_quantile`).
+2. **Decode poses** - integrate the per-step `[translation(3), rot6d(6)]` deltas
    into an absolute `(T+1, 4, 4)` SE3 trajectory anchored at the robot's current
-   EE pose (`decode_pose_trajectory`).
-3. **Inverse kinematics** — solve each Cartesian target to joint angles with
+   EE pose (`decode_pose_trajectory`, via `MinkIKBridge.ee_pose(qpos)`, the
+   forward-kinematics call).
+3. **Inverse kinematics** - solve each Cartesian target with
    [`mink`](https://github.com/kevinzakka/mink) differential IK on the *same*
-   `mujoco.MjModel` (a `FrameTask` on the EE body + a `PostureTask` regularizer),
-   warm-starting each step (`MinkIKBridge`).
+   `mujoco.MjModel`, warm-starting each step (`MinkIKBridge`).
 
 ```python
 import mujoco, numpy as np
@@ -286,10 +248,10 @@ out["tracking_error"]  # {"mean_mm", "max_mm"} Cartesian tracking error
 ```
 
 Verified on Thor against real `nvidia/Cosmos3-Nano` weights, a reachable EE
-trajectory tracks to **mean ≈ 11.5 mm / max ≈ 42.8 mm** — the bar pinned by the
-`tests/policies/cosmos3/test_sim_ik.py` regression. (Errors grow only when the
-de-normalized deltas are scaled past the ~0.85 m Franka reach — a workspace
-concern, not an IK one.)
+trajectory tracks to **mean ≈ 11.5 mm / max ≈ 42.8 mm** - the bar pinned by
+`tests/policies/cosmos3/test_sim_ik.py`. The Cosmos "modes" above are
+world-model *conditioning* modes, not a kinematics solve; this IK layer is
+applied *after* Cosmos.
 
 #### De-normalization stats are per domain
 
@@ -305,8 +267,8 @@ ship them bundled; the other three registered embodiments do not:
 | `openarm` | `openarm_lerobot` | 10 | no |
 
 `nvidia/Cosmos3-Edge` documents its forward-dynamics example on `umi` and its
-inverse-dynamics example on `av` — both without bundled quantiles — so
-driving the sim bridge from Edge means supplying that domain's stats yourself:
+inverse-dynamics example on `av` - both without bundled quantiles - so driving
+the sim bridge from Edge means supplying that domain's stats yourself:
 
 ```python
 out = decode_cosmos_chunk_to_targets(
@@ -316,40 +278,17 @@ out = decode_cosmos_chunk_to_targets(
 )
 ```
 
-`stats` takes the quantiles in whatever form you have them — a list straight
-out of a JSON file (the layout the bundled `stats/*_stats.json` files use), a
-tuple, or a NumPy array. Every component must be a finite real number: the
-de-normalization is `0.5 * (a + 1) * (q99 - q01) + q01`, so one `nan` or `inf`
-quantile spreads across the whole chunk and every pose the trajectory composes
-from it, and `denormalize_quantile` refuses it naming the quantile and the
-component rather than returning an all-`nan` trajectory.
-
-`stats_domain` is required whenever `stats` is passed, and must match the
-embodiment's domain. It is not bookkeeping: `umi`, `droid_lerobot`,
-`bridge_orig_lerobot` and `openarm_lerobot` are all 10 columns, so the width
-check cannot tell one
-domain's quantiles from another's, and the two bundled domains disagree by up to
-**2.77x** on the physical translation they decode from the same normalized
-action. Substituting another domain's stats would rescale every commanded pose
-delta with nothing reported.
-
-> **The Cosmos "modes" are not FK/IK.** `policy` / `forward_dynamics` /
-> `inverse_dynamics` are world-model *conditioning* modes (video↔action), not a
-> kinematics solve. Joint-space IK is this separate geometric layer applied
-> *after* Cosmos.
->
-> The reverse map — joints → Cartesian pose — is **forward kinematics**, exposed
-> as `MinkIKBridge.ee_pose(qpos) -> (4, 4)`. Step 2 above anchors the decoded SE3
-> trajectory at the robot's current EE pose via exactly this FK call, and the IK
-> solver uses it internally to score each Cartesian target.
+`stats` takes the quantiles as a list (the layout of the bundled
+`stats/*_stats.json`), tuple or array; every component must be a finite real
+number, since one `nan` quantile would spread through the whole trajectory.
+`stats_domain` is required with `stats` and must match the embodiment's domain:
+four of the five domains are 10 columns wide, so the width check cannot tell
+their quantiles apart, and the two bundled domains disagree by up to **2.77x**
+on the translation they decode from the same normalized action.
 
 ![Cosmos 3 -> MuJoCo: Franka tracking the Cosmos action (left) beside the Cosmos predicted world (right)](../assets/cosmos3/cosmos3_mujoco_sidebyside.gif)
 
 *Left: MuJoCo Franka driven by a **real** `nvidia/Cosmos3-Nano` action chunk through de-normalize → decode → IK. Right: the Cosmos predicted world video from the same forward pass. Runnable: `examples/vla/cosmos3_diffusers_mujoco_rollout.py --render out.mp4`.*
-
-> Install the sim bridge: `uv pip install "strands-robots[cosmos3-sim]"`
-> (pulls `mink` + `mujoco`; numpy>=2 compatible, co-installable with
-> `cosmos3-diffusers` / `cosmos3-service` / `sim-mujoco` / `lerobot`).
 
 ## Rollout
 
@@ -376,5 +315,3 @@ sim.run_policy(
 - [GR00T](groot.md)
 - [LeRobot Local](lerobot-local.md)
 - [Custom policies](custom-policies.md)
-- [cuRobo](curobo.md)
-- [Policy providers](../policies/overview.md)

--- a/docs/policies/kimodo.md
+++ b/docs/policies/kimodo.md
@@ -3,22 +3,10 @@
 `KimodoPolicy` wraps NVIDIA's Kimodo (`nvidia/Kimodo-G1-RP-v1`) text-conditioned
 motion diffusion model. Given a natural-language prompt it samples per-frame
 full-body `qpos` sequences for the Unitree G1 in a single diffusion pass, then
-streams them one frame per tick as G1 joint targets.
-
-Kimodo is a *kinematic motion generator*: it emits motion targets, not torques
-— a whole-body reference over all 29 leg + waist + arm joints. Applying that
-reference under physics needs a controller that *tracks* it; see
-[Tracking the reference under physics](#tracking-the-reference-under-physics).
-
-## When to use
-
-| | Kimodo |
-|---|---|
-| Control input | free-form text prompt |
-| Prompt vocabulary | anything English |
-| Sampler | diffusion (multi-step) |
-| Wall clock (Jetson AGX-class, 100 steps, 120 frames) | ~8 s |
-| Best for | novel motions, prompt engineering |
+streams them one frame per tick as G1 joint targets. It is a *kinematic motion
+generator*: a whole-body reference over all 29 leg + waist + arm joints, not
+torques. It takes free-form English and pays for it with a multi-step diffusion
+sampler (~8 s for 100 steps, 120 frames on a Jetson AGX-class device).
 
 ## Install
 
@@ -27,10 +15,8 @@ pip install "strands-robots[kimodo]"
 ```
 
 The extra installs the `diffusers` loader, which drives any checkpoint published
-in *diffusers pipeline layout*.
-
-Two independent opt-ins guard that loader, and both are off by default. The
-first decides whether the provider may be built at all:
+in *diffusers pipeline layout*. Two independent opt-ins guard that loader, both
+off by default. The first decides whether the provider may be built at all:
 
 ```bash
 export STRANDS_TRUST_REMOTE_CODE=1
@@ -38,8 +24,7 @@ export STRANDS_TRUST_REMOTE_CODE=1
 
 The second decides whether a checkpoint's own Python code may run when it is
 loaded. It is per call, defaults to `False`, and is never set by the environment
-variable above, so opting in to the provider does not also opt in to executing a
-repository's code:
+variable above:
 
 ```python
 sim.run_policy(
@@ -52,19 +37,16 @@ sim.run_policy(
 )
 ```
 
-Leave it unset for any checkpoint that does not genuinely need it; `diffusers`
-reports plainly when a pipeline requires the flag.
-
 Weights are fetched from HuggingFace on first use under the NVIDIA Open Model
 License; nothing is bundled with `strands_robots`.
 
 !!! important "`nvidia/Kimodo-G1-RP-v1` is not a diffusers pipeline"
 
     NVIDIA publishes the Kimodo weights bare — `config.yaml`,
-    `model.safetensors` and `stats/`, with `library_name: kimodo` on the Hub.
-    There is no `model_index.json`, so `DiffusionPipeline.from_pretrained`
-    cannot load it and the default `model_id` is refused at construction. To
-    run the NVIDIA checkpoint, supply its sampler through `motion_agent=` — see
+    `model.safetensors` and `stats/`, `library_name: kimodo` on the Hub, no
+    `model_index.json` — so `DiffusionPipeline.from_pretrained` cannot load it
+    and the default `model_id` is refused at construction. To run the NVIDIA
+    checkpoint, supply its sampler through `motion_agent=` — see
     [Driving the NVIDIA checkpoint](#driving-the-nvidia-checkpoint).
 
 ## Quick start
@@ -95,34 +77,22 @@ sim.run_policy(
 
 ## Tracking the reference under physics
 
-Kimodo is kinematic: it emits joint *targets* for all 29 DOFs, not torques. Run
-standalone (the example above) those targets are applied directly, which is the
-faithful visualisation of the generated motion.
-
-Making the robot follow that motion under physics requires a controller that
-**tracks the reference** — the 29 targets are the tracker's input. Generator and
-tracker therefore run in **series over the same joints**:
+Run standalone (the example above) the 29 targets are applied directly, which is
+the faithful visualisation of the generated motion. Making the robot follow it
+under physics needs a controller that **tracks the reference**, in series over
+the same joints:
 
 ```text
 prompt -> Kimodo -> 29 joint targets -> reference tracker -> torques -> robot
 ```
 
-That is a cascade, and `CompositePolicy` does not express it.
+That tracker is [`ProtoMotionsPolicy`](./protomotions.md), which takes a `qpos`
+clip and emits balanced PD targets. It is a cascade, not a composition:
 [`CompositePolicy`](./custom-policies.md) merges two policies over **disjoint**
-joint groups (locomotion legs+waist plus manipulation arms, each joint owned by
-exactly one child); handing it a whole-body generator and a whole-body controller
-gives both children the same joints, so one child's output is discarded entirely.
-That configuration is refused with an error naming the shadowed joints rather
-than silently returning one child's commands.
-
-[`WBCPolicy`](./wbc.md) in particular is **not** a reference tracker: its only
-command input is a target base velocity (`target_velocity`, plus optional
-orientation and height), it has no reference-pose input, and it drives 15 of the
-same 29 joints Kimodo drives. Composing the two cannot track a Kimodo motion.
-
-`strands_robots` does not currently ship a whole-body reference tracker. A
-tracker matched to the generator's motion distribution (an RL tracker trained on
-it, or a tuned PD law) is required, and is out of scope for this provider.
+joint groups, so handing it a whole-body generator and a whole-body controller
+is refused with the shadowed joints named. [`WBCPolicy`](./wbc.md) is not a
+reference tracker either — its only command is a target base velocity — so
+composing it with Kimodo cannot track a Kimodo motion.
 
 ## Config reference
 
@@ -141,8 +111,9 @@ it, or a tuned PD law) is required, and is out of scope for this provider.
 | `dtype` | str | `"fp16"` | `"fp16"` / `"bf16"` / `"fp32"` |
 | `seed` | int \| None | None | Reproducible sampling. A whole number, either sign, or `None` for fresh entropy |
 
-Every field above is also an explicit keyword argument of `KimodoPolicy`, so it
-can be set three interchangeable ways:
+Every field is also an explicit keyword argument of `KimodoPolicy`, so it can be
+set three interchangeable ways, with precedence per-field override > `config`
+field > default; a merged value is re-validated by `KimodoConfig`:
 
 ```python
 from strands_robots import create_policy
@@ -153,42 +124,25 @@ KimodoPolicy(config=KimodoConfig(diffusion_steps=25))  # a config object
 KimodoPolicy(config={"diffusion_steps": 25})           # a plain dict
 ```
 
-Precedence is per-field override > `config` field > the default in the table. A
-merged value is re-validated by `KimodoConfig`, so `diffusion_steps=0` is
-refused whichever way it arrives - including as the per-call
-`get_actions(..., diffusion_steps=0)` override below, which reaches the sampler
-without passing through the config and so applies the field's domain itself.
+A misspelled knob is refused by the two keyword forms (`TypeError`) and dropped
+by the dict form: `KimodoConfig.from_dict` drops unknown keys for forward
+compatibility, so `config={"diffusion_stpes": 25}` builds with the default 100
+and no warning. Pass the knob as a keyword if a typo should be refused.
 
-A misspelled knob is refused by the two keyword forms and dropped by the dict
-form. Neither `KimodoPolicy` nor `KimodoConfig` takes `**kwargs`, so
-`KimodoPolicy(diffusion_stpes=25)` raises `TypeError` at construction. A
-`config` dict is read by `KimodoConfig.from_dict`, which drops keys that are not
-fields for forward compatibility - the policy the WBC config states for its own
-`from_dict` - so `KimodoPolicy(config={"diffusion_stpes":
-25})` builds with the default 100 and emits no warning. Pass the knob as a
-keyword, or build a `KimodoConfig` first, if a typo should be refused.
-
-### Loading a config from a file
+A config can also come from a JSON object on disk; `from_json` expands `~`,
+names the file in every refusal, and does not check the extension:
 
 ```python
 KimodoPolicy(config=KimodoConfig.from_json("~/kimodo.json"))
 ```
 
-`from_json` expands `~` and names the file in every refusal: a path that is not
-a file raises `FileNotFoundError`, and a file that is not valid JSON or that
-holds a JSON value other than an object raises `ValueError` naming the file and
-what it found instead. Keys inside the object follow the drop policy above, and
-values keep the domains in the table. The extension is not checked, so a JSON
-object stored under any name loads.
-
 ## When the sampler runs again
 
-One `sample()` call produces a motion buffer that `get_actions` then drains one
-frame per control tick, holding the last frame once the buffer is exhausted. The
-buffer is identified by the four inputs that determine it - the prompt plus
-`diffusion_steps`, `guidance_scale` and `seed` - so the sampler runs again as
-soon as any of them differs from the values that produced the buffer in hand,
-and otherwise the buffered frames are reused:
+One `sample()` call produces a motion buffer that `get_actions` drains one frame
+per control tick, holding the last frame once exhausted. The buffer is keyed on
+the four inputs that determine it — the prompt plus `diffusion_steps`,
+`guidance_scale` and `seed` — so the sampler runs again as soon as any of them
+differs, and otherwise the buffered frames are reused:
 
 ```python
 await policy.get_actions({}, "walking forward")                     # samples
@@ -199,39 +153,19 @@ policy.reset()                                                      # rewinds
 policy.reset(seed=7); await policy.get_actions({}, "waving")        # samples
 ```
 
-`diffusion_steps`, `guidance_scale` and `seed` are held to the same domains as
-the config fields when they arrive this way, and are checked before the key is
-built: a refused override raises `ValueError` naming
-`KimodoPolicy.get_actions` and leaves the motion in hand and the frame cursor
-exactly as they were, so it costs neither a diffusion run nor a frame.
-
-This is what makes a multi-episode `eval_policy` meaningful for a stochastic
-policy. `PolicyRunner.evaluate` derives a distinct seed per episode and forwards
-it to `policy.reset(seed=...)`, so each episode samples its own motion while the
-whole run stays reproducible: re-running at the same master `seed=` replays the
-same per-episode motions. Repeating a seed replays the buffered motion rather
-than re-running the sampler for identical frames, and `reset()` without a seed
-only rewinds - neither pays for a diffusion run.
-
-That replay is keyed on the seed, so the seed has to be a whole number and all
-three surfaces that set one enforce it: `KimodoConfig` (however the value
-arrives), `reset(seed=...)` (which stores a per-episode reseed on the frozen
-config and so applies the domain itself), and the per-call `seed` override in
-`get_actions(seed=...)`. A fractional seed would reach the sampler as itself
-and key as `int(seed)`, making `2.5` and `2.9` name one motion - the second
-episode would read as a cache hit and replay the first. `nan` and `inf` cannot
-be keyed at all, and `inf` is what a config file spelling `1e400` parses to.
-Either sign and any width is accepted; a seed too wide for `torch.manual_seed`
-is refused by the applier, which names the overflow itself. A refused
-`reset(seed=...)` or a refused per-call override changes nothing - the held
-motion and the cursor are left as they were.
+Per-call overrides keep the config fields' domains and are checked before the
+key is built, so a refused override costs neither a diffusion run nor a frame.
+The seed must be a whole number on every surface that sets one: a fractional
+seed would key as `int(seed)`, making `2.5` and `2.9` replay one motion. This is
+what makes a multi-episode `eval_policy` meaningful — `PolicyRunner.evaluate`
+hands each episode its own seed through `reset(seed=...)`, so every episode
+samples its own motion and the run replays exactly at the same master `seed=`.
 
 ## Chaining prompts into a long-horizon sequence
 
 Because a changed prompt samples the next segment and the stream simply
 continues, a long-horizon episode is a rollout that changes the instruction as
-it goes — no stitching layer required. Anything that can vary the instruction
-per tick will do; a `policy_object` driven directly is the smallest version:
+it goes; a `policy_object` driven directly is the smallest version:
 
 ```python
 import asyncio
@@ -258,79 +192,26 @@ for instruction, ticks in CHAIN:
 ```
 
 Each segment is sampled once, on the tick its instruction first appears. Kimodo
-samples every motion from its own canonical start pose, which has no relation to
-wherever the previous segment left the robot, so a new segment is eased off the
-pose last commanded across `transition_frames` native frames. Without that the
-seam commands every joint to step at once — measured across the 600 ordered
-pairs of a 25-motion corpus, the median seam moved a joint 1.6 rad in a single
-tick and 84% of transitions exceeded the largest step the motions themselves
-ever take. A reference like that is not one a tracker can follow, and it is
-reported as a successful rollout.
-
-`transition_frames` defaults to 5, the same length Kimodo's own sampler uses for
-`num_transition_frames` when it generates a multi-prompt sequence. Raise it for
-wider pose gaps (opposing poses eased over more frames), lower it toward 1 to
-keep segment boundaries crisp. It is bounded below at 1, matching the domain the
-sampler enforces on its own transition length.
-
-Every channel absorbs its share of the offset the same way, so easing changes
-where a segment starts and not how it moves. Root position and joint angles take
-one offset scaled by the frame's weight. The root's orientation takes the
-rotational form of exactly that: the offset is the rotation carrying the
-segment's own start orientation onto the pose last commanded, and each eased
-frame is its own orientation turned by the weighted share of it. A motion that
-turns therefore keeps its turn rate through the transition, and a seam whose
-orientations already agree leaves the root alone.
-
-Note the difference in kind from the sampler's native multi-prompt path: Kimodo
-conditions the *diffusion* of the next segment on the previous segment's last
-frames, so the generated motion itself leads into the transition. The agent
-protocol here takes only a prompt and sampling knobs, with no continuation
-state, so easing shapes the emitted stream rather than the sample. It removes
-the discontinuity; it does not re-plan the motion around it.
-
-An episode boundary is not a seam. `reset()` forgets the last commanded pose, so
-the next episode opens on its motion's own start pose rather than being eased
-onto wherever the previous episode finished.
+samples every motion from its own canonical start pose, so a new segment is
+eased off the pose last commanded across `transition_frames` native frames
+(default 5, the sampler's own `num_transition_frames`; minimum 1). Without it,
+across the 600 ordered pairs of a 25-motion corpus the median seam moved a joint
+1.6 rad in one tick. Easing shifts where a segment starts, not how it moves (the
+root orientation takes the rotational form of the same offset, so a turn keeps
+its rate); it removes the discontinuity without re-planning the motion. An
+episode boundary is not a seam: `reset()` forgets the last commanded pose.
 
 ## When the checkpoint is not a Kimodo checkpoint
 
 `model_id` is accepted verbatim so an alternate revision can be pinned. Two
-distinct refusals guard that freedom.
-
-**At load time**, a target carrying no `model_index.json` is not a diffusers
-pipeline at all, so no amount of sampling will help. Rather than surface a bare
-404 for a file that will never exist, the loader names the layout mismatch and
-the remedy:
-
-```text
-RuntimeError: Kimodo model_id 'nvidia/Kimodo-G1-RP-v1' is not a diffusers
-pipeline: it carries no model_index.json, so DiffusionPipeline.from_pretrained
-cannot load it. NVIDIA's Kimodo checkpoints publish bare weights (config.yaml
-plus model.safetensors) for their own runtime - the Hub declares library_name
-'kimodo', not 'diffusers'. Pass motion_agent= with a sampler that loads this
-checkpoint through its own runtime and returns a (num_frames, 7+29) qpos array,
-or point model_id at a checkpoint published in diffusers pipeline layout.
-```
-
-A transport failure is *not* reported this way — a 401 or a 503 re-raises
-untouched, so a network problem is never misread as a layout problem.
-
-**At sample time**, a pipeline that loaded but names its output something other
-than `motion` is refused with a `RuntimeError` naming the `model_id` and the
-fields the output *did* carry:
-
-```text
-RuntimeError: Kimodo pipeline output for model_id 'acme/not-kimodo' carries no
-'motion' field: got _SampleOutput with fields sample. Kimodo emits per-frame
-qpos under 'motion' - point model_id at a Kimodo checkpoint, or pass
-motion_agent= to adapt a sampler that names its output differently.
-```
-
-The remedies are the two the message names: point `model_id` at a Kimodo
-checkpoint, or pass a `motion_agent=` adapter that reads the sampler's own
-output field and returns the `(num_frames, 7+29)` `qpos` array this policy
-expects.
+refusals guard that freedom, both `RuntimeError`s naming the `model_id` and the
+two remedies (point `model_id` at a Kimodo checkpoint, or pass a `motion_agent=`
+adapter that returns the `(num_frames, 7+29)` `qpos` array): **at load time**, a
+target with no `model_index.json` is not a diffusers pipeline, so the loader
+names the layout mismatch instead of a bare 404 (a 401 or 503 re-raises
+untouched, so a network problem is never misread as a layout problem); **at
+sample time**, a pipeline whose output carries no `motion` field is refused
+naming the fields it did carry.
 
 ## Driving the NVIDIA checkpoint
 
@@ -379,27 +260,17 @@ sim.run_policy(
 )
 ```
 
-The runtime emits a dict of rotation matrices and root positions, so the
-`MujocoQposConverter` step is what produces the `(num_frames, 7+29)` qpos array
-the agent protocol expects. `guidance_scale` has no counterpart in that runtime
-(its classifier-free-guidance knob is a per-stage `cfg_weight` list) and is
-ignored by this adapter.
+`MujocoQposConverter` turns the runtime's rotation matrices into the
+`(num_frames, 7+29)` array; `guidance_scale` has no counterpart there and is
+ignored. `seed` goes through `torch.manual_seed` because the runtime draws from
+the global generator — an adapter that accepts `seed` and ignores it still
+satisfies the protocol, raises nothing, and defeats the per-episode seed above.
 
-`seed` is applied with `torch.manual_seed` because the runtime draws its initial
-noise from the global torch generator and accepts no generator or seed argument
-of its own. Seeding is what makes the agent reproducible, and it is what an
-adapter is most likely to leave out: an agent that accepts `seed` and ignores it
-still satisfies the protocol, so nothing raises, but every request samples fresh
-noise. That silently defeats the per-episode seed, since `eval_policy` derives
-one seed per episode and hands it to `reset()`, and the policy re-samples
-whenever a sampler input changes. Every episode would then get an independent
-motion no seed can reproduce.
 ## Driving the real robot
 
-Kimodo names its joint targets the way the URDF does (`left_hip_pitch_joint`);
-lerobot's `UnitreeG1` driver names its action keys after its own joint enum
-(`kLeftHipPitch.q`). The two vocabularies name the same 29 joints, so the
-hardware path is a key rename applied between the policy and the driver:
+Kimodo names joints the way the URDF does (`left_hip_pitch_joint`); lerobot's
+`UnitreeG1` driver names its action keys after its own enum (`kLeftHipPitch.q`).
+The hardware path is a key rename between the two:
 
 ```python
 from strands_robots.policies.kimodo.hardware import build_lerobot_g1_action_dict
@@ -408,29 +279,12 @@ for policy_action in await policy.get_actions(observation, instruction):
     robot.send_action(build_lerobot_g1_action_dict(policy_action))
 ```
 
-`get_joint_map()` returns the table itself (`{"left_hip_pitch_joint":
-"kLeftHipPitch.q", ...}`) if you would rather rename in your own loop. Both are
-lerobot-only helpers: `pip install "strands-robots[lerobot]"`. Commanding the
-physical robot additionally needs Unitree's `unitree_sdk2` runtime, which
-lerobot documents separately for its `unitree_g1` robot.
-
-The table pairs joints by name, never by position in the driver enum. That
-matters because the driver applies only the action keys it recognises and leaves
-every other motor on its previous command, so a key paired with the wrong joint
-— or spelled in a way the driver does not know — raises nothing at all and the
-robot simply moves wrong. Pairing by name means a driver-side reorder cannot
-move a target, and a driver-side rename or DOF change is refused with the
-unmatched joints named on both sides instead of being taken on trust:
-
-```text
-RuntimeError: Unitree G1 joint sets disagree between the policy and lerobot's
-driver. Joints the policy commands that the driver does not name:
-['waist_yaw_joint']. Joints the driver names that the policy does not command:
-['kTorsoYaw.q']. ...
-```
-
-The rename is one-way. The driver's `get_observation()` already reports
-`<motor>.q` keys, so the read path needs no inverse table.
+`get_joint_map()` returns the table itself. Both are lerobot-only helpers
+(`pip install "strands-robots[lerobot]"`); the physical robot also needs Unitree's
+`unitree_sdk2`. Joints are paired by name, never by enum position, because the
+driver silently ignores keys it does not know; a driver-side rename or DOF change
+is refused with the unmatched joints named on both sides. The rename is one-way —
+`get_observation()` already reports `<motor>.q` keys.
 
 ## Unit testing without weights
 

--- a/docs/policies/microduck.md
+++ b/docs/policies/microduck.md
@@ -29,15 +29,11 @@ python examples/microduck/render_video.py \
     --gif docs/assets/microduck/microduck_walk.gif
 ```
 
-`render_video.py` steps the sim manually at the control frequency and captures
-each frame with a tracking camera locked to the pelvis, so the duck stays
-centered as it walks. `--vx`/`--vy`/`--vyaw` set the twist command, and any
-weight that runs on the default scene (`alpha_stand`, `roulade`,
-`alpha_sitstand`, `alpha_ground_pick`) drops straight in. The script builds
-`Robot("microduck")`, so the four skills that need a different scene -
-`roller`, `roller_crouch`, `ball_kick_left`, `ball_kick_right` - need the
-scene named for them in [Skill scenes](#skill-scenes) below.
-
+`--vx`/`--vy`/`--vyaw` set the twist command, and any weight that runs on the
+default scene (`alpha_stand`, `roulade`, `alpha_sitstand`, `alpha_ground_pick`)
+drops straight in. The four skills that need a different scene — `roller`,
+`roller_crouch`, `ball_kick_left`, `ball_kick_right` — need it named, see
+[Skill scenes](#skill-scenes).
 
 ## Install
 
@@ -73,10 +69,8 @@ for the runnable script.
 ## Skill scenes
 
 A shipped weight and the scene it was trained in are one pair. `Robot("microduck")`
-resolves the entry's declared asset - flat ground, no props - which is what the
-walking, standing, sitstand, roulade and ground-pick skills need. Four skills
-need something the default scene does not contain, and Pollen ships the scene
-for each one in the same asset directory:
+resolves the entry's declared asset — flat ground, no props; four skills need
+more, and Pollen ships their scenes in the same asset directory:
 
 | skill | scene | what the scene adds |
 | --- | --- | --- |
@@ -84,9 +78,9 @@ for each one in the same asset directory:
 | `roller`, `roller_crouch` | `scene_rollers.xml` | four passive ankle wheels, so the feet can roll |
 | `ball_kick_left`, `ball_kick_right` | `scene_ball.xml` | a 70 mm, 15 g ball placed in front of the duck |
 
-Reach a non-default scene by path. The registry entry names the fourteen-hinge
-model deliberately - it is the layout the catalog documents - so the variants are
-loaded as an explicit asset rather than resolved by name:
+Reach a non-default scene by path; the registry entry deliberately names the
+fourteen-hinge model the catalog documents, so variants load as an explicit
+asset:
 
 ```python
 from pathlib import Path
@@ -105,86 +99,55 @@ sim.reset()
 sim.run_policy(policy_object=MicroduckPolicy(onnx_path="roller.onnx"), duration=8.0)
 ```
 
-Running a skill on the default scene is not an error and reports success: a
-roller policy writes the same fourteen control targets, and with no wheels under
-the feet the duck simply stands; a ball-kick policy swings at a ball that is not
-there. Nothing refuses it, so the scene is the caller's to choose.
+Running a skill on the wrong scene is not an error: a roller policy with no
+wheels simply stands, a ball-kick policy swings at nothing, and both report
+success. The scene is the caller's to choose.
 
 ### The ball scene carries the ball, not the kick geometry
 
-`scene_ball.xml` places the prop, and where it sits is not where the kick policies
-were trained to find it. The scene declares the ball 0.3 m straight ahead
-(`ball.xml`: `pos="0.3 0 0.035"`). Pollen's training reset placed it 0.09 m ahead and
-0.042 m to the side of the kicking foot, in the robot's yaw frame - 3.3x closer, and
-offset laterally to the foot that swings.
-
-Loading the scene is therefore necessary and not sufficient. Driven from the shipped
-position, `ball_kick_left` completes and reports success while no robot body ever
-touches the ball: across a four-second rollout the closest any robot geom comes to the
-ball centre is 0.109 m, against a 0.035 m radius. The ball still travels forward on its
-own - its geom sets a deliberately low rolling resistance - which is why the miss reads
-as a weak kick rather than as a miss.
-
-A caller who wants the trained geometry teleports the ball before the rollout, which is
-what Pollen's runtime does at the moment a kick is triggered: write the ball free
-joint's `qpos` to that offset rotated into the trunk's yaw frame, zero the joint's
-`qvel`, and step. The file names the joint `ball_free`; `add_robot(name=...)` prefixes
-every joint with the name the caller passed, so resolve the name rather than assuming
-either spelling.
+`scene_ball.xml` declares the ball 0.3 m straight ahead (`ball.xml`:
+`pos="0.3 0 0.035"`). Pollen's training reset placed it 0.09 m ahead and
+0.042 m to the side of the kicking foot, in the robot's yaw frame — 3.3x closer
+and offset to the foot that swings. Driven from the shipped position,
+`ball_kick_left` reports success while no robot geom comes closer than 0.109 m
+to the ball centre (radius 0.035 m); the ball's low rolling resistance still
+carries it forward, so the miss reads as a weak kick. For the trained geometry,
+teleport the ball before the rollout as Pollen's runtime does: write the ball
+free joint's `qpos` to that offset rotated into the trunk's yaw frame, zero its
+`qvel`, step. The file names the joint `ball_free`, but `add_robot(name=...)`
+prefixes every joint with the caller's name, so resolve the name rather than
+assuming either spelling.
 
 ### Reading joint positions on the rollers scene
 
 `scene_ball.xml` appends the ball's free joint after the robot's, so the robot's
-`qpos` layout is byte-for-byte the default one. `scene_rollers.xml` does not:
-it inserts two passive wheel joints after `left_ankle` and two more after
-`right_ankle`, which moves nine of the fourteen actuated joints to a different
-`qpos` index. A consumer that reads a flat `qpos[7:21]` slice therefore reads
-different joints there - the two left wheels arrive where `neck_pitch` and
-`head_pitch` sit on the default scene.
-
-The actuator order is identical across all three scenes, so a policy writing
-`ctrl` is unaffected, and `MicroduckPolicy` reads its observation by joint name
-rather than by slice, so the provider is immune either way. Only a raw position
-read has to care.
+`qpos` layout is the default one. `scene_rollers.xml` inserts two passive wheel
+joints after each ankle, which moves nine of the fourteen actuated joints to a
+different `qpos` index — a flat `qpos[7:21]` read gets the two left wheels where
+`neck_pitch` and `head_pitch` sit on the default scene. The actuator order is
+identical across all three scenes and `MicroduckPolicy` reads by joint name, so
+only a raw position read has to care.
 
 ### The stance every weight was trained in
 
-A weight and its scene are one pair; so are a weight and the stance it starts
-from. Every shipped Pollen weight bakes that stance into its ONNX metadata as
-`default_joint_pos`, and all nine declare the same fourteen values.
-`MicroduckPolicy` reads it into `default_pose` and decodes every action relative
-to it - `motor_target = default_pose + raw_action * action_scale` - so the stance
-is not advice, it is the origin the network's output is measured from. The same
-values ship as `strands_robots.policies.microduck.MICRODUCK_DEFAULT_POSE`, the
-fallback the provider uses when a session carrying no metadata is injected.
-
-The asset ships that stance too, as the `STAND` keyframe in `scene.xml` and
-`scene_rollers.xml`. Name it at spawn and the robot starts there:
+Every shipped weight bakes its start stance into the ONNX metadata as
+`default_joint_pos` (all nine declare the same fourteen values); actions decode
+as `motor_target = default_pose + raw_action * action_scale`, so the stance is
+the origin the network's output is measured from. The same values ship as
+`strands_robots.policies.microduck.MICRODUCK_DEFAULT_POSE`. The asset carries
+the stance as the `STAND` keyframe of `scene.xml` and `scene_rollers.xml`; name
+it at spawn and every `reset()` restores it:
 
 ```python
 sim = Robot("microduck", urdf_path=str(scene), keyframe="STAND")
 ```
 
-A keyframe spawn is sticky across resets: `sim.reset()` restores the pose and the
-actuator command that holds it, so every episode of a `run_policy` + `reset` loop
-begins from the same stance.
-
-Spawning without `keyframe` is not an error and reports success. The robot starts
-at the zero configuration, 0.458 rad from the trained stance at the widest joint
-- legs straight rather than crouched - while the policy still decodes relative to
-the stance it expects. Nothing refuses it, so the first inference of the rollout
-reads a pose no shipped weight was trained on.
-
-Two details a caller meets:
-
-- The keyframe is named `STAND`. The asset's own comment calls the current values
-  "STAND2", because they supersede an earlier `STAND` that is commented out
-  beside them; the live keyframe kept the name. `keyframe="STAND2"` is refused,
-  and the refusal names the keyframes the model does declare.
-- `scene_ball.xml` declares no keyframe at all, so the route above is unavailable
-  on the one scene a ball kick needs. Seat the stance yourself there, reading it
-  from `MICRODUCK_DEFAULT_POSE` rather than copying the numbers - the asset has
-  already revised this pose once.
+Spawning without `keyframe` is not an error: the robot starts at the zero
+configuration, 0.458 rad from the trained stance at the widest joint. The live
+keyframe is `STAND` although the asset's comment calls the values "STAND2"
+(`keyframe="STAND2"` is refused naming the declared keyframes), and
+`scene_ball.xml` declares no keyframe at all — seat the stance there yourself
+from `MICRODUCK_DEFAULT_POSE`, not copied numbers.
 
 ## The observation contract
 
@@ -202,17 +165,11 @@ The vector is a fixed float32 concatenation (measured off Pollen's reference
 
 Total width is `48 + C`: **61** for the shipped alpha policies (C = 13) and 51
 for legacy twist-only policies (C = 3). The width is read from `command_names`,
-never hardcoded, and unused command slots stay present and zero (the
-dead-weight rule) so one observation layout serves every skill. Actions decode
-as `motor_target = DEFAULT_POSE + action * action_scale`.
-
-`action_scale` is the only path from the network's output to the joint targets,
-so it must be a positive finite number. A scale of `0` would make every target
-exactly `DEFAULT_POSE` — the network's decision discarded and the biped holding
-its nominal stance while the rollout reports success — and a non-finite one
-would make all fourteen targets `nan`. Both routes to the decode are held to
-that domain: an explicit `action_scale=` and the value read from the ONNX
-`action_scale` metadata.
+never hardcoded, and unused command slots stay present and zero so one layout
+serves every skill. `action_scale` — explicit or read from the ONNX metadata —
+must be a positive finite number: `0` would make every target exactly
+`DEFAULT_POSE` while the rollout reports success, and a non-finite one would
+make all fourteen targets `nan`.
 
 ## Commanding motion
 
@@ -224,23 +181,15 @@ wholesale with `command=`:
 await policy.get_actions(obs, "", target_velocity=[0.3, 0.0, 0.2])  # vx, vy, ω
 ```
 
-`target_velocity` takes three components (`[vx, vy, omega]`) or two
-(`[vx, vy]`, which leaves `omega` at its current value - the command vector
-persists across ticks). Any other component count is refused rather than
-truncated or partially written, and a `nan`/`inf` component is refused before it
-reaches the command; `command=` must be `command_names`-wide and finite for the
-same reasons.
-
-What the twist slots MEAN, however, is a property of the loaded weights rather
-than of this provider. Pollen's locomotion exports (`alpha_walking`,
-`alpha_stand`, the `roller*` pair) read them as a velocity, which is exactly what
-`target_velocity` writes. Other exports in the family read the same three slots
-differently - `alpha_ground_pick`, for instance, reads them as a progress
-encoding through a one-shot motion rather than as a velocity - and for those a
-caller supplies the slots wholesale through `command=` and advances them itself.
-`target_velocity` is a locomotion kwarg, not a universal one, and the ONNX
-metadata does not distinguish the two: several exports declare the same
-`command_names` (`twist`) while reading it under different conventions.
+`target_velocity` takes three components or two (`[vx, vy]`, leaving `omega` as
+it was — the command vector persists across ticks); any other count, or a
+non-finite component, is refused before it reaches the command, and `command=`
+must be `command_names`-wide and finite. What the twist slots MEAN is a property
+of the weights: the locomotion exports (`alpha_walking`, `alpha_stand`, the
+`roller*` pair) read them as a velocity, but `alpha_ground_pick` reads the same
+three slots as a progress encoding through a one-shot motion, and the ONNX
+metadata does not distinguish the two. For those, supply the slots through
+`command=` and advance them yourself.
 
 ## Hot-swapping skills
 
@@ -262,37 +211,14 @@ bundle = MicroduckPolicyBundle(
 ```
 
 Select explicitly with `get_actions(..., select="walk")` or `bundle.switch(...)`.
-
-An explicit selection is not undone by the gate: it arbitrates *between*
-`move_key` and `idle_key`, and leaves any other skill alone until a gate key is
-selected again. That matters most for `alpha_sitstand`, whose `twist[0]` is a
-posture flag (`1` sit, `0` stand) rather than a velocity — both of its commands
-have a magnitude the gate would otherwise read as a walk or an idle request, so
-neither would have reached the skill that was asked for.
-
-`switch_on_velocity` must be a positive finite number. The gate compares a
-magnitude, so a threshold of `0` or below could never select the idle skill and
-a non-finite one could never select the move skill. Omit it (the default) to
-leave the gate off and switch only explicitly.
-
-The velocity it is compared against is held to the same standard as the threshold
-it is compared with. With the gate on, a `target_velocity` this tick cannot honor
-is refused before the gate arbitrates, naming the bundle and the parameter — so a
-refused tick leaves the active skill exactly as it was, rather than selecting the
-idle skill from a `nan` magnitude and keeping that selection on every tick after.
-The accepted values are the ones the active skill accepts: finite numeric
-components, and the same two component counts documented above. An absent
-`target_velocity` is still simply "no goal this tick" and leaves the selection
-alone.
-
-`move_key` and `idle_key` name the two skills that gate selects between, and each
-must be one of the bundle's own keys whenever the gate is enabled. The gate reads
-both every tick, so a key naming no held skill leaves it inert rather than
-failing — a bundle keyed by the weight names it loads (`alpha_walking`,
-`alpha_stand`) and left on the defaults `"walk"`/`"stand"` constructs, reports a
-validated threshold, and then never switches. Key by the names the gate expects,
-or pass `move_key=`/`idle_key=` to match the keys you used. With the gate off
-neither is read, and neither is checked.
+The gate arbitrates only *between* `move_key` and `idle_key` (defaults `"walk"` /
+`"stand"`) and leaves any other explicit selection alone — which is what lets
+`alpha_sitstand`, whose `twist[0]` is a posture flag, be selected at all.
+`switch_on_velocity` must be positive and finite (omit it to switch only
+explicitly); a `target_velocity` the active skill would refuse is refused before
+the gate reads it, so the selection never sticks on a `nan` magnitude; and with
+the gate on both keys must name held skills — a bundle keyed by weight names and
+left on the default keys constructs, validates, and never switches.
 
 ## Byte-compatibility
 

--- a/docs/policies/wbc.md
+++ b/docs/policies/wbc.md
@@ -8,18 +8,15 @@ description: NVIDIA GR00T Whole-Body-Control (SONIC) humanoid locomotion - in-pr
 wraps NVIDIA's
 [GR00T Whole-Body-Control](https://github.com/NVlabs/GR00T-WholeBodyControl)
 (SONIC / decoupled-WBC) ONNX controllers for deploy-grade humanoid locomotion
-on the Unitree G1. Like [cuRobo](curobo.md) it runs **in the same process**
-(via ONNX Runtime - no sidecar, no network round-trip), but unlike cuRobo it
-needs no GPU: the ONNX sessions run on CPU.
+on the Unitree G1. It runs **in the same process** through ONNX Runtime on CPU:
+no sidecar, no network round-trip, no GPU.
 
-It is a non-VLA, locomotion controller: it reads its goal from the well-known
+It is a non-VLA locomotion controller: it reads its goal from the well-known
 locomotion `**kwargs` (`target_velocity`), ignores camera frames
-(`requires_images = False`), and never parses the instruction string for
-control. The controller drives the **15 leg+waist DOFs** of the G1; the arm
-joints are held at their nominal defaults. To drive the arms as well, layer an
-upper-body manipulation policy (e.g. GR00T) on top of WBC locomotion with
-[`CompositePolicy`](#composing-an-upper-body-manipulation-on-top-of-wbc): WBC
-keeps the robot balanced and walking while the upper policy owns the arm joints.
+(`requires_images = False`), and never parses the instruction string. It drives
+the **15 leg+waist DOFs** of the G1 and holds the arms at their nominal defaults;
+to drive the arms as well, layer a manipulation policy on top with
+[`CompositePolicy`](#composing-an-upper-body-manipulation-on-top-of-wbc).
 
 ## Install
 
@@ -28,11 +25,11 @@ pip install "strands-robots[wbc]"            # onnxruntime only - light, no torc
 pip install "strands-robots[wbc,sim-mujoco]" # + MuJoCo to drive the G1 in sim
 ```
 
-No model weights are bundled and there is no default download: a bare
-`create_policy("wbc")` raises an actionable error instead of fetching the wrong
-model family. The decoupled-WBC G1 policies live in the
+No weights are bundled and there is no default download: a bare
+`create_policy("wbc")` raises instead of fetching the wrong model family. The
+decoupled-WBC G1 policies live in the
 [`NVlabs/GR00T-WholeBodyControl`](https://github.com/NVlabs/GR00T-WholeBodyControl)
-git-LFS tree at `decoupled_wbc/sim2mujoco/resources/robots/g1/policy/`:
+git-LFS tree:
 
 ```bash
 git clone https://github.com/NVlabs/GR00T-WholeBodyControl.git   # 4.6G LFS
@@ -42,9 +39,8 @@ GR00T-WholeBodyControl-{Balance,Walk}.onnx /path/to/grootwbc-g1/
 ```
 
 The canonical `GR00T-WholeBodyControl-Balance.onnx` / `-Walk.onnx` filenames are
-accepted verbatim - no rename is needed. The conventional `policy.onnx` /
-`walk_policy.onnx` names also work and take precedence when both are present, so
-either layout is valid:
+accepted verbatim; `policy.onnx` / `walk_policy.onnx` also work and take
+precedence when both are present:
 
 ```text
 /path/to/grootwbc-g1/
@@ -53,10 +49,9 @@ either layout is valid:
     config.json                           # optional
 ```
 
-Note: the HuggingFace repo
-[`nvidia/GEAR-SONIC`](https://huggingface.co/nvidia/GEAR-SONIC) is the SONIC VLA
-inference stack (encoder/decoder/planner ONNX), **not** this decoupled-WBC
-Balance/Walk family; passing it as a checkpoint raises a clear error.
+The HuggingFace repo [`nvidia/GEAR-SONIC`](https://huggingface.co/nvidia/GEAR-SONIC)
+is the SONIC VLA inference stack, **not** this Balance/Walk family; passing it as
+a checkpoint raises.
 
 ## Quickstart
 
@@ -103,11 +98,9 @@ construction - WBC never falls back to silent zero torques.
 
 ### Config value domain
 
-`WBCConfig` rejects an unusable *value* at construction, not just an impossible
-dimension - the same reason a bad dimension is refused there. Every numeric
+`WBCConfig` refuses an unusable *value* at construction, because every numeric
 field is read verbatim into the PD law that writes `data.ctrl` or into the
-observation the network sees, so an unusable one becomes a wrong torque rather
-than an error:
+observation, so an unusable one becomes a wrong torque rather than an error:
 
 | Field | Accepted | Why |
 |-------|----------|-----|
@@ -117,11 +110,8 @@ than an error:
 | `cmd_scale`, `obs_scales` (arity) | stated, or empty to mean the upstream default | An EMPTY `cmd_scale` means "not stated" and is completed with `(2.0, 2.0, 0.5)` at construction, so it cannot scale the velocity differently from omitting the argument. A wrong NON-empty length is still refused by name. |
 | `obs_scales` values, `height_cmd`, `freq_cmd` | finite | A non-finite scale poisons the observation frame the network is given. |
 
-A `nan`/`inf` anywhere reaches `data.ctrl` as a non-finite torque on all
-`num_actions` joints; a `None` or a numeric string raises from the `float()`
-inside `compute_targets`, which runs per tick inside `get_actions` - after the
-ONNX sessions have loaded and the rollout has started. Both now surface as a
-`ValueError` naming the field (and the component index) at construction.
+A `nan`/`inf` or a `None` anywhere surfaces as a `ValueError` naming the field
+and component at construction, not as a non-finite torque mid-rollout.
 
 ## Goal kwargs
 
@@ -135,81 +125,45 @@ coupling to a backend:
 | `target_orientation` | `list[float]` | numeric, >= 3 entries, every component finite | Target base `[roll, pitch, yaw]` (rad), written to command slots `[4:7]`. Defaults to the config `rpy_cmd` (`[0,0,0]`). |
 | `height` | `float` | finite | Target base height (m), written to command slot `[3]`. Defaults to the config `height_cmd` (`0.74`). |
 
-A per-call `target_velocity` overrides the constructor-time default. With no
-command at all the controller holds a standing balance (zero velocity, default
-height + level orientation). Omitting a key (or passing `None`) selects the next
-source in the precedence chain, so `None` is how a kwarg spells "not supplied".
-
-`target_velocity` is one of the issue #300 well-known goal keys, so the mesh
-path forwards it the same way it forwards a planner's goal:
+A per-call `target_velocity` overrides the constructor-time default; with no
+command the controller holds a standing balance, and `None` means "not
+supplied". `target_velocity` is one of the issue #300 well-known goal keys, so
+the mesh path forwards it the same way it forwards a planner's goal:
 `mesh.tell(peer, "walk forward", policy_provider="wbc", target_velocity=[0.5, 0.0, 0.0])`.
-It travels as a per-call kwarg, which is why it overrides the constructor
-default rather than being read as one. `target_orientation` and `height` are
-WBC's own kwargs rather than part of that shared vocabulary - set them on a
-local `run_policy(policy_kwargs=...)` call, or as constructor defaults.
-
-Each key's accepted domain is the one `WBCConfig` enforces for the field it
-overrides - `height` for `height_cmd`, `target_orientation` for `rpy_cmd` - so a
-value the config refuses is not reachable through the kwarg documented to take
-precedence over it. Both vector keys additionally require at least three
-components: the command block is zero-initialised, so accepting a shorter
-`target_orientation` would leave the axes it omits at `0.0` rather than at the
-configured `rpy_cmd` value the omitted kwarg falls back to - silently commanding
-zero for an axis the caller never mentioned. A LONGER sequence is accepted and
-truncated to the slots available, since every component the block has room for is
-honored and only the surplus is dropped. The command block is the observation's first `command_dim`
-entries, so a non-finite component is not one wrong slot: the network is dense,
-so it reaches all `num_actions` joint targets, every one is then refused by
-`send_action`, and the rollout aborts reporting *"100% unresolved keys ... the
-robot has not moved"* - a message about the embodiment, for a bad `height`.
+`target_orientation` and `height` are WBC's own kwargs. Each key keeps the
+domain `WBCConfig` enforces for the field it overrides; the vector keys need at
+least three components because the command block is zero-initialised, so a
+shorter one would silently command zero for an unmentioned axis (a longer one is
+truncated).
 
 ## Control contract
 
 WBC reproduces the upstream `GearWbcController` loop (NVlabs/GR00T-WholeBodyControl
 `decoupled_wbc/sim2mujoco`, `run_mujoco_gear_wbc.py` + `g1_gear_wbc.yaml`):
 
-- **Two ONNX sessions** - a main `policy.onnx` and an optional `walk_policy.onnx`,
-  loaded once at construction. Selection matches upstream: when the **raw**
-  velocity-command norm is `<= 0.05` the robot is "standing" and the main policy
-  runs; above that the walk policy runs (when `walk=True`).
+- **Two ONNX sessions** - `policy.onnx` and an optional `walk_policy.onnx`,
+  loaded once. When the **raw** velocity-command norm is `<= 0.05` the main
+  (standing) policy runs; above that the walk policy (when `walk=True`).
 - **Observation** - an 86-dim frame stacked over `obs_history_len` (default 6,
-  so the network input is `86 * 6 = 516`):
-  - command `[0:7]` = `[vx*2.0, vy*2.0, omega*0.5, height, roll, pitch, yaw]`
-  - base angular velocity `[7:10]` (scaled by `ang_vel_scale=0.5`)
-  - projected gravity `[10:13]`
-  - joint positions `[13:28]` (minus `default_angles`, scaled by `dof_pos_scale`)
-  - joint velocities `[28:43]` (scaled by `dof_vel_scale=0.05`)
-  - previous action `[43:58]`; indices `[58:86]` are a reserved (zero) tail.
-
-  The upstream YAML spells these three scales as flat `ang_vel_scale` /
-  `dof_pos_scale` / `dof_vel_scale` keys, and `WBCConfig` normalises them into
-  the nested `obs_scales` map. A config only has to state the scales it wants to
-  change: the rest keep the upstream defaults above, so naming one scale never
-  changes what an unnamed sibling is scaled by. `config.obs_scales` is therefore
-  always the complete map the frame is built with, whichever spelling the config
-  used.
-
-  `cmd_scale` - the velocity scale of the command block - is completed the same
-  way and for the same reason: an empty sequence means "not stated" and resolves
-  to the upstream `(2.0, 2.0, 0.5)`, so `config.cmd_scale` is always the vector
-  the block is built with. Both `_resolve_command` implementations resolve a
-  component the config does not supply from that same table rather than from a
-  bare `1.0` - a second fallback number would scale `omega` by `1.0` where the
-  table says `0.5`, commanding a yaw rate DOUBLE the one asked for (and `vx`/`vy`
-  halved) in the observation's first `command_dim` entries, which a dense network
-  carries to all `num_actions` joint targets. A `cmd_scale` a caller does state is
-  always honored, including a deliberate unit scale.
-- **Action** - the network emits a 15-dim joint-position *offset*; the policy
-  forms absolute targets `target_q = default_angles + action_scale * raw` and
-  returns them keyed by actuator name. For torque-actuated MuJoCo, convert with
-  the upstream PD law via `policy.compute_torques(target, q, dq)`.
+  network input `86 * 6 = 516`): command `[0:7]` =
+  `[vx*2.0, vy*2.0, omega*0.5, height, roll, pitch, yaw]`, base angular velocity
+  `[7:10]` (`ang_vel_scale=0.5`), projected gravity `[10:13]`, joint positions
+  `[13:28]` (minus `default_angles`, `dof_pos_scale`), joint velocities
+  `[28:43]` (`dof_vel_scale=0.05`), previous action `[43:58]`, reserved zero tail
+  `[58:86]`. The upstream YAML's flat scale keys are normalised into the nested
+  `obs_scales` map, and a config states only the scales it changes; the rest keep
+  the upstream defaults. An empty `cmd_scale` means "not stated" and resolves to
+  `(2.0, 2.0, 0.5)`, never to a bare `1.0` - which would command a yaw rate
+  double the one asked for.
+- **Action** - a 15-dim joint-position *offset*; the policy forms
+  `target_q = default_angles + action_scale * raw`, keyed by actuator name. For
+  torque-actuated MuJoCo, convert with `policy.compute_torques(target, q, dq)`.
 
 ## Actuator mapping
 
-WBC output index `i` drives `WBC_G1_LEG_WAIST_JOINTS[i]` - an explicit table
-(no positional guessing). `set_robot_state_keys` validates that the robot's
-first 15 joints match this order and raises otherwise, so a mismatched model
-can never silently actuate the wrong joints:
+WBC output index `i` drives `WBC_G1_LEG_WAIST_JOINTS[i]` - an explicit table.
+`set_robot_state_keys` validates that the robot's first 15 joints match this
+order and raises otherwise:
 
 ```
 left_hip_pitch_joint, left_hip_roll_joint, left_hip_yaw_joint,
@@ -237,68 +191,41 @@ sim.run_policy(
 )
 ```
 
-`run_policy` writes a policy's joint-position **targets** straight to the sim's
-actuators, but the stock Menagerie G1 ships *position-servo* actuators with a
-uniform `kp=500` gain that overrides SONIC's tuned per-joint PD - so driving
-those servos directly diverges and the robot falls. To make this quickstart
-just work, `run_policy` auto-detects a `WBCPolicy` on a position-servo scene and
-installs the torque shim (the `WBCTorqueController` PD->torque loop) for the
-duration of the call, then hands the world back afterwards: the controller is
-deregistered from the action-controller seam **and** the actuators are restored,
-so a second `run_policy` on the same sim installs a fresh shim and behaves
-exactly like the first. Constructing the shim directly takes
-`physics_substeps_per_control` - the `mj_step` calls one action is held for,
-which at the SONIC 0.005 s timestep makes the upstream `control_decimation=4`
-one inference per 20 ms (50 Hz). It is the same quantity as `control_substeps`
-and `send_action(n_substeps=)`, held to the same domain: a non-positive or
-non-integral count is refused rather than clamped, because the gait clock
-integrates at the declared control period, so a count other than the one asked
-for would run the gait at a rhythm nobody commanded. With the real
-`GR00T-WholeBodyControl-{Balance,Walk}.onnx` weights and `target_velocity =
-[0.5, 0, 0]` the base advances ~1.9 m over 5 s while holding pelvis height
-~0.75 m and staying upright. Pass `wbc_install_torque_control=False` to opt out
-(e.g. to drive a torque-actuated scene directly or manage the controller
-yourself):
+The stock Menagerie G1 ships *position-servo* actuators with a uniform `kp=500`
+that overrides SONIC's tuned PD, so writing targets to them directly makes the
+robot fall. `run_policy` therefore detects a `WBCPolicy` on a position-servo
+scene and installs the torque shim (`WBCTorqueController`, PD->torque) for the
+call, restoring the actuators afterwards so a second call behaves like the
+first. The shim's `physics_substeps_per_control` (upstream `control_decimation=4`
+at 0.005 s = one inference per 20 ms) must be a positive integer, because the
+gait clock integrates at the declared period. With the real weights and
+`target_velocity = [0.5, 0, 0]` the base advances ~1.9 m over 5 s at pelvis
+height ~0.75 m. Opt out to drive a torque scene directly:
 
 ```python
 sim.run_policy(..., policy_provider="wbc", wbc_install_torque_control=False)
 ```
 
-The per-call command rides through `run_policy`'s `policy_kwargs` to
-`policy.get_actions(..., target_velocity=[...])`. A *static* walk can also be
-set once at construction via `policy_config={"checkpoint": ..., "target_velocity":
-[0.5, 0.0, 0.0]}` (the value forwarded to the policy constructor), which is how a
-command reaches the policy over the mesh `tell()` path.
-
-> **Note:** `policy_kwargs` is wired on the control/deploy path
-> (`run_policy` / `start_policy` / mesh `tell()`), not the evaluation path.
-> `eval_policy` / `evaluate_benchmark` are instruction-driven (built for
-> task-success benchmarks); to evaluate WBC at a fixed velocity, set it once via
-> the constructor `target_velocity` (above). Per-episode velocity variation in
-> eval is out of scope for this provider.
+A *static* velocity can be set once via
+`policy_config={"checkpoint": ..., "target_velocity": [0.5, 0.0, 0.0]}`; that is
+also the way to evaluate WBC at a fixed velocity, since `policy_kwargs` is wired
+on the control path (`run_policy` / `start_policy` / `tell()`), not on
+`eval_policy`.
 
 ## Watching it walk (torque-control deploy)
 
-The `sim.run_policy` path above already produces a stable gait: it auto-installs
-the torque shim that converts the policy's joint-position **targets** to
-**torque** via SONIC's per-joint PD law (the stock position-servo actuators
-alone diverge - see the note in [In simulation](#in-simulation)).
-
-For a self-contained, low-level reference - building the torque-actuated G1,
-running `policy.compute_torques(...)` at `control_decimation=4`, and rendering -
 [`examples/wbc/wbc_g1_torque_deploy.py`](https://github.com/strands-labs/robots/blob/main/examples/wbc/wbc_g1_torque_deploy.py)
-reproduces the upstream deploy loop directly - torque motors, `policy.compute_torques(...)` at
-`control_decimation=4`, whole-body observation with real joint velocities + base
-IMU - and is the right way to see the G1 actually locomote:
+reproduces the upstream deploy loop directly - torque motors,
+`policy.compute_torques(...)` at `control_decimation=4`, whole-body observation
+with real joint velocities + base IMU:
 
 ```bash
 python examples/wbc/wbc_g1_torque_deploy.py --checkpoint /path/to/grootwbc-g1 \
     --duration 5 --vx 0.5 --mp4 /tmp/g1_walk.mp4
 ```
 
-With the real `GR00T-WholeBodyControl-{Balance,Walk}.onnx` weights this produces
-a stable forward walk (the base advances ~0.38 m/s for a 0.5 m/s command while
-holding height); a standing command (`--vx 0`) holds balance in place.
+With the real weights this produces a stable forward walk (~0.38 m/s for a
+0.5 m/s command); `--vx 0` holds balance in place.
 
 <figure markdown>
   ![Unitree G1 walking forward under WBC torque control](../assets/wbc/g1_walk.gif)
@@ -311,11 +238,9 @@ holding height); a standing command (`--vx 0`) holds balance in place.
 
 ## Composing an upper body (manipulation on top of WBC)
 
-`WBCPolicy` drives the 15 leg+waist DOFs and holds the arms at their defaults.
 To layer a manipulation policy on the arms while WBC keeps the robot balanced
-and walking, wrap both in
-[`CompositePolicy`](custom-policies.md): the lower policy owns the
-legs+waist joints, the upper policy owns the arms, and the composite queries
+and walking, wrap both in [`CompositePolicy`](custom-policies.md): the lower
+policy owns legs+waist, the upper policy owns the arms, and the composite queries
 both each tick and merges their action dicts by joint name.
 
 ```python
@@ -334,29 +259,15 @@ policy = CompositePolicy(
 )
 ```
 
-Routing is explicit: with `lower_joints` / `upper_joints` set, each child
-contributes only its own joint group (foreign keys are dropped). Left default,
-the lower policy takes precedence on any name it emits and the upper policy
-fills the rest. A genuine ownership conflict (both children claim the same
-joint) is raised, never silently resolved. The merged chunk length is the
-shorter of the two, so a per-tick controller (WBC, `execution_horizon == 1`) is
-never starved by a slower chunk-emitting manipulation policy.
-
-`lower_obs_keys` / `upper_obs_keys` narrow what each child is *queried* with,
-and are optional - left unset, both children receive the whole observation and
-read it by name. The key names belong to whatever produced the observation (a
-simulated world names them after the robot's own joints and cameras, a LeRobot
-dataset spells the joint reading `observation.state`), so a subset that shares
-no key with the observation is refused rather than forwarded as an empty dict:
-a child queried with nothing commands its joints from no reading at all, which
-on a humanoid is the balance controller running open-loop. A subset that
-matches only *some* of its keys is still forwarded - the child got what it
-asked for and reads by name.
-
-Run the composite the same way as a bare policy - the goal payload goes in
-`policy_kwargs`, and the torque shim
-([In simulation](#in-simulation)) is auto-installed for the
-`WBCPolicy` inside the composite just as it is for a bare one:
+Each child contributes only its own joint group; a genuine ownership conflict
+is raised, never silently resolved, and the merged chunk length is the shorter
+of the two so the per-tick controller is never starved. `lower_obs_keys` /
+`upper_obs_keys` optionally narrow what each child is queried with, and a subset
+sharing no key with the observation is refused - a balance controller reading
+nothing runs open-loop. Run the composite like a bare policy; the torque shim is
+installed for the `WBCPolicy` inside it (or inside a `PersistentPolicy`) and
+runs a light PD (`kp = 100`, `kd = 0.5`) on each arm joint toward the upper
+policy's target:
 
 ```python
 sim.run_policy(
@@ -368,16 +279,9 @@ sim.run_policy(
 )
 ```
 
-The shim drives the legs+waist with SONIC's PD law and runs a light position PD
-(`kp = 100`, `kd = 0.5`) on each arm joint toward whatever target the upper
-policy commands for it, holding the nominal pose for any arm joint left
-unnamed. The same applies to a `WBCPolicy` held warm by a `PersistentPolicy`:
-the shim follows the policy that drives the joints, not the type of the object
-passed to `run_policy`.
-
 [`examples/wbc/wbc_g1_composite.py`](https://github.com/strands-labs/robots/blob/main/examples/wbc/wbc_g1_composite.py)
-runs the composite in the torque-deploy loop with a zero-dependency scripted
-arm-wave as the upper body (swap in `--upper-port` for a real GR00T server):
+runs the composite in the torque-deploy loop with a scripted arm-wave as the
+upper body (`--upper-port` for a real GR00T server):
 
 ```bash
 python examples/wbc/wbc_g1_composite.py --checkpoint /path/to/grootwbc-g1 \
@@ -404,8 +308,6 @@ implemented by `WBCGaitPolicy` (provider `wbc_gait`). See
 ## See also
 
 - [Policy overview](overview.md)
-- [cuRobo](curobo.md) - in-process CUDA collision-aware planning (non-VLA).
-- [MoveIt2](moveit2.md) - ROS 2 sidecar collision-aware planning (non-VLA).
 - [GR00T](groot.md) - ZMQ service VLA (manipulation upper body).
 - [Custom policies](custom-policies.md) - implement the non-VLA goal-kwargs contract.
 - [GR00T-WholeBodyControl](https://github.com/NVlabs/GR00T-WholeBodyControl)


### PR DESCRIPTION
## What

Four provider pages restated the same contract facts in successive paragraphs of refusal prose. Each fact is now stated once. Docs-only: **0 `.py` files**, 4 files, **+287/-668 (-381 net)**.

![words before/after and structure kept](https://raw.githubusercontent.com/cagataycali/robots/d35833921272a2d156a014242014492368b2d443/docs468.png)

| page | words | lines | python fences | table rows | headings | `STRANDS_` vars |
|---|---|---|---|---|---|---|
| kimodo | 2856 -> 1621 | 442 -> 296 | 8 -> 8 | 19 -> 12 | 14 -> 12 | 1 -> 1 |
| wbc | 2912 -> 1891 | 411 -> 313 | 6 -> 6 | 12 -> 12 | 15 -> 15 | 2 -> 2 |
| microduck | 2158 -> 1412 | 303 -> 229 | 5 -> 5 | 13 -> 13 | 12 -> 12 | 0 -> 0 |
| cosmos3 | 2531 -> 1876 | 380 -> 317 | 8 -> 8 | 27 -> 27 | 21 -> 21 | 0 -> 0 |

## Why

Every python fence is preserved **byte-identical** (27 of 27) and no env var is dropped, so nothing a reader copies or a grader executes changed. Only prose was cut. kimodo also drops three `text` fences and a degenerate one-column comparison table whose facts (free-form English input, ~8 s for 100 steps / 120 frames on Jetson AGX-class) now open the page.

`target_velocity`'s locomotion-envelope note is kept verbatim.

## Tests

`mkdocs build --strict` clean. Full `tests/`: **50,523 passed / 308 skipped / 0 failed**. `ruff check`/`format` on `strands_robots tests tests_integ` clean. The kimodo graders that *execute* the documented `NativeKimodoAgent` block and pin `KimodoConfig.from_dict` still pass.