### PR TITLE
fix(hardware): __del__ skips an instance whose __init__ refused a kwarg

### DIFF
--- a/changelog.d/3448-hardware-refused-kwarg-finalizer-is-silent.md
+++ b/changelog.d/3448-hardware-refused-kwarg-finalizer-is-silent.md
@@ -1,0 +1,11 @@
+### Fixed: a refused `control_frequency` or `action_horizon` no longer logs a cleanup error
+
+`Robot("so100", mode="real", control_frequency=0)` raised the documented
+`ValueError`, and then the half-built instance was finalised: `__del__` ran
+`cleanup()` unconditionally, `cleanup()` read the shutdown latch the validators
+had raised before, and the operator saw
+`ERROR Cleanup error for so100: 'Robot' object has no attribute '_shutdown_event'`
+beside the refusal they had actually caused. `__del__` now returns before
+`cleanup()` when `__init__` never created the latch, because such an instance
+holds nothing to release; a bring-up that fails after the latch exists still
+runs the full teardown.

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -3128,6 +3128,14 @@ class Robot(TeleopMixin, AgentTool):
 
     def __del__(self) -> None:
         """Destructor to ensure cleanup."""
+        if not hasattr(self, "_shutdown_event"):
+            # ``__init__`` refused a kwarg (``action_horizon``,
+            # ``control_frequency``) before the executor and this latch were
+            # created, so the instance holds nothing to release. ``cleanup()``
+            # would raise on the first attribute it never reached and log that
+            # name as a cleanup failure beside the ValueError the caller was
+            # owed. A bring-up that fails after this point still cleans up.
+            return
         try:
             self.cleanup()
         except Exception:

--- a/tests/test_hardware_refused_kwarg_leaves_no_cleanup_error.py
+++ b/tests/test_hardware_refused_kwarg_leaves_no_cleanup_error.py
@@ -1,0 +1,69 @@
+"""A kwarg ``Robot.__init__`` refuses must not be followed by a cleanup error.
+
+``control_frequency`` and ``action_horizon`` are validated at the top of
+``Robot.__init__``, before the executor, the shutdown latch, the mesh handle
+or the device exist -- that ordering is the point, a refused rate never touches
+the arm. The half-built instance is still finalised, and ``__del__`` called
+``cleanup()`` on it unconditionally, so the first line of ``cleanup()`` raised
+``AttributeError: 'Robot' object has no attribute '_shutdown_event'`` and the
+handler logged it at ERROR beside the ``ValueError`` the caller was owed.
+
+An instance without the shutdown latch never acquired anything, so there is
+nothing to release and nothing to report. A bring-up that fails *after* the
+latch exists -- the ``_initialize_robot`` path pinned in
+``tests/test_hardware_cleanup_survives_a_failed_robot_init.py`` -- still runs
+the full teardown.
+"""
+
+from __future__ import annotations
+
+import gc
+import logging
+from typing import Any
+
+import pytest
+
+from strands_robots.hardware_robot import Robot as HwRobot
+
+_LOGGER = "strands_robots.hardware_robot"
+
+REFUSED_KWARGS: list[dict[str, Any]] = [
+    {"control_frequency": 0},
+    {"control_frequency": float("nan")},
+    {"action_horizon": 0},
+]
+
+
+def _construct_refused(**kwargs: Any) -> None:
+    """Construct with a kwarg ``__init__`` refuses, then force the finalizer.
+
+    The traceback keeps the half-built instance alive while the exception
+    propagates, so the ``ValueError`` is caught here and ``gc.collect()`` runs
+    once the frame chain is dropped.
+    """
+    try:
+        HwRobot(tool_name="probe", robot="so101_follower", **kwargs)
+    except ValueError:
+        gc.collect()
+        return
+    raise AssertionError(f"__init__ accepted {kwargs}")
+
+
+def _cleanup_errors(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR and "Cleanup error" in r.getMessage()]
+
+
+@pytest.mark.parametrize("kwargs", REFUSED_KWARGS, ids=lambda k: next(iter(k.items())).__repr__())
+def test_a_refused_kwarg_logs_no_cleanup_error(caplog: pytest.LogCaptureFixture, kwargs: dict[str, Any]) -> None:
+    with caplog.at_level(logging.ERROR, logger=_LOGGER):
+        _construct_refused(**kwargs)
+    assert _cleanup_errors(caplog) == []
+
+
+def test_the_finalizer_skips_an_instance_without_a_shutdown_latch(caplog: pytest.LogCaptureFixture) -> None:
+    """``__del__`` returns before ``cleanup()`` when ``__init__`` never got that far."""
+    instance = HwRobot.__new__(HwRobot)
+    instance.tool_name_str = "probe"
+    with caplog.at_level(logging.ERROR, logger=_LOGGER):
+        instance.__del__()
+    assert _cleanup_errors(caplog) == []


### PR DESCRIPTION
**What**
`Robot.__del__` on the hardware class returns before `cleanup()` when `__init__` never created the shutdown latch.

**Why**
`Robot("so100", mode="real", control_frequency=0)` (or `action_horizon=0`) raises the documented `ValueError`, and then the half-built instance is finalised: `cleanup()` reads `_shutdown_event`, which the validators raised before, so the operator also sees `ERROR Cleanup error for so100: 'Robot' object has no attribute '_shutdown_event'`. On main the new test fails with:

```
assert ["Cleanup error for probe: 'Robot' object has no attribute '_shutdown_event'"] == []
```

A bring-up that fails after the latch exists still runs the full teardown (`tests/test_hardware_cleanup_survives_a_failed_robot_init.py` still passes).

**Tests**
`tests/test_hardware_refused_kwarg_leaves_no_cleanup_error.py`; ruff, mypy clean on touched files.
