### PR TITLE
fix(docs): the README wrist-camera example mounts on a body the arm has

### DIFF
--- a/README.md
+++ b/README.md
@@ -931,13 +931,15 @@ from strands_robots.simulation import Simulation
 
 sim = Simulation(tool_name="sim", mesh=False)
 sim.create_world()
-sim.add_robot(name="arm", data_config="so100")
+sim.add_robot(name="arm", data_config="so101")
 sim.add_object(name="cube", shape="box", position=[0.3, 0, 0.05])
 sim.add_camera(name="topdown", position=[0, 0, 1.5], target=[0, 0, 0])
 
 # Wrist camera: mount ON the gripper body so it tracks the arm like the real
-# SO101/SO100 hardware cam. position/target are in the body's LOCAL frame.
-# Body names are namespaced "<robot>/<body>" (e.g. "arm/gripper").
+# SO-101 hardware cam. position/target are in the body's LOCAL frame.
+# Body names are namespaced "<robot>/<body>"; the SO-101 MJCF names its
+# gripper body "gripper", so the mount is "arm/gripper" (the SO-100 names it
+# "Fixed_Jaw"). list_bodies(robot_name="arm") reports it as gripper_body.
 sim.add_camera(name="wrist", position=[0, -0.05, 0], target=[0, -0.15, 0],
                parent_body="arm/gripper")
 
@@ -982,9 +984,10 @@ frame = sim.render(camera_name="topdown")   # {status, content:[text, image]}
   `is_static=True`; passing `is_static=False` is a hard error.
 - **Aim cameras.** Pass `target=[x,y,z]` to look at a point; `target == position`
   errors.
-- **Wrist cameras mount on a body.** Pass `parent_body="<robot>/gripper"` to
-  `add_camera` so the camera rides with the arm (realistic SO101/SO100 wrist
-  cam). In that mode `position`/`target` are in the body's LOCAL frame, not
+- **Wrist cameras mount on a body.** Pass `parent_body=` the `gripper_body`
+  that `list_bodies(robot_name=...)` reports (`so101/gripper` on an SO-101,
+  `<robot>/Fixed_Jaw` on an SO-100) to `add_camera` so the camera rides with
+  the arm. In that mode `position`/`target` are in the body's LOCAL frame, not
   world coordinates. Omit `parent_body` for a world-fixed camera.
 - **MP4 vs dataset recording.** `start_cameras_recording` writes plain MP4
   (`[sim-mujoco]` only). `start_recording` writes a LeRobotDataset (parquet +

--- a/changelog.d/3467-readme-wrist-camera-mount.md
+++ b/changelog.d/3467-readme-wrist-camera-mount.md
@@ -1,0 +1,3 @@
+### Fixed: the README's wrist-camera example mounts on a body its robot has
+
+The Simulation (MuJoCo) block in the README added an SO-100 as `arm` and then mounted the wrist camera on `arm/gripper`, a body only the SO-101 model carries (the SO-100 names its jaws `Fixed_Jaw` and `Moving_Jaw`), so copying the block returned `status: error` at the `add_camera` line. The example now adds an SO-101, and the wrist-camera bullet tells you to take the mount name from `list_bodies(robot_name=...)`'s `gripper_body` instead of assuming `<robot>/gripper`. A test now reads every README fence that adds a robot and mounts a camera on it and checks the named body against that robot's MJCF.

--- a/tests/test_readme_wrist_camera_mounts_a_body_the_robot_has.py
+++ b/tests/test_readme_wrist_camera_mounts_a_body_the_robot_has.py
@@ -1,0 +1,84 @@
+"""The README's wrist-camera example names a body that exists on the robot it adds.
+
+``add_camera(parent_body="<robot>/<body>")`` mounts a camera on a MuJoCo body
+and refuses a name the model does not carry. The body vocabulary is the MJCF's,
+not ours: the SO-101 names its gripper body ``gripper`` while the SO-100 names
+its jaws ``Fixed_Jaw`` and ``Moving_Jaw``. A README fence that adds one robot
+and mounts on the other's body name returns ``status: error`` on the first copy.
+
+Each ``python`` fence in ``README.md`` is read for ``add_robot(name=...,
+data_config=...)`` and ``add_camera(..., parent_body="<name>/<body>")`` calls;
+where the prefix matches a robot the same fence added, ``<body>`` must be a body
+of that robot's shipped model.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+mujoco = pytest.importorskip("mujoco")
+
+_README = Path(__file__).resolve().parent.parent / "README.md"
+_PYTHON_FENCE = re.compile(r"```python\n(.*?)```", re.DOTALL)
+
+
+def _keyword_strings(call: ast.Call) -> dict[str, str]:
+    return {
+        kw.arg: kw.value.value
+        for kw in call.keywords
+        if kw.arg and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str)
+    }
+
+
+def _method_name(call: ast.Call) -> str | None:
+    return call.func.attr if isinstance(call.func, ast.Attribute) else None
+
+
+def _mounts() -> list[tuple[str, str]]:
+    """Return ``(data_config, body)`` for every mount on a robot the same fence added."""
+    pairs: list[tuple[str, str]] = []
+    for fence in _PYTHON_FENCE.findall(_README.read_text(encoding="utf-8")):
+        try:
+            tree = ast.parse(fence)
+        except SyntaxError:
+            continue
+        calls = [node for node in ast.walk(tree) if isinstance(node, ast.Call)]
+        robots = {
+            kws["name"]: kws["data_config"]
+            for call in calls
+            if _method_name(call) == "add_robot"
+            for kws in [_keyword_strings(call)]
+            if "name" in kws and "data_config" in kws
+        }
+        for call in calls:
+            if _method_name(call) != "add_camera":
+                continue
+            parent = _keyword_strings(call).get("parent_body")
+            if parent is None or "/" not in parent:
+                continue
+            robot, body = parent.split("/", 1)
+            if robot in robots:
+                pairs.append((robots[robot], body))
+    return pairs
+
+
+def _body_names(data_config: str) -> list[str]:
+    from strands_robots.simulation.model_registry import resolve_model_path
+
+    model = mujoco.MjModel.from_xml_path(str(resolve_model_path(data_config)))
+    return [name for i in range(model.nbody) if (name := mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, i))]
+
+
+def test_the_readme_mounts_at_least_one_wrist_camera() -> None:
+    """A fence that grades nothing would pass silently; the corpus is asserted."""
+    assert _mounts(), "README.md no longer adds a robot and mounts a camera on it in one fence"
+
+
+@pytest.mark.parametrize(("data_config", "body"), _mounts())
+def test_the_mounted_body_exists_on_the_robot_the_fence_added(data_config: str, body: str) -> None:
+    bodies = _body_names(data_config)
+    assert body in bodies, f"README mounts on {data_config!r} body {body!r}; that model has {bodies}"


### PR DESCRIPTION
**What**

The README Simulation block now adds an SO-101 before mounting the wrist camera on `arm/gripper`, and the wrist-camera bullet names where the mount body comes from (`list_bodies()` -> `gripper_body`).

**Why**

The block added an SO-100 as `arm` and mounted on `arm/gripper`; the SO-100 MJCF has no such body (its jaws are `Fixed_Jaw` / `Moving_Jaw`), so the copied example returned `status: error` on a clean install. The new test on main:

```
AssertionError: README mounts on 'so100' body 'gripper'; that model has ['world', 'Base', 'Rotation_Pitch', 'Upper_Arm', 'Lower_Arm', 'Wrist_Pitch_Roll', 'Fixed_Jaw', 'Moving_Jaw']
```

**Tests**

`tests/test_readme_wrist_camera_mounts_a_body_the_robot_has.py` grades every README fence's `parent_body` against the MJCF of the robot that fence added. ruff, mypy clean on touched files.