### PR TITLE
fix(simulation): get_robot_state names torque-only actuation

### DIFF
--- a/changelog.d/3442-sim-torque-actuator-hint.md
+++ b/changelog.d/3442-sim-torque-actuator-hint.md
@@ -1,0 +1,9 @@
+### Added: `get_robot_state` names torque-only actuation
+
+A Menagerie `go2` sinks from base z 0.445 to 0.20 within 2 s of the first
+`step`, and the state read gave no reason for it: all 12 of its actuators are
+`<motor>`, so `ctrl` is a force in Nm and nothing holds the pose. The text now
+carries one `note:` line naming that and the `json` payload an
+`"actuation": "torque"` key. The classification is unanimous and three-term, so
+a robot with even one position servo is unchanged and a `<damper>` -- whose
+`ctrl` is not a torque -- is not described as one.

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -347,6 +347,63 @@ def joint_rate_drive_map(model: Any, mj: Any) -> dict[int, int]:
     return rate_drives
 
 
+def torque_only_actuation(model: Any, robot: SimRobot, mj: Any) -> bool:
+    """Whether every actuator ``robot`` owns commands a raw force.
+
+    The third question in this family: :func:`joint_drive_map` asks which
+    actuator commands a *pose*, :func:`joint_rate_drive_map` which commands a
+    *rate*, and this one whether NOTHING the robot carries commands either. A
+    pure torque motor's ``ctrl`` is a force in Nm, so such a robot holds no
+    configuration on its own -- it settles under gravity unless a controller
+    supplies the holding force every step. That is the normal state of a
+    Menagerie quadruped or humanoid (``go2``, ``g1``), whose actuators are all
+    ``<motor>``.
+
+    Three terms, for the reason :func:`joint_drive_map` gives: the actuator
+    shortcuts overlap on any one of them, so no single field separates a motor
+    (measured on mujoco 3.13, one shortcut per row):
+
+    * ``gaintype == mjGAIN_FIXED`` - the force is ``ctrl`` times a constant, so
+      ``ctrl`` IS the force. ``<damper kv>`` clears the other two terms with
+      ``gaintype == mjGAIN_AFFINE``, and its ``ctrl`` scales a damping
+      coefficient rather than being a torque, so this term is what keeps the
+      claim "ctrl is in Nm" true of everything reported here.
+    * ``biastype == mjBIAS_NONE`` - no bias computed from the joint's own state,
+      so nothing restores toward a setpoint (``<position kp>`` and
+      ``<velocity kv>`` are both affine-bias).
+    * ``dyntype == mjDYN_NONE`` - ``ctrl`` reaches the force law directly, with
+      no ``act`` state in between (``<intvelocity>`` integrates it,
+      ``<cylinder>`` filters it).
+
+    Per actuator, and unanimous: a robot with even one position servo is not
+    reported here, because a pose written to that joint does hold.
+
+    Args:
+        model: The compiled ``MjModel``.
+        robot: The robot to scope, read through its already resolved
+            ``actuator_ids`` (control indices, which index the ``actuator_*``
+            arrays because :func:`_unaddressable_actuator_reason` declines any
+            model where the two spaces differ).
+        mj: The ``mujoco`` module.
+
+    Returns:
+        ``True`` when ``robot`` owns at least one actuator and every one of them
+        is a torque motor. An unactuated robot is ``False``: it has no ``ctrl``
+        to describe.
+    """
+    if not robot.actuator_ids:
+        return False
+    fixed_gain = int(mj.mjtGain.mjGAIN_FIXED)
+    no_bias = int(mj.mjtBias.mjBIAS_NONE)
+    stateless = int(mj.mjtDyn.mjDYN_NONE)
+    return all(
+        int(model.actuator_gaintype[act_id]) == fixed_gain
+        and int(model.actuator_biastype[act_id]) == no_bias
+        and int(model.actuator_dyntype[act_id]) == stateless
+        for act_id in robot.actuator_ids
+    )
+
+
 def actuator_driven_joint_ids(model: Any, act_id: int, mj: Any) -> frozenset[int]:
     """Return every joint id actuator ``act_id`` drives.
 

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -126,6 +126,7 @@ from strands_robots.simulation.mujoco.scene_ops import (
     persist_world_option,
     replace_scene_mjcf,
     reposition_body_in_scene,
+    torque_only_actuation,
 )
 from strands_robots.simulation.mujoco.spec_builder import (
     SpecBuilder,
@@ -3403,6 +3404,13 @@ class MuJoCoSimEngine(
         reported as a scalar joint (its qpos is [xyz+quat], not a single angle),
         and the base ``quaternion``/``angular_velocity`` match get_observation's
         ``base_quat``/``base_ang_vel`` for the same robot.
+
+        A robot whose every actuator is a torque ``<motor>`` (a Menagerie
+        quadruped or humanoid) additionally carries ``"actuation": "torque"``,
+        with the same fact as a ``note:`` line in the text: its ``ctrl`` is a
+        force in Nm rather than a pose, so it holds no configuration and settles
+        under gravity unless a controller drives it every step. Absent for a
+        robot with even one position servo, whose pose writes do hold.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -3511,6 +3519,22 @@ class MuJoCoSimEngine(
                     f"pos=[{ee_pos[0]:.4f}, {ee_pos[1]:.4f}, {ee_pos[2]:.4f}]\n"
                 )
                 json_payload["end_effector"] = {"name": frame_name, "type": frame_type, "position": ee_pos}
+
+        # Name torque-only actuation, because its normal behaviour reads as a
+        # broken model. A Menagerie quadruped is driven entirely by <motor>, so
+        # ctrl is a force and a pose written there is a torque: go2 sinks from
+        # base z 0.445 to 0.20 within 2 s of the first step, holding nothing.
+        # The reading above reports that collapse without a word on its cause,
+        # which is the one thing a caller needs to know it is not a defect --
+        # the robot needs a controller every step (run_policy), not a fix.
+        # torque_only_actuation owns the three-term classification.
+        if torque_only_actuation(model, robot, mj):
+            text += (
+                f"note: all {len(robot.actuator_ids)} actuators are torque motors (ctrl in Nm) - a "
+                "position target written to them is a force, so nothing holds the pose and the robot "
+                "settles under gravity unless a controller drives it every step (run_policy).\n"
+            )
+            json_payload["actuation"] = "torque"
         return {"status": "success", "content": [{"text": text}, {"json": json_payload}]}
 
     def list_bodies(self, robot_name: str | None = None) -> dict[str, Any]:

--- a/tests/simulation/mujoco/test_get_robot_state_names_torque_only_actuation.py
+++ b/tests/simulation/mujoco/test_get_robot_state_names_torque_only_actuation.py
@@ -1,0 +1,133 @@
+"""``get_robot_state`` names torque-only actuation, so a settling robot is not read as a bug.
+
+A Menagerie quadruped like ``go2`` is driven entirely by ``<motor>`` actuators:
+``ctrl`` is a force in Nm, so a pose written there is a torque and nothing holds
+the robot up. It sinks from base z 0.445 to 0.20 within 2 s of the first
+``step`` - which the state read reported as a falling number with no word on its
+cause, indistinguishable from a broken model. The note names the cause, so the
+answer is "drive it with a controller" rather than a hunt for a defect.
+
+The classification is unanimous and three-term (see
+:func:`~strands_robots.simulation.mujoco.scene_ops.torque_only_actuation`): one
+position servo is enough to make a robot's pose writes hold, and ``<damper>``
+clears the other two terms while its ``ctrl`` is not a torque at all.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from strands_robots.assets.manager import is_robot_asset_present
+
+requires_mujoco = pytest.mark.skipif(importlib.util.find_spec("mujoco") is None, reason="mujoco not installed")
+
+_LEG_XML = """
+<mujoco model="drive_leg">
+  <compiler angle="radian" autolimits="true"/>
+  <worldbody>
+    <body name="trunk" pos="0 0 0.5">
+      <freejoint name="floating_base_joint"/>
+      <geom type="box" size="0.1 0.1 0.05" mass="2"/>
+      <body name="thigh" pos="0 0 -0.05">
+        <joint name="hip" type="hinge" axis="0 1 0" range="-1.5 1.5"/>
+        <geom type="capsule" size="0.02" fromto="0 0 0 0 0 -0.4" mass="0.2"/>
+        <body name="shank" pos="0 0 -0.4">
+          <joint name="knee" type="hinge" axis="0 1 0" range="-1.5 1.5"/>
+          <geom type="capsule" size="0.02" fromto="0 0 0 0 0 -0.3" mass="0.1"/>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    {actuators}
+  </actuator>
+</mujoco>
+"""
+
+# One row per MuJoCo actuator shortcut whose compiled fields overlap a motor's on
+# some term, so the table pins the boundary rather than one happy case. Measured
+# (gaintype, biastype, dyntype) on mujoco 3.13 in the comment.
+_DRIVES = {
+    # FIXED, NONE, NONE - ctrl is the force. The reported case.
+    "motor": '<motor name="hip_act" joint="hip"/><motor name="knee_act" joint="knee"/>',
+    # <general> defaults to exactly a motor, so it must read as one.
+    "general": '<general name="hip_act" joint="hip"/><general name="knee_act" joint="knee"/>',
+    # AFFINE bias (-kp) - the setpoint restores a pose, so the pose holds.
+    "position": '<position name="hip_act" joint="hip" kp="50"/><position name="knee_act" joint="knee" kp="50"/>',
+    # AFFINE bias with kp slot 0 - commands a rate, still not a raw force.
+    "velocity": '<velocity name="hip_act" joint="hip" kv="5"/><velocity name="knee_act" joint="knee" kv="5"/>',
+    # dyntype INTEGRATOR - an act state stands between ctrl and the force law.
+    "intvelocity": (
+        '<intvelocity name="hip_act" joint="hip" kp="10" actrange="-1 1"/>'
+        '<intvelocity name="knee_act" joint="knee" kp="10" actrange="-1 1"/>'
+    ),
+    # AFFINE *gain* with no bias and no dynamics: clears a two-term test, yet
+    # ctrl scales a damping coefficient, so "ctrl in Nm" would be false of it.
+    "damper": (
+        '<damper name="hip_act" joint="hip" kv="5" ctrlrange="0 1"/>'
+        '<damper name="knee_act" joint="knee" kv="5" ctrlrange="0 1"/>'
+    ),
+    # Unanimous: one servo among motors means a pose write holds somewhere.
+    "mixed": '<motor name="hip_act" joint="hip"/><position name="knee_act" joint="knee" kp="50"/>',
+}
+_TORQUE_ONLY = {"motor", "general"}
+
+
+def _state(tmp_path, drive: str):
+    from strands_robots.simulation import Simulation
+
+    path = tmp_path / f"{drive}.xml"
+    path.write_text(_LEG_XML.format(actuators=_DRIVES[drive]))
+    sim = Simulation()
+    sim.create_world(timestep=0.002)
+    assert sim.add_robot("leg", urdf_path=str(path))["status"] == "success"
+    try:
+        res = sim.get_robot_state("leg")
+        assert res["status"] == "success", res
+        return res["content"][0]["text"], res["content"][1]["json"]
+    finally:
+        sim.destroy()
+
+
+@requires_mujoco
+class TestGetRobotStateNamesTorqueOnlyActuation:
+    @pytest.mark.parametrize("drive", sorted(_DRIVES))
+    def test_only_a_wholly_motor_driven_robot_is_reported_as_torque(self, tmp_path, drive) -> None:
+        text, payload = _state(tmp_path, drive)
+        if drive in _TORQUE_ONLY:
+            assert "all 2 actuators are torque motors (ctrl in Nm)" in text
+            assert "nothing holds the pose" in text
+            assert payload["actuation"] == "torque"
+        else:
+            assert "torque motors" not in text
+            assert "actuation" not in payload
+
+    def test_the_note_does_not_disturb_the_joint_and_base_contract(self, tmp_path) -> None:
+        text, payload = _state(tmp_path, "motor")
+        assert set(payload["state"]) == {"hip", "knee"}
+        assert payload["base"]["position"] == pytest.approx([0.0, 0.0, 0.5], abs=1e-9)
+        assert text.startswith("'leg' state (t=0.000s):")
+
+    @pytest.mark.skipif(not is_robot_asset_present("go2"), reason="go2 Menagerie asset not present")
+    def test_go2_says_why_it_settles_within_two_seconds(self) -> None:
+        from strands_robots.simulation import Simulation
+
+        sim = Simulation()
+        sim.create_world()
+        try:
+            assert sim.add_robot("go2")["status"] == "success"
+            before = sim.get_robot_state("go2")["content"][1]["json"]
+            assert before["base"]["position"][2] == pytest.approx(0.445, abs=0.01)
+            timestep = sim.physics_timestep()
+            assert timestep is not None, "a created world reports its timestep"
+            sim.step(int(2.0 / timestep))
+            res = sim.get_robot_state("go2")
+            text, after = res["content"][0]["text"], res["content"][1]["json"]
+            # It collapsed, and now the same read says why.
+            assert after["base"]["position"][2] < 0.25, after["base"]["position"]
+            assert "all 12 actuators are torque motors (ctrl in Nm)" in text
+            assert after["actuation"] == "torque"
+        finally:
+            sim.destroy()


### PR DESCRIPTION
![go2 settles under gravity, and the same read now says why](https://raw.githubusercontent.com/cagataycali/robots/assets/torque-actuation-hint-34459618407/d072_torque_hint.png)

**What.** A robot whose actuators are all `<motor>` holds no pose: `ctrl` is a force in Nm, so a position target written there is a torque. A Menagerie `go2` sinks from base z 0.4450 to 0.2037 within 2 s of the first `step`, and `get_robot_state` reported that collapse without a word on its cause. The text now carries one `note:` line and the `json` payload `"actuation": "torque"`.

**Why.** Otherwise the normal behaviour of a torque-actuated robot is indistinguishable from a broken model, and the answer is "drive it every step (`run_policy`)" rather than a hunt for a defect. `scene_ops.torque_only_actuation` owns the classification, as the third sibling of `joint_drive_map` (pose) and `joint_rate_drive_map` (rate). Three terms, because the actuator shortcuts overlap on any one: `<damper>` clears biastype/dyntype `NONE` while its `ctrl` scales a damping coefficient, so `gaintype FIXED` is what keeps "ctrl in Nm" true of everything reported. Unanimous per actuator, so one position servo means no note.

**Tests.** A table over 7 actuator shortcuts plus the `go2` witness: 3 fail on `main`, 9 pass after. Base z at t=2 s is 0.2037 on both trees, so no physics changed. Full suite 50532 passed / 308 skipped; ruff and mypy clean.