### PR TITLE
docs(policies): lerobot-local and protomotions pages state each contract once

### DIFF
--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -19,6 +19,12 @@ policy = create_policy(
 )
 ```
 
+`lerobot_local` loads a LeRobot checkpoint in-process and drives it through the
+same `get_actions` contract as every other provider. The policies themselves,
+their configs and their processor pipelines are LeRobot's - see the
+[LeRobot policy docs](https://huggingface.co/docs/lerobot). This page covers
+what strands adds around them.
+
 ## Parameters
 
 ```python
@@ -40,119 +46,47 @@ LerobotLocalPolicy(
     image_keys=None,                     # MolmoAct2 camera key override
     inference_action_mode="continuous",  # "continuous" | "discrete"
     camera_key_map=None,                 # {robot_cam_name: policy_image_key}
-    obs_rename_override=None,            # {runtime_obs_key: "observation.images.*"} merged over embodiment.obs_rename (value None/"" DROPS that key)
+    obs_rename_override=None,            # {runtime_obs_key: "observation.images.*"} merged over embodiment.obs_rename
     strict_keys=False,                   # raise instead of a degraded camera OR joint-state binding
     cache_model=True,                    # reuse a process-cached model across instances
     revision=None,                       # pin a HF Hub revision (branch/tag/commit SHA)
 )
 ```
 
-`tokenizer_max_length` is the instruction's token budget and must be a positive
-`int`. The tokenizer takes it as a slice bound over the encoded instruction, so a
-count below one truncates the instruction away and the policy acts on an empty
-prompt; an unusable value is refused when the policy is constructed (and by
-`preflight`, before the weights are fetched) rather than at the first inference.
-
-
-### Pinning a Hub revision
-
-Pass `revision=` to pin a checkpoint to a reproducible Hub version - a
-branch name, tag, or commit SHA. It is threaded to lerobot's
-`PreTrainedPolicy.from_pretrained(..., revision=...)` (and to the config
-resolution that auto-detects `policy_type`), so the exact weights are
-loaded regardless of later pushes to the repo's default branch:
-
-```python
-policy = create_policy(
-    "lerobot_local",
-    pretrained_name_or_path="lerobot/smolvla_base",
-    revision="v1.0",   # or a 40-char commit SHA
-)
-```
-
-Two revisions of the same repo are cached independently (the revision is
-part of the model-cache key), so pinning never collides with an unpinned
-load. Revision pinning is not supported for transformers-native MolmoAct2
-checkpoints, which load weights via `checkpoint_path` rather than
-`from_pretrained`; passing `revision=` with one raises `ValueError`. Pin
-those by downloading the revision locally and pointing at the directory.
+| Parameter | What strands does with it | Refused |
+|---|---|---|
+| `policy_type` | auto-detected from the checkpoint config; `list_policy_types()` enumerates what the installed lerobot resolves | a type lerobot cannot resolve |
+| `revision` | threaded to `from_pretrained(revision=...)`; part of the cache key | - |
+| `device` | remaps a checkpoint's baked `device_processor.device` (e.g. `"cuda"`) to the requested device instead of failing on a CPU-only host | an unavailable device |
+| `tokenizer_max_length` | instruction token budget | anything but a positive `int` (a count below one truncates the instruction away) |
+| `image_keys` | MolmoAct2 camera declaration | a bare string (`"wrist"` would be read as five one-letter names) |
+| `strict_keys` | turns the degraded camera / joint-state bindings below into raises | non-boolean |
+| `cache_model` | see Model caching | non-boolean |
 
 ## Model caching
 
-Loading a checkpoint reads its weights from disk and uploads them to the
-device. For a large VLA (MolmoAct2 SO-100/101 ships 1295 weight files) that is
-on the order of a minute or more per load. Eval/rollout drivers that build a
-fresh policy per call - e.g. ``create_policy("lerobot_local", ...)`` inside a
-per-episode loop - would otherwise pay that full load cost every time.
-
-By default (`cache_model=True`) the loaded underlying model is cached at
-process level, keyed by `(pretrained_name_or_path, policy_type, device)` (plus
-the MolmoAct2 normalisation/processor knobs). Re-instantiating the policy for
-the same checkpoint reuses the resident model and skips the weight load:
+Loading a large VLA (MolmoAct2 SO-100/101 ships 1,295 weight files) takes a
+minute or more. Models are cached process-wide, keyed by
+`(pretrained_name_or_path, policy_type, device, revision)`; a second
+`create_policy` with the same key reuses the weights. Every instance records
+`load_cache_hit` (`bool`) and `load_seconds`, and `run_policy` reports them as
+`policy_load_cache_hit` / `policy_load_time_s` in its result block.
 
 ```python
-from strands_robots.policies import create_policy
-from strands_robots.policies.lerobot_local import clear_model_cache
-
-# First build loads the weights; subsequent builds for the same checkpoint
-# reuse the resident model (no reload).
-p1 = create_policy("lerobot_local", pretrained_name_or_path="allenai/MolmoAct2-SO100_101", device="cuda")
-p2 = create_policy("lerobot_local", pretrained_name_or_path="allenai/MolmoAct2-SO100_101", device="cuda")
-
+from strands_robots.policies.lerobot_local import clear_model_cache, list_cached_models
 clear_model_cache()  # evict cached models and free their GPU/CPU memory
-```
-
-The cached object is the same live module shared by every instance with the
-same key. LeRobot policies carry per-episode state (action queue, temporal
-ensemble buffers) that `Policy.reset()` clears between episodes, so sequential
-reuse - including `Simulation.eval_policy` and per-rollout drivers - is safe.
-Pass `cache_model=False` to force a private load when driving two rollouts of
-the same checkpoint+device concurrently, and call `clear_model_cache()` to
-release the held memory.
-
-For multi-episode evaluation, prefer a single `Simulation.eval_policy(..., 
-n_episodes=N)` (or `run_policy(..., policy_object=loaded)`) call, which loads
-the policy once and reuses it across episodes regardless of this cache.
-
-### Load telemetry
-
-Every `LerobotLocalPolicy` records two attributes after construction so the
-saving from the cache is observable instead of guessed:
-
-- `load_cache_hit` (`bool`): `True` when the heavy `from_pretrained` weight
-  read was skipped because the process cache already held this checkpoint.
-- `load_time_s` (`float`): seconds the load took (near `0.0` on a cache hit).
-  Measured on a monotonic clock, so a wall-clock correction landing during a
-  multi-minute weight read cannot report the load as negative or as hours.
-
-`Simulation.run_policy` and `Simulation.eval_policy` surface these in their
-`{"json": {...}}` result block as `policy_load_cache_hit` and
-`policy_load_time_s`. In a multi-episode loop, a `policy_load_cache_hit=False`
-on episode 2+ is a smell that the caller rebuilt the policy per episode instead
-of reusing one warm `policy_object=`; an agent can read that field and
-self-correct. Policies that expose no load telemetry (e.g. `MockPolicy`) report
-the honest defaults `0.0` / `False`.
-
-```python
-from strands_robots.policies.lerobot_local import list_cached_models
-
-# Inspect what is resident without touching private state.
 for entry in list_cached_models():
     print(entry["namespace"], entry["pretrained_name_or_path"], entry["device"])
 ```
 
-`list_cached_models()` returns one read-only dict per cached entry
-(`namespace`, `pretrained_name_or_path`, `device`, `policy_class`); pair it with
-`clear_model_cache()` to decide when to evict before loading a different
-checkpoint.
-
 ## Supported models
 
-`policy_type` accepts any type the installed lerobot can resolve - the strings
-below mirror lerobot's own policy registry. It is auto-detected from a
-checkpoint's config when omitted; pass `policy_type=` to override. The set
-tracks the installed lerobot, so enumerate it at runtime rather than trusting a
-static list (see [Discovering supported policy types](#discovering-supported-policy-types)).
+`policy_type` accepts any type the installed lerobot resolves:
+
+```python
+from strands_robots import list_policy_types
+list_policy_types()
+```
 
 | `policy_type` | Model |
 |---------------|-------|
@@ -171,69 +105,14 @@ static list (see [Discovering supported policy types](#discovering-supported-pol
 | `multi_task_dit` | Multi-task Diffusion Transformer |
 | `gaussian_actor` | Gaussian actor |
 
-### Discovering supported policy types
-
-Enumerate the resolvable `policy_type` strings programmatically instead of
-guessing. `list_policy_types` is the discovery peer of `list_providers` (the
-follow-up to "which provider?" is "which `policy_type` does it take?"), so it
-is re-exported at the package root and on `strands_robots.policies` alongside
-`list_providers` -- no reach into the `lerobot_local` submodule required:
-
-```python
-from strands_robots import list_policy_types  # or: from strands_robots.policies import list_policy_types
-
-list_policy_types()
-# ['act', 'diffusion', 'eo1', 'gaussian_actor', 'groot', 'molmoact2',
-#  'multi_task_dit', 'pi0', 'pi05', 'pi0_fast', 'smolvla', 'tdmpc',
-#  'vla_jepa', 'vqbet', 'wall_x', 'xvla']
-```
-
-The submodule path `from strands_robots.policies.lerobot_local import
-list_policy_types` keeps working; the top-level re-export is lazy, so reaching
-it does not make a bare `import strands_robots` pull in torch.
-
-The list reflects the *installed* lerobot (sourced from its policy registry),
-so a newer lerobot reports more entries and a slimmer one fewer; it returns
-`[]` when lerobot is not installed. Passing an unknown `policy_type` to
-inference now raises an error that names these valid choices, so a typo is a
-one-line fix instead of a dead end.
-
 ## MolmoAct2
 
-MolmoAct2 ships in lerobot **>= 0.6** - its `MolmoAct2Policy` was merged in
-lerobot PR #3604 and first released in 0.6.0 - so it resolves straight from
-PyPI with no git-from-source install. The `[molmoact2]` extra layers the
-auxiliary deps MolmoAct2's modeling and processor code needs
-(`transformers>=5.4.0,<5.6.0`, `peft`, `scipy`) on top of
-`strands-robots[lerobot]` (which pins `lerobot>=0.6.1,<0.7.0`):
+MolmoAct2 ships in lerobot >= 0.6 and resolves straight from PyPI; the
+`[molmoact2]` extra layers its transformers range on top of `[lerobot]`:
 
 ```bash
 uv pip install "strands-robots[molmoact2]"
 ```
-
-MolmoAct2 then works:
-
-```python
-policy = create_policy(
-    "lerobot_local",
-    pretrained_name_or_path="your-org/molmoact2-so101",
-    device="cuda",
-    norm_tag="so101",
-    image_keys=["wrist_camera", "front_camera"],
-    inference_action_mode="continuous",
-    # actions_per_step is auto-set from config.n_action_steps (30 for the
-    # SO-100/101 checkpoints) when left at the default 1 - so the full
-    # 30-step chunk the model was trained to replay open-loop is consumed
-    # before re-querying vision. Pass an explicit value to override.
-)
-# see examples/vla/molmoact2_so101_pickplace.py
-```
-
-MolmoAct2 SO-100/101 was trained for **30-step open-loop chunk replay**
-(`n_action_steps = 30`). Run it through the sim with an `action_horizon` that
-does not truncate the chunk - the runner clamps the effective horizon up to the
-policy's `actions_per_step`, so passing `action_horizon=8` (or the default) is
-safe, but you can also pin it explicitly:
 
 ```python
 sim.run_policy(
@@ -250,97 +129,25 @@ sim.run_policy(
 )
 ```
 
-This requirement will go away once HuggingFace publishes lerobot >= 0.5.2 to PyPI
-(which will include MolmoAct2 natively). At that point the `[molmoact2]` extra can
-pin `lerobot[feetech]>=0.5.2` directly and the git-source step drops away --
-`pip install strands-robots[molmoact2]` alone will suffice.
+Action contract, units and motion diagnostics: [MolmoAct2](molmoact2.md).
 
 ## Processor bridge and normalization
 
-`use_processor=True` (default) wraps the policy in a processor bridge that
-normalizes observations going into the model and unnormalizes actions coming
-back out, so the robot sees commands in physical joint units.
-
-The bridge loads the model's own pipeline configs in priority order:
-
-1. `policy_preprocessor.json` / `policy_postprocessor.json` - LeRobot's standard
-   saved pipelines (most lerobot-native checkpoints).
-2. **In-model normalization recovery** - a pre-processor-era checkpoint ships no
-   pipeline JSON but carries `normalize_inputs.*` / `unnormalize_outputs.*`
-   buffers in its `model.safetensors` (still the case for canonical zoo
-   checkpoints such as `lerobot/act_aloha_sim_transfer_cube_human`). Current
-   lerobot drops those buffers on load, so the bridge rebuilds both pipelines
-   from them using lerobot's own `extract_normalization_stats` +
-   `make_pre_post_processors`.
-
-Without (2), such a checkpoint would silently pass data through un-normalized:
-state reaches the policy in raw degrees and predicted actions reach the motors
-still in the model's normalized space, producing off-policy / micro-motion
-trajectories.
-
-### MolmoAct2 normalization is lerobot's
-
-MolmoAct2 checkpoints do not take either bridge path. They are
-transformers-native (`config.json` has `model_type=molmoact2` and no lerobot
-draccus `type`), so the policy routes them to lerobot's own factory --
-`make_policy_config("molmoact2", ...)` then `make_pre_post_processors(cfg)`.
-That factory reads the checkpoint's `norm_stats.json` itself, resolves
-`norm_tag` against the tags the file declares, and honors a
-`norm_stats_filename` the checkpoint names in its `config.json`.
-
-Pass `norm_tag=` to select an embodiment's statistics. A tag the file does not
-declare is refused by lerobot, which names the tag asked for and the tags the
-checkpoint actually declares:
-
-```
-ValueError: Unknown MolmoAct2 norm_tag='so101'.
-Available tags: ['so100_so101_molmoact2'].
-```
-
-Because lerobot owns this transform, strands does not reimplement it -- a second
-copy could drift from lerobot's normalizer without anything failing. See
-[MolmoAct2](#molmoact2) for the load path.
-
-### Device-pinned checkpoints
-
-A checkpoint trained on GPU bakes `device_processor.device = "cuda"` into its
-`policy_preprocessor.json` / `policy_postprocessor.json`. Loaded on a host
-without that device (CPU-only edge box, or a CUDA build on a machine whose
-driver predates the wheel's CUDA version), LeRobot asserts the device is
-available and the `device_processor` step fails to instantiate -- which surfaces
-as an error indistinguishable from "no pipeline config present".
-
-The bridge already moves every tensor onto the `device` you pass to
-`create_policy` (auto-detected when `None`), so it reconciles the pinned step
-onto that resolved device and retries the load once, rather than dropping the
-pipeline. Without this, normalization would be silently disabled: state reaches
-the policy in raw units and actions reach the motors in normalized space,
-producing off-policy / micro-motion trajectories. An explicit
-`processor_overrides={"device_processor": {"device": ...}}` is still honored
-as-is and takes precedence over the automatic reconciliation.
-
-### Overriding a processor step
-
-`processor_overrides` is keyed by step name -- a step's `registry_name`, or its
-class name when the step is not registry-backed. A checkpoint ships two
-pipelines whose step names are mostly disjoint, so each override is routed to
-the pipeline that declares it:
-
-| step | pipeline | what it controls |
-| --- | --- | --- |
-| `normalizer_processor` | preprocessor | `observation.state` normalization |
-| `unnormalizer_processor` | postprocessor | `action` un-normalization |
-| `device_processor` | both | tensor placement |
-
-A key no pipeline declares is refused, and the refusal lists both pipelines'
-step names.
-
-This is how you supply stats to a checkpoint whose declared normalization is
-inert -- a pretraining *base* checkpoint such as `lerobot/smolvla_base` ships
-stats keyed by its training dataset (`so100.buffer.action`) rather than the
-canonical `action` / `observation.state` keys, so LeRobot's normalizer finds no
-matching key and passes those tensors through untouched. Both halves live in
-different pipelines, so a remedy has to name both steps:
+`use_processor=True` (default) wraps the policy in the checkpoint's
+pre/post-processor pipelines, so observations are normalized going in and
+actions come back in physical joint units. The bridge takes them from
+`policy_preprocessor.json` / `policy_postprocessor.json` when the checkpoint
+ships them; a pre-processor-era checkpoint that instead carries
+`normalize_inputs.*` / `unnormalize_outputs.*` buffers in `model.safetensors`
+(still the case for zoo checkpoints such as
+`lerobot/act_aloha_sim_transfer_cube_human`) has both pipelines rebuilt from
+those buffers with lerobot's own `extract_normalization_stats` +
+`make_pre_post_processors`. MolmoAct2 checkpoints take neither path: lerobot's
+own factory reads their `norm_stats.json`, and a `norm_tag` the file does not
+declare is refused by lerobot naming the tags it does (see
+[MolmoAct2](#molmoact2)). `processor_overrides` is keyed by step name (a step's
+`registry_name`, or its class name when it is not registry-backed) and each
+override is routed to the pipeline that owns that step:
 
 ```python
 policy = create_policy(
@@ -358,11 +165,12 @@ Naming only one leaves the other inert, and the diagnostic keeps reporting
 whichever half is still unnormalized. Fine-tuning the checkpoint writes stats
 under the canonical keys and needs no override at all.
 
-Supplied stats have to be as WIDE as the features the checkpoint declares. Width
-is what differs between embodiments -- a 6-DOF SO-101, a 7-DOF arm and a 14-DOF
-bimanual all have `observation.state` and `action` -- so reaching for the wrong
-dataset's stats is easy. A mismatch is refused when the policy loads, naming the
-feature and both widths:
+Supplied stats must be as wide as the features the checkpoint declares - a
+6-DOF SO-101, a 7-DOF arm and a 14-DOF bimanual all have `observation.state`,
+so the wrong dataset's stats are an easy reach. A mismatch is refused at load,
+naming the feature and both widths, instead of surfacing as LeRobot's tensor
+broadcast error on the first inference after the robot has been commanded.
+Visual `(C,)` stats are exempt (LeRobot reshapes them to `(C, 1, 1)`):
 
 ```
 ValueError: lerobot_local: lerobot/smolvla_base was given normalization stats
@@ -371,140 +179,33 @@ that do not match the widths the checkpoint declares: ["observation.state
 supply 7", ...]
 ```
 
-LeRobot itself would reach the arithmetic and raise from the tensor broadcast
-(`The size of tensor a (6) must match the size of tensor b (7)`) on the FIRST
-inference instead -- naming neither the feature nor either width, and only after
-a rollout has started and the robot has been commanded. Visual stats are exempt:
-LeRobot reshapes a flat `(C,)` channel stat to `(C, 1, 1)`, so a 3-wide stat is
-correct for a `(3, H, W)` image feature.
-
 ## State routing
 
-`observation.state` is composed from `robot_state_keys` (set explicitly with
-`set_robot_state_keys([...])`, or by an `embodiment`). That ordering is used
-verbatim whenever at least one of its keys is present in the observation; a
-configured key the observation does not carry is zero-filled IN PLACE so the
-present joints keep their index.
-
-When NONE of the configured keys match - typically generic auto-generated names
-(`joint_0..joint_N`) paired with a sim that reports named joints - the policy
-warns (or raises under `strict_keys=True`), sets `generic_state_keys_used`, and
-falls back to the observation's own scalar keys so the state is populated rather
-than silently dropped.
-
-Both degradations quote a remedy chosen from the observation itself rather than a
-fixed example. `matching_embodiments(observation_keys)` returns every shipped
-embodiment whose entire `state_keys` set the observation carries, and only those
-are offered:
-
-- one match - the message names it (`embodiment='so100'`);
-- several - all are listed, because an observation cannot always tell them apart
-  (the real SO, Koch and OMX arms all report the same six `'<motor>.pos'` keys);
-- none - no embodiment is suggested at all, only `set_robot_state_keys([...])`,
-  quoted with the observed keys verbatim when the list is short enough to paste.
-
-This matters most on hardware. A real SO arm reports `'<motor>.pos'` keys, while
-the `so101` embodiment declares the MuJoCo asset's numeric joints `'1'..'6'` and
-converts degrees to radians - so recommending it there would re-declare keys the
-observation does not have, landing back on this same guard. `so_real` is the
-configuration that binds that observation, and it is what the message names.
-
-That fallback ordering is **position-only**: a `<joint>.vel` entry is dropped
-when the observation also carries its `<joint>` position companion. The MuJoCo
-backend emits a velocity sibling beside every joint position, so taking its keys
-in observation order would otherwise interleave velocities into the state vector
-and push the trailing joints past the model's declared state dim. A `.vel` key
-with no position companion is kept, because some embodiments legitimately declare
-velocity state (LeKiwi's body-frame base velocities `x.vel` / `y.vel` /
-`theta.vel`). Explicit `robot_state_keys` are never filtered - naming `elbow.vel`
-there states the model's input.
-
-### A declarative `embodiment=` reports the same two degradations
-
-A declarative `embodiment=` installs its own state step, and it reports both
-degradations with that same registry-checked remedy. A partly-bound vector names
-the absent keys, the keys the observation does carry, and the remedy; an
-all-bound-nothing configuration says so instead of handing the observation on in
-silence, since the downstream error it would otherwise produce knows nothing
-about embodiments and cannot name the one that binds this observation.
-
-The two conventions in the embodiment registry are what make an all-missing
-binding easy to reach in either direction:
-
-- **A sim embodiment driven from real hardware.** `embodiment="so101"` declares
-  the MuJoCo asset's `'1'..'6'`, and a real arm reports `'<motor>.pos'`. This
-  direction binds anyway: the step falls back to the observation's `'.pos'` keys
-  in motor order, packed raw because hardware already reports the model's
-  training units.
-- **A `*_real` embodiment driven from sim.** Several names are both a lerobot
-  driver spelling and a sim-loadable registry robot - `so100_follower`,
-  `so101_follower`, `koch_follower`, `bi_so_follower`, `lekiwi`, `openarm` - and
-  each resolves to a `*_real` configuration whose `'.pos'` keys no sim
-  observation emits. There is no fallback in this direction, so no
-  `observation.state` is packed; the report names the sim-side configuration to
-  use instead (`embodiment='so101'` for a MuJoCo so101).
-
-An unbound state is a configuration mistake rather than a degraded reading, so
-nothing is invented to stand in for it - no all-zero vector is emitted, and the
-observation is passed on unchanged for a state-less policy or the caller's own
-handling.
+`observation.state` is composed from `robot_state_keys`, set with
+`set_robot_state_keys([...])` or by an `embodiment`. When only some keys are
+present the vector is partly bound and the policy reports the absent keys, the
+keys the observation does carry and the remedy; when none are present it falls
+back to the observation's own state vector. Both degradations are logged, and
+`strict_keys=True` turns them into raises.
 
 ## Camera routing
 
-Robot/sim observations use bare camera names (`top`, `wrist`, `side`); the policy
-declares image inputs under its own keys (`observation.images.top`, ...). The
-policy routes each camera to a declared image slot by, in order:
+Observations use bare camera names (`top`, `wrist`); the policy declares image
+inputs as `observation.images.*`. Each camera is routed by, in order:
 
-1. an explicit `camera_key_map` (`{robot_cam: policy_image_key}`) when provided;
-2. exact name match (`top` -> `observation.images.top`);
-3. positional fallback into remaining slots, with a WARNING so a mismatched
-   wiring is loud rather than silent. Pass `strict_keys=True` to raise a
-   `ValueError` (listing the unmatched cameras vs available image keys)
-   instead of falling back positionally; it defaults to `False` and is a
-   no-op when `camera_key_map` or exact names already resolve every camera.
-
-The declared order follows the model config's `image_keys` list when present
-(e.g. MolmoAct2), otherwise the order of the model's image input features. If
-the robot supplies fewer cameras than the policy requires, a `ValueError` is
-raised instead of feeding the model a missing or wrong view.
-
-Image input slots are identified by their declared `FeatureType.VISUAL`, not
-by a substring match on the feature name. A policy may declare image keys that
-do not follow the `observation.images.*` convention (for example MolmoAct2's
-bare `base`/`wrist` keys); such cameras are still routed to their VISUAL slots
-rather than dropped, so the preprocessor never fails with a misleading
-"image_keys missing from observation".
-
-```python
-policy = create_policy(
-    "lerobot_local",
-    pretrained_name_or_path="your-org/molmoact2-so101",
-    camera_key_map={"front": "observation.images.top", "hand": "observation.images.wrist"},
-)
-```
+1. `camera_key_map={"front": "observation.images.top", ...}` when given;
+2. the embodiment's `obs_rename` map (below);
+3. a name heuristic (exact stem, then substring).
 
 ### Embodiment `obs_rename` and the pre-flight check
 
-When you pass an `embodiment` (e.g. `embodiment="so101"`), camera routing is
-configured declaratively from the embodiment's `obs_rename` map
-(`{runtime_camera_name: "observation.images.*"}`) instead of the heuristic
-above. The runtime observation MUST therefore contain the camera names the
-embodiment declares as rename sources. For `so101` those are `front` and
-`wrist`:
+`embodiment="so101"` routes cameras from the embodiment's `obs_rename`
+(`{runtime_camera_name: "observation.images.*"}`), merged under any
+`obs_rename_override`. Before the model is built the policy checks that every
+declared image feature has a source in the runtime observation and refuses
+otherwise, naming both sides:
 
-```json
-"obs_rename": {"front": "observation.images.image", "wrist": "observation.images.wrist_image"}
-```
-
-A camera-name mismatch (e.g. you added `realsense_top` / `realsense_side`
-because a model card said "top + side") used to surface only deep in the
-preprocessor AFTER the multi-minute weight download, as a confusing
-`image_keys missing from observation` failure. `run_policy` / `eval_policy` now
-run a cheap pre-flight check (`Policy.preflight`) BEFORE `create_policy`
-downloads anything, and return a `status=error` naming the expected source
-keys:
-
-```
+```text
 Embodiment 'so101' cannot route cameras to the model's image feature(s)
 ['observation.images.image', 'observation.images.wrist_image']: none of the
 expected source key(s) ['front', 'wrist'] are in the runtime observation, which
@@ -512,264 +213,58 @@ provides [...]. Either: (a) rename your sim cameras to one of ['front', 'wrist']
 ..., or (b) pass policy_config={'obs_rename_override': {...}} ...
 ```
 
-Two ways to fix it:
-
-1. Rename your cameras to the expected source keys
-   (`sim.add_camera(name="front", ...)`, `sim.add_camera(name="wrist", ...)`).
-2. Keep your custom names and pass `obs_rename_override`, which merges OVER the
-   embodiment's `obs_rename` so your names route onto the model's image
-   features without renaming cameras:
-
-   ```python
-   sim.run_policy(
-       robot_name="so101",
-       policy_provider="lerobot_local",
-       policy_config={
-           "pretrained_name_or_path": "allenai/MolmoAct2-SO100_101",
-           "embodiment": "so101",
-           "obs_rename_override": {
-               "realsense_top": "observation.images.image",
-               "realsense_side": "observation.images.wrist_image",
-           },
-       },
-   )
-   ```
-
-3. Drop a camera the embodiment declares but your checkpoint does not. The
-   built-in SO embodiments declare both `front` and `wrist`; a single-camera
-   checkpoint declares only one image feature, so the unmatched `wrist` rename
-   targets a feature the model never declares and fails validation. Map the
-   stale source key to `None` (or `""`) in `obs_rename_override` to remove it,
-   and route your real camera onto the model's feature:
-
-   ```python
-   create_policy(
-       "lerobot_local",
-       pretrained_name_or_path="your-org/so101-single-cam-act",
-       embodiment="so_real",
-       obs_rename_override={
-           "front": "observation.images.front",  # route the one camera you have
-           "wrist": None,                         # drop the camera you do not
-       },
-   )
-   ```
-
-#### `image_keys` must declare what the embodiment feeds
-
-The pre-flight check works in both directions. An explicit `image_keys=` is
-priority 1 in `derive_image_keys`, so it *replaces* the feature list that would
-otherwise be derived from the embodiment's `obs_rename` targets. If the list does
-not cover those targets, the model is built without the inputs the embodiment
-routes and its configuration is refused after the weight download, so pre-flight
-refuses it up front instead:
-
-```
-Embodiment 'so_real' feeds image feature(s) ['observation.images.image',
-'observation.images.wrist_image'], but the explicit image_keys=['base', 'wrist']
-does not declare them, so the model would be built without the inputs the
-embodiment routes and its configuration is refused after the weight download.
-Either: (a) drop image_keys= ..., or (b) pass image_keys=[...] ..., or
-(c) pass policy_config={'obs_rename_override': {...}} for EVERY key you declared ...
-```
-
-Any of the three named fixes resolves it: drop `image_keys` so the features come
-from the embodiment, declare the embodiment's own targets, or retarget every key
-you declared with `obs_rename_override` so each declared feature is a rename
-target. `image_keys` is a MolmoAct2 knob and is inert for other policy types, so
-this check applies to the MolmoAct2 load path only.
-
-#### `image_keys` is a list of names, not a name
-
-A single key still has to be a one-element list. `str` is iterable, so a bare
-string is read one name per character - `image_keys="wrist"` would declare five
-features named `w`, `r`, `i`, `s` and `t` - and nothing downstream can tell that
-apart from a deliberate five-entry list. Passing one is refused, with the reading
-it would have produced and the list to pass instead:
-
-```
-LerobotLocalPolicy: image_keys must be a list of names, not a single string, got
-'wrist'. A string is iterable per character, so this would be read as
-['w', 'r', 'i', 's', 't'] (5 name(s)). Wrap it in a list: ['wrist'].
-```
-
-A mapping is refused for the mirror-image reason (it iterates over its keys, so
-its values would be dropped), as is a non-string entry, a blank entry, and a
-repeated one - a duplicate collapses in the feature dict, declaring fewer
-features than asked for. `None` and `[]` keep their meaning of "not supplied",
-so the list is derived from the embodiment as usual. The refusal happens before
-the weight download.
-
-### Single camera with no embodiment
-
-You do not need an embodiment at all for a single-camera checkpoint. Declare the
-robot's joint names with `set_robot_state_keys([...])` and the policy synthesizes
-a state-only embodiment that routes each declared `observation.images.*` feature
-from its short name (`observation.images.front` <- `front`) and composes
-`observation.state` in your joint order. A bare camera key (`front`) is
-canonicalized to CHW float and renamed onto the model feature, and the state is
-batched alongside it, so a single-camera ACT checkpoint runs on the declarative
-path without manual key wiring:
-
-```python
-policy = create_policy("lerobot_local", pretrained_name_or_path="your-org/so101-single-cam-act")
-policy.set_robot_state_keys(
-    ["shoulder_pan.pos", "shoulder_lift.pos", "elbow_flex.pos",
-     "wrist_flex.pos", "wrist_roll.pos", "gripper.pos"]
-)
-# obs={"front": <HWC uint8 frame>, "shoulder_pan.pos": ..., ...}
-actions = policy.get_actions_sync(obs, "pick up the cube")
-```
-
-Pass `camera_key_map={"my_cam": "observation.images.front"}` if your runtime
-camera name differs from the feature's short name.
-
-See [camera naming](camera-naming.md) for the model-card -> embodiment
-translation table.
+A single-camera checkpoint needs no embodiment: declare the joint names with
+`set_robot_state_keys([...])` and the policy synthesizes a state-only embodiment
+that routes the one declared image feature to the one camera.
 
 ## RTC
+
+Real-Time Chunking (LeRobot's `rtc_*` config) blends each new action chunk into
+the still-unexecuted tail of the previous one and lets inference overlap
+execution. Enable it per policy:
 
 ```python
 policy = create_policy("lerobot_local", pretrained_name_or_path="lerobot/pi0_so100",
                         rtc_enabled=True, rtc_execution_horizon=16, rtc_max_guidance_weight=1.0)
 ```
 
-Real-Time Chunking does two things. First, **seam blending**: each new action
-chunk is denoised conditioned on the still-unexecuted tail of the previous
-chunk (`rtc_execution_horizon`), so the trajectory has no discontinuity where
-one chunk hands off to the next. Second, on real hardware, it lets **inference
-overlap execution**: the controller fires the next inference while the current
-chunk is still being executed, so the model's latency is hidden behind motion
-rather than appearing as a stall at the seam.
-
-### Re-query interval: `execution_horizon`
-
-The SIM consumes `policy.execution_horizon` actions from each chunk before
-re-querying - the single source of truth for the re-query rate. For an RTC
-policy this is `rtc_execution_horizon` (default 10), **not** the trained chunk
-length (`actions_per_step`, auto-detected from the model, e.g. 50). Re-querying
-mid-chunk is what lets the policy receive its previous chunk's unexecuted tail
-(`prev_chunk_left_over`) and blend the seam; draining the full trained chunk
-first leaves that tail empty and silently degrades RTC to open-loop replay. The
-policy decides this interval - a caller-supplied `action_horizon` is ignored for
-RTC policies (it cannot stretch the interval and break blending). For non-RTC
-policies `execution_horizon == actions_per_step` and the consumer still takes
-`max(action_horizon, actions_per_step)` so the trained chunk is never truncated.
-
-### What the prefix contains: `prev_chunk_left_over`
-
-The prefix is the previous chunk **from the observation tick to its end** - the
-same span LeRobot's `ActionQueue.get_left_over()` returns
-(`original_queue[last_index:]`). Row 0 is the action applied on the tick right
-after the observation, and row *i* the action applied on the tick the new chunk's
-row *i* lands on. LeRobot's denoiser depends on that index alignment: it builds
-`get_prefix_weights(inference_delay, execution_horizon, T)`, pinning weight 1.0
-across `[0, inference_delay)` - the steps that elapse *during* inference - and
-blending `[inference_delay, execution_horizon)` toward the prefix.
-
-The provider therefore keeps each chunk as the consumer received it and cuts the
-prefix at the next query, from the overlap the runtime reports
-(`set_rtc_observed_delay`). Under `async_rtc=True` the runner fires the prefetch
-mid-chunk, so the prefix opens on the action still pending at that moment; under
-`async_rtc=False` the chunk has drained and it opens past the execution horizon.
-Cutting the prefix when the chunk is produced cannot express the async case: how
-far the consumer has drained the chunk is not known until its next observation is
-captured.
-
-### Relative-action policies: prefix re-anchoring
-
-Some flow-matching checkpoints (pi0 / pi0.5 / pi0-FAST trained with a
-`RelativeActionsProcessorStep`) predict actions as offsets from the current
-robot state rather than absolute joint targets. The unexecuted tail carried into
-the next chunk (`prev_chunk_left_over`) is therefore only valid in the
-coordinate frame of the observation that produced it. Because the robot state
-moves between chunks, feeding that tail back verbatim would blend a STALE-frame
-prefix into the next chunk and corrupt the seam.
-
-For these policies the provider keeps the leftover in absolute coordinates and
-re-expresses it against the live robot state every query via LeRobot's
-`reanchor_relative_rtc_prefix` (reading the cached state from the preprocessor's
-`RelativeActionsProcessorStep`), so the model always receives a correctly
-anchored prefix. This is detected automatically from the loaded preprocessor
-pipeline - no flag is needed - and only engages when an enabled relative-action
-step is present. Absolute-action policies carry the model-space leftover
-verbatim (their frame does not move). The deterministic step-count delay below
-is untouched, so re-anchoring preserves bit-reproducibility.
+The sim consumes `policy.execution_horizon` actions from each chunk before
+re-querying - `rtc_execution_horizon` (default 10) for an RTC policy, the full
+chunk otherwise. For relative-action checkpoints (pi0 / pi0.5 / pi0-FAST
+trained with `RelativeActionsProcessorStep`) the carried prefix is re-anchored
+to the state at the new query, so the seam does not double-apply the offset.
 
 ### Synchronous vs async chunk execution in sim
 
-`run_policy` / `PolicyRunner.run` accept an `async_rtc` flag controlling which
-of those two RTC benefits the sim reproduces:
+`run_policy` / `PolicyRunner.run` accept `async_rtc`:
 
 | `async_rtc` | Behaviour | Use when |
 | --- | --- | --- |
 | `None` (default) | Auto-resolve from `policy.is_chunk_emitting()`: chunk-emitting policies get the async overlap, single-step policies stay synchronous. An explicit `True`/`False` always wins. | The common case - let the policy decide. |
-| `False` | Query the policy, drain `execution_horizon` actions (the full chunk for non-RTC; `rtc_execution_horizon` for RTC), then re-query. Seam blending works because the RTC policy is re-queried mid-chunk, but inference and execution do **not** overlap. | Single-step policies, deterministic regression runs, or any policy whose `get_actions` reads live sim state. |
-| `True` | While the current chunk drains, fire the next `get_actions` on a single background worker once the chunk is ~50% consumed (using a fresh mid-execution observation), then atomically swap it in. A policy whose inference latency is at most the chunk's execution window pays (almost) zero visible stall at the seam. | Chunk-emitting VLA / flow-matching policies (pi0, pi0.5, pi0-FAST, SmolVLA, MolmoAct2) where you want sim per-step timing to track real-hardware behaviour, or to benchmark a streaming controller. |
-
-Because MolmoAct2, pi0, pi0.5, pi0-FAST and SmolVLA all self-report as chunk-emitting, the default `async_rtc=None` enables latency masking for them automatically - no flag needed. Each `run_policy` result carries `rtc_*` telemetry (`rtc_async_enabled`, `rtc_prefetch_hits`, `rtc_prefetch_blocks`, `rtc_avg_inference_ms`, ...) so you can confirm the masking worked; see [Simulation -> Async-RTC chunk pipeline](../simulation/overview.md#async-rtc-chunk-pipeline-latency-masking). Pass `rtc_inference_timeout_s=` to abort cleanly on a stuck inference instead of stalling the whole rollout.
+| `False` | Query the policy, drain `execution_horizon` actions, then re-query. Seam blending works because the RTC policy is re-queried mid-chunk, but inference and execution do **not** overlap. | Single-step policies, deterministic regression runs, or any policy whose `get_actions` reads live sim state. |
+| `True` | While the current chunk drains, fire the next `get_actions` on a background worker once the chunk is ~50% consumed, then atomically swap it in. | Chunk-emitting VLA / flow-matching policies (pi0, pi0.5, pi0-FAST, SmolVLA, MolmoAct2) where sim per-step timing should track real hardware. |
 
 ```python
-# Default (async_rtc=None): pi0 self-reports as chunk-emitting, so the async
-# overlap is enabled automatically - inference latency is masked.
-sim.run_policy(robot_name="so101", policy_provider="lerobot_local",
-               policy_config={"pretrained_name_or_path": "lerobot/pi0_so100", "rtc_enabled": True},
-               action_horizon=8)
-
-# Force the synchronous chunk-then-drain loop (inference shows up as a per-seam
-# stall in sim) - e.g. for a deterministic regression run.
 sim.run_policy(robot_name="so101", policy_provider="lerobot_local",
                policy_config={"pretrained_name_or_path": "lerobot/pi0_so100", "rtc_enabled": True},
                action_horizon=8, async_rtc=False)
 ```
 
-`async_rtc` is provider-agnostic: it only schedules the inference/execution
-overlap and never touches the policy's RTC machinery, so RTC-capable policies
-still blend the seam internally. The runner invokes the policy from at most one
-thread at a time and blocks on any in-flight inference before returning, so it
-introduces no data race. Masking only helps when there is execution to hide
-behind, so the benefit is largest at real-time pacing (`fast_mode=False`) with
-multi-step chunks; with `fast_mode=True` and near-instant physics there is
-little execution window to overlap.
-
 ### Deterministic inference delay
 
-RTC has to know how many control steps the robot executed *while inference was
-running* - that offset is where it slices the next chunk so the seam lines up.
-Estimating it from wall-clock latency is non-reproducible: the measured latency
-warms up over the first few inferences of an episode and jitters run-to-run, so
-two fixed-seed episodes drift apart at the seam (the "seeds fixed but trajectory
-varies" symptom in multi-episode evals).
-
-`PolicyRunner` instead tells the policy the **exact** step count via
-`policy.set_rtc_observed_delay(steps)` immediately before each query:
-
-- Synchronous loop (`async_rtc=False`): the world is paused during inference, so
-  exactly `0` steps elapse.
-- Async pipeline (`async_rtc=True`): the prefetched chunk first applies after the
-  remaining steps of the chunk currently executing drain - a known integer,
-  independent of how long inference actually takes (a slow inference just stalls
-  the loop; the arm does not advance past the chunk end while it waits).
-
-So an eval driven by the runner is bit-reproducible across episodes regardless of
-machine load. When a policy is driven directly without a runner (e.g. on async
-real hardware where the arm genuinely keeps moving during inference), leave the
-override unset (`None`) and the policy falls back to the wall-clock p95 estimate,
-which is the right proxy there.
-
-The override is an offset into the action chunk, so it accepts `None` or a
-non-negative `int` and nothing else. A fractional count is not a smaller offset
-and `True` is not a count of one - both used to be coerced into a neighbouring
-value, which moves the seam silently. The control rate the estimator multiplies
-by (`set_control_frequency(hz)`) is a finite positive number for the same
-reason: `nan` and `inf` survive a `hz <= 0` test but not the `int()` that turns
-a latency into a step count, so they are refused where they arrive rather than
-part-way through a rollout.
+RTC slices the next chunk by how many control steps elapsed during inference.
+`PolicyRunner` passes the exact count via `policy.set_rtc_observed_delay(steps)`
+before each query (`0` in the synchronous loop; the remaining drain of the
+current chunk in the async pipeline), so a runner-driven eval is
+bit-reproducible regardless of machine load. Driven without a runner (async
+real hardware), leave it `None` and the policy uses its wall-clock p95
+estimate. The override accepts `None` or a non-negative `int` only, and
+`set_control_frequency(hz)` a finite positive number - `nan`, `inf`, fractions
+and `True` are refused where they arrive.
 
 ## See also
 
 - [MolmoAct2 (SO-100/101)](molmoact2.md) - action contract, units, and motion diagnostics
 - [Policy providers](../policies/overview.md)
 - [Training](../training/overview.md)
-- [GR00T](groot.md)
-- [cuRobo](curobo.md)
-- [LeRobot project](https://github.com/huggingface/lerobot)
+- [LeRobot policy docs](https://huggingface.co/docs/lerobot) - configs, processors, RTC

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -5,7 +5,7 @@ description: HuggingFace LeRobot direct inference - ACT, Pi0, SmolVLA, Diffusion
 # LeRobot Local
 
 ```bash
-uv pip install "strands-robots[lerobot]"
+uv pip install "strands-robots[smolvla]"  # [lerobot] plus transformers, which SmolVLA needs at load
 export STRANDS_TRUST_REMOTE_CODE=1        # required; raises UntrustedRemoteCodeError otherwise
 ```
 
@@ -14,7 +14,7 @@ from strands_robots.policies import create_policy
 
 policy = create_policy(
     "lerobot_local",
-    pretrained_name_or_path="lerobot/pi0_so100",   # HF model_id or local path
+    pretrained_name_or_path="lerobot/smolvla_base",   # HF model_id or local path
     device="cuda",
 )
 ```
@@ -224,7 +224,7 @@ the still-unexecuted tail of the previous one and lets inference overlap
 execution. Enable it per policy:
 
 ```python
-policy = create_policy("lerobot_local", pretrained_name_or_path="lerobot/pi0_so100",
+policy = create_policy("lerobot_local", pretrained_name_or_path="lerobot/smolvla_base",
                         rtc_enabled=True, rtc_execution_horizon=16, rtc_max_guidance_weight=1.0)
 ```
 
@@ -246,7 +246,7 @@ to the state at the new query, so the seam does not double-apply the offset.
 
 ```python
 sim.run_policy(robot_name="so101", policy_provider="lerobot_local",
-               policy_config={"pretrained_name_or_path": "lerobot/pi0_so100", "rtc_enabled": True},
+               policy_config={"pretrained_name_or_path": "lerobot/smolvla_base", "rtc_enabled": True},
                action_horizon=8, async_rtc=False)
 ```
 

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -69,7 +69,8 @@ Loading a large VLA (MolmoAct2 SO-100/101 ships 1,295 weight files) takes a
 minute or more. Models are cached process-wide, keyed by
 `(pretrained_name_or_path, policy_type, device, revision)`; a second
 `create_policy` with the same key reuses the weights. Every instance records
-`load_cache_hit` (`bool`) and `load_seconds`, and `run_policy` reports them as
+`load_cache_hit` (`bool`) and `load_time_s` (`float`, near `0.0` on a hit),
+and `run_policy` reports them as
 `policy_load_cache_hit` / `policy_load_time_s` in its result block.
 
 ```python

--- a/docs/policies/protomotions.md
+++ b/docs/policies/protomotions.md
@@ -3,13 +3,11 @@
 `ProtoMotionsPolicy` wraps a ProtoMotions **Generalist Tracking Policy** (GTP)
 ONNX export. Given a reference motion clip it emits balanced PD joint targets
 for the Unitree G1's 29 actuators, tracking that clip while keeping the robot
-upright.
-
-It is the tracking half of a two-stage pipeline. A *kinematic* generator such as
-[`KimodoPolicy`](./kimodo.md) (text-to-motion diffusion) produces a `qpos`
-sequence with no notion of balance; the tracker turns that sequence into physics. Compare
+upright. It is the tracking half of a two-stage pipeline: a *kinematic*
+generator such as [`KimodoPolicy`](./kimodo.md) produces a `qpos` sequence with
+no notion of balance, and the tracker turns it into physics. Compare
 [`WBC`](./wbc.md), which takes a velocity/height *command* rather than a
-reference clip and so cannot follow a whole-body pose trajectory.
+reference clip.
 
 ## Install
 
@@ -52,32 +50,24 @@ sim.run_policy(
 
 ## The observation contract
 
-The tracker consumes four inputs per tick. Three are ordinary proprioception —
-joint positions, joint velocities, and the floating base's angular velocity —
-and the runtime already publishes all three (`<joint>`, `<joint>.vel` and
-`base_ang_vel`, which is the base freejoint's `qvel[3:6]` and so is already in
-the body frame the network wants).
-
-The fourth is the **world orientation of the anchor link**, `torso_link` on the
-G1. This one is not derivable from the observation's floating-base signals:
-`base_quat` is the *pelvis*, and the torso differs from it by the three waist
-joints. On a G1 sweeping its waist through 0.6 rad the two frames diverge by up
-to 42 degrees, so substituting the base would feed the network a wrong frame
-rather than an approximation of the right one.
-
-The policy therefore declares the link it needs:
+The tracker consumes four inputs per tick. Three are ordinary proprioception the
+runtime already publishes: joint positions (`<joint>`), joint velocities
+(`<joint>.vel`) and the base angular velocity (`base_ang_vel`, the freejoint's
+`qvel[3:6]`, already in the body frame). The fourth is the **world orientation
+of the anchor link**, `torso_link` on the G1 - not derivable from `base_quat`,
+which is the *pelvis*: with the waist swept through 0.6 rad the two frames
+diverge by up to 42 degrees. So the policy declares the link it needs, and the
+runtime resolves it once per rollout and merges `body.torso_link.quat` into every
+observation (the same "policy declares, runtime supplies" contract as
+[`requires_images`](./overview.md)):
 
 ```python
 policy.required_bodies        # ('torso_link',)
 ```
 
-and the runtime resolves that name once per rollout and merges
-`body.torso_link.quat` into every observation it hands to `get_actions`. Nothing
-is required of the caller — this is the same "policy declares, runtime supplies"
-contract as [`requires_images`](./overview.md).
-
-A caller assembling observations by hand (a hardware loop reading an IMU, for
-instance) can pass the signals directly instead:
+A caller assembling observations by hand (a hardware loop reading an IMU) passes
+the two signals directly, or puts them on the observation dict under either
+spelling:
 
 ```python
 await policy.get_actions(
@@ -88,36 +78,18 @@ await policy.get_actions(
 )
 ```
 
-Either signal can instead sit on the observation dict itself, under its bare
-name or its `observation.`-prefixed spelling - the shape a runtime that
-namespaces its observation keys produces:
-
 | signal | accepted observation keys |
 | --- | --- |
 | anchor rotation, `xyzw` | `anchor_rot_xyzw`, `observation.anchor_rot_xyzw` |
 | root angular velocity, local frame | `root_ang_vel_local`, `observation.root_ang_vel_local` |
 
-The prefixed spelling is the bare name with `observation.` in front in both
-rows, so one dict can carry both signals written the same way. (`anchor_rot`
-without the `_xyzw` suffix is also still accepted for the anchor rotation, but
-it does not say which component order it carries, so prefer the suffixed name.)
+Missing signals are refused, not substituted: no anchor pose raises naming the
+key it wanted (`base_quat` stands in only when the config's anchor body *is* the
+floating base), and an absent `<joint>.vel` is refused rather than read as zero.
 
-If neither the declared body pose nor an explicit override is present the policy
-raises, naming the key it wanted. It will not fall back to `base_quat` unless
-the config's anchor body *is* the floating base, in which case the two are the
-same frame by definition.
-
-Joint velocities are treated the same way: an absent `<joint>.vel` is refused
-rather than substituted with zero. Velocity is tracker feedback, and zeros are a
-plausible-looking value that quietly degrades tracking.
-
-### Orientations need not be exactly unit
-
-Every rotation the tracker derives — body-framing the root angular velocity,
-and extracting a yaw for heading alignment — is computed from a formula that
-mixes a quadratic term in the quaternion components with a constant, so the
-quaternion's scale does not cancel. Both helpers therefore normalise their
-input, and a quaternion scaled by any positive factor gives the same answer:
+Orientations need not be exactly unit: both rotation helpers normalise their
+input, so a drifted IMU reading or a lerped sample (up to 8% short, which read
+as-is is a heading 6.2 degrees off) gives the unit quaternion's answer:
 
 ```python
 from strands_robots.policies.protomotions import extract_yaw_quat
@@ -126,42 +98,27 @@ extract_yaw_quat(q)          # same heading as
 extract_yaw_quat(q * 0.92)   # this
 ```
 
-That is worth knowing when assembling observations by hand. An IMU reading
-drifts off unit, and an orientation obtained by *linearly* interpolating two
-samples is short by up to about 8% — for two samples 90 degrees apart the
-midpoint has `|q| = 0.924`, which read as-is would be a heading 6.2 degrees off
-and an angular velocity 29% short of its true magnitude. (Linear interpolation
-is why the clip loader slerps and renormalises rather than lerping.)
-
-An orientation that cannot define a rotation at all — all zeros, which is how a
-never-written or dropped orientation reads, or a non-finite component — is
-refused with a `ValueError` naming the helper and the value. Scaling cannot
-recover a direction from it, and standing in an arbitrary rotation would feed
-the network a plausible-looking wrong frame.
+An orientation that cannot define a rotation - all zeros, or a non-finite
+component - is refused with a `ValueError` naming the helper and the value.
 
 ## Bridging a qpos clip
 
 `qpos_to_motion_data` turns a `[T, 7 + 29]` MuJoCo `qpos` sequence into the
-cache the tracker plays. It runs forward kinematics through the ProtoMotions
-MJCF to recover per-body world poses, finite-differences velocities at the
-source rate, and resamples onto the tracker's `control_dt` (0.02 s):
+cache the tracker plays: forward kinematics through the ProtoMotions MJCF for
+per-body world poses, finite-differenced velocities at the source rate,
+resampled onto the tracker's `control_dt` (0.02 s):
 
 ```python
 cache = qpos_to_motion_data(qpos, fps=30, proto_mjcf_path=mjcf)
 cache["num_frames"], cache["control_dt"]
 ```
 
-`MotionPlayer` accepts that dict, an `.npz` written by
-`MotionPlayer.save_cache_npz`, or a raw ProtoMotions `.pt`.
+`MotionPlayer` accepts that dict, an `.npz` from `MotionPlayer.save_cache_npz`,
+or a raw ProtoMotions `.pt`. Four things to know about the cache:
 
-Each channel is `[num_frames, ...]`, so a cache states its frame count several
-times over and `MotionPlayer` checks those statements agree before playing it.
-That matters when you edit a cache by hand - trimming or concatenating the
-channels and leaving `num_frames` behind is refused with both counts named,
-rather than overrunning the arrays part-way through the clip (the frame index is
-clamped to `num_frames`, and the tracker's future window reads ahead of the
-playhead) or silently hiding the tail. Drop `num_frames` and the channels' own
-row count is used:
+- **Frame counts must agree.** Every channel is `[num_frames, ...]`; trimming
+  the channels and leaving `num_frames` behind is refused with both counts
+  named. Drop `num_frames` (or set it) after editing:
 
 ```python
 cache["dof_pos"] = cache["dof_pos"][:100]   # ... and the other five channels
@@ -169,70 +126,26 @@ del cache["num_frames"]                     # or set it to 100
 player = MotionPlayer(cache)
 ```
 
-### The MJCF has to be the tracker's own embodiment
-
-`proto_mjcf_path` is not just any G1. The tracker reads a body out of the cache
-by **row index**, never by name: `anchor_body_index` and `root_body_index` are
-offsets into `GTP_G1_BODY_NAMES`, the 33-name list pinned from the checkpoint's
-sidecar. `qpos_to_motion_data` fills those rows by name from the model you hand
-it, so the model has to carry all 33 - plus a free root and the 29
-`GTP_G1_JOINT_NAMES` joints, for a `qpos` width of 36.
-
-The G1 family does not agree on that body set. The widely-shipped fingerless
-models omit `head` and both `rubber_hand` placeholders and expose 30 bodies;
-`g1_29dof_with_hand` and `g1_with_hands` expose 44 and a `qpos` width of 50.
-Passing one of those is refused, with a message that names what is missing:
-
-```text
-ValueError: ProtoMotions G1 MJCF .../g1_29dof.xml is missing 3 of the 33 bodies
-the tracker reads by row index: ['head', 'left_rubber_hand', 'right_rubber_hand'].
-```
-
-The refusal is the point. Read positionally, a 30-body model shifts every row
-after the gap by one, so the tracker asks for `torso_link` at row 16 and is
-handed `left_shoulder_pitch_link` - on a walking clip, an anchor orientation
-some 20 degrees out, with nothing in the cache to say so. A model whose `qpos`
-layout differs is refused separately and says so, so a model-side mismatch is
-not read as a bad `qpos` argument.
-
-### An MJCF that declares its own ground is used as-is
-
-Forward kinematics needs a floor, and the ProtoMotions G1 MJCF names one from
-`<contact><pair geom2="floor">`, so the bridge appends a plane geom called
-`floor` when - and only when - the model does not already declare a ground.
-
-Whether it does is decided from the geom list MuJoCo itself parses out of the
-file, so every way of declaring a ground counts: a plane in any of the
-`<worldbody>` sections MuJoCo merges, one nested inside a body, and one spliced
-in through `<include>`. Pass any G1 MJCF that already ships a floor - the
-`unitree_ros` G1 descriptions declare theirs in a second `<worldbody>`, and
-menagerie-style `scene.xml` wrappers `<include>` the robot and add their own -
-and it is used unchanged.
-
-### Cache velocities are world-frame
-
-`body_pos` and `body_rot` are world poses, and `body_vel` and `body_ang_vel`
-are **world-frame** velocities derived from them - the same convention a raw
-ProtoMotions motion library uses for `rigid_body_ang_vel`. That matters when
-you hand-build a cache instead of bridging one: the tracker's root input is a
-*local*-frame angular velocity, and `compute_root_local_ang_vel` produces it by
-rotating a world-frame row into the root's frame. Storing local-frame rows here
-gets them rotated a second time. The frames are not interchangeable - on a
-walking G1 clip they differ by whole rad/s, the same class of silent wrong-frame
-error as substituting the base for the anchor link above.
-
-### Motion files are read with a restricted unpickler
-
-An `.npz` cache is read by NumPy and needs no torch. A raw `.pt` is read with
-`torch.load(..., weights_only=True)`, which accepts tensors and plain scalars -
-the documented payload above - and refuses anything else.
-
-That restriction matters because a motion file travels: clips get downloaded,
-shared between machines and committed to dataset repos. The unrestricted
-unpickler runs whatever `__reduce__` a file names *while reading it*, so
-accepting one would make playing a third-party motion enough to execute code on
-the machine that plays it. If a `.pt` is refused, re-save it as a dict of
-tensors, or convert it once with `save_cache_npz` and load the `.npz`.
+- **The MJCF has to be the tracker's own embodiment.** The tracker reads bodies
+  by **row index** into `GTP_G1_BODY_NAMES` (33 names from the checkpoint's
+  sidecar), so `proto_mjcf_path` must carry all 33 bodies plus a free root and
+  the 29 `GTP_G1_JOINT_NAMES` joints (`qpos` width 36). The common fingerless
+  G1 models expose 30 bodies (no `head`, no `rubber_hand`s) and the hand
+  variants 44; both are refused naming what is missing, since a positional
+  read of a 30-body model hands the tracker the wrong link for `torso_link`.
+- **A floor is added only when the model has none.** The bridge appends a
+  plane geom named `floor` unless MuJoCo's parsed geom list already has a
+  ground (a `unitree_ros` second `<worldbody>`, a menagerie `scene.xml`
+  `<include>`), in which case the file is used unchanged.
+- **Cache velocities are world-frame.** `body_vel` / `body_ang_vel` follow the
+  ProtoMotions motion-library convention; `compute_root_local_ang_vel` rotates
+  them into the root frame, so a hand-built cache holding local-frame rows is
+  rotated twice - whole rad/s off on a walking clip.
+- **Motion files are read with a restricted unpickler.** `.npz` needs no torch;
+  a `.pt` is read with `torch.load(..., weights_only=True)`, which accepts
+  tensors and scalars only, because clips travel and an unrestricted unpickler
+  executes what the file names. A refused `.pt`: re-save it as a dict of
+  tensors, or convert once with `save_cache_npz`.
 
 ## Per-episode reset
 
@@ -250,102 +163,29 @@ names, the anchor and root body indices, per-joint PD gains, timing, and the
 lookahead offsets for the future-reference window. Pass `yaml_path=` to load a
 sidecar; omit it to use the defaults, which match the shipped export.
 
-| Field | Default | Meaning |
-| --- | --- | --- |
-| `joint_names` | 29 G1 joints | ONNX action order |
-| `anchor_body_index` | `16` (`torso_link`) | Link whose world rotation the network reads |
-| `root_body_index` | `0` (`pelvis`) | Floating base |
-| `control_dt` | `0.02` | Seconds per control tick (50 Hz); the period the reference motion is resampled onto |
-| `future_step_indices` | `(1, 2, 4, 8)` | Lookahead offsets, in control steps |
-| `action_ema_alpha` | `1.0` | Smoothing weight on the emitted joint targets; `1.0` is passthrough |
+| Field | Default | Meaning | Accepted |
+| --- | --- | --- | --- |
+| `joint_names` | 29 G1 joints | ONNX action order | |
+| `anchor_body_index` | `16` (`torso_link`) | Link whose world rotation the network reads | a whole number in `0..len(body_names)-1`; negative indices and booleans are refused, an integral float is kept as its row |
+| `root_body_index` | `0` (`pelvis`) | Floating base | same |
+| `control_dt` | `0.02` | Seconds per control tick (50 Hz); the period the reference motion is resampled onto | finite, `> 0`; a cache dict's own `control_dt` outranks the argument and is held to the same domain by `MotionPlayer` |
+| `future_step_indices` | `(1, 2, 4, 8)` | Lookahead offsets, in control steps | |
+| `action_ema_alpha` | `1.0` | Smoothing weight on the emitted joint targets; `1.0` is passthrough | finite, in `(0, 1]` |
 
-### A body index has to address a body
-
-The two body indices are offsets into `body_names`, so an index that misses is
-the config-side mirror of the model-side row shift above - and it is refused the
-same way, when the config is built rather than when something reads it:
-
-```text
-ValueError: ProtoMotionsConfig.anchor_body_index must be a row of body_names
-(0..32), got 99 for 33 bodies. The index is an offset into body_names, so one
-that misses cannot resolve the body it names.
-```
-
-Both directions are checked, because they fail differently. A negative index is
-a valid tuple lookup: `body_names[-1]` is `right_rubber_hand`, so an
-`anchor_body_index: -1` sidecar resolves a real link and the tracker anchors on
-it consistently - `required_bodies` declares that link, the runtime supplies its
-quaternion, and the future-reference window slices the same row. Nothing
-disagrees, and on the tracker's own embodiment that link's world orientation is
-20 degrees from `torso_link` with the waist turned and an arm raised. An index
-past the end used to surface only as `IndexError: tuple index out of range` from
-whichever property read the name first.
-
-The index also goes through the shared whole-number domain, so a yaml
-`anchor_body_index: true` is refused instead of being read as row 1 (`head`),
-and a hand-built `ProtoMotionsConfig(...)` reports the same value the same way a
-sidecar does. An integral float such as `16.0` addresses a row and is kept,
-normalised to the row number both consumers index with.
-
-### A control period has to be a period
-
-`control_dt` is the field of the timing block the control path spends. It is the
-period the reference motion is *resampled* onto, so it fixes how many frames one
-clip becomes, and the playhead advances exactly one of those frames per control
-tick. It goes through the same positive-finite domain, at construction:
-
-```text
-ValueError: ProtoMotionsConfig: control_dt must be > 0, got True.
-```
-
-The values it turns away are not near-misses. Measured by resampling a 3-second,
-30 fps reference clip that sweeps every joint once, then commanding the tracker one
-frame per tick and asking the default lookahead offsets `(1, 2, 4, 8)` for frames
-ahead of the playhead:
-
-| sidecar `timing.control_dt` | resolved | frames in the clip | widest joint travel | lookahead offsets already past the end |
-| --- | --- | --- | --- | --- |
-| `0.02` (shipped) | `0.02` | 151 | 1.050 rad | 0 of 4 |
-| `0.04` | `0.04` | 76 | 1.050 rad | 0 of 4 |
-| `true` | `1.0` | 4 | 0.940 rad | 2 of 4 |
-| `-0.02` | `-0.02` | 1 | 0.0 rad | 4 of 4 |
-| `inf` | `inf` | 1 | 0.0 rad | 4 of 4 |
-
-A negative period and `inf` collapse the clip to a single frame, because the
-conversion is `max(1, round(motion_length / control_dt) + 1)` and both make that
-term non-positive; the index clamp in `get_state_at_frame` then serves that one
-frame for every tick of the episode. Traced over 200 ticks, the commanded target
-never leaves `0.0` rad for either, while the shipped period arches to `1.0` rad at
-tick 75 and back by tick 150; `true` is over in three ticks (`0.0` -> `0.866` ->
-`0.866` -> `0.0`) and holds there for the remaining 196 - a tracker that reports a
-motion and plays almost none of it. `0` left the reported rate undefined, and
-`nan` used to reach
-`int(round(...))` inside the resampler and raise `cannot convert float NaN to
-integer` there, naming neither the field nor the sidecar it came from.
-
-A cache dict's own `control_dt` outranks the `control_dt=` argument, so it is
-held to the same domain by `MotionPlayer` rather than only at the config.
-
-`physics_dt` and `decimation` are deliberately left alone: no reader in this
-package consumes either, so refusing a value would change which sidecars load
-with no behaviour to protect. Their documented relation to `control_dt` is
-unchecked for the same reason.
+Every domain is checked when the config is built, from a sidecar or by hand, not
+when a field is read. The values turned away are not near-misses: a negative or
+infinite `control_dt` collapses a 3-second clip to one frame for the whole
+episode, `true` (read as `1.0`) plays it in three ticks, `action_ema_alpha=0`
+freezes the first target and `nan` poisons every later tick. `physics_dt` and
+`decimation` are unchecked: nothing in this package reads them.
 
 ### Target smoothing
 
-`action_ema_alpha` is the weight the CURRENT network output carries in the target
-the PD loop receives:
-
-```text
-y[t] = alpha * x[t] + (1 - alpha) * y[t-1]
-```
-
-`1.0` - the shipped checkpoint's own value - is passthrough, and returns the
-network output unchanged and bit-exact rather than multiplying it by one. A
-smaller value weights the previous target more heavily, trading tracking lag for
-less per-tick jitter in the commanded pose. Measured on a tracker output carrying
-an alternating +/-0.11 rad per-tick component, the mean per-tick change in the
-emitted `left_hip_pitch_joint` target:
+`action_ema_alpha` is the weight the current network output carries in the
+target the PD loop receives, `y[t] = alpha * x[t] + (1 - alpha) * y[t-1]`.
+`1.0` returns the output unchanged and bit-exact; a smaller value trades
+tracking lag for less per-tick jitter. Measured on an output with an alternating
++/-0.11 rad component, the mean per-tick change in `left_hip_pitch_joint`:
 
 | `action_ema_alpha` | mean per-tick change |
 | --- | --- |
@@ -354,30 +194,10 @@ emitted `left_hip_pitch_joint` target:
 | `0.2` | 0.029 rad |
 | `0.05` | 0.010 rad |
 
-Two things the filter deliberately does not do. The first tick of an episode
-seeds from the network's own output rather than from zeros - a zero-seeded filter
-would command a pose between the origin and the first target, which on a 29-DOF
-humanoid holding a stance is a lurch toward the zero pose, and the smaller the
-alpha the further that first command would sit from the motion. And the
-historical-actions buffer keeps carrying the RAW output: it feeds the graph's own
-`historical_processed_actions` input, which is defined over it, so smoothing what
-the network reads back would change its input distribution.
-
-The factor must be a finite number in `(0, 1]`, refused when the config is built
-rather than when the filter reads it, and by the sidecar and a hand-built
-`ProtoMotionsConfig(...)` alike:
-
-```text
-ValueError: ProtoMotionsConfig: action_ema_alpha must be > 0, got 0.0.
-```
-
-`0` weights the current output at zero, freezing the commanded pose at the first
-tick's target for the whole clip - a tracker that reports every frame and moves
-through none of them. A negative weight drives each joint the opposite way from
-the motion, a value above `1` gives the previous target a negative weight and
-extrapolates past the motion instead of smoothing toward it, and `nan` enters the
-filter state and never leaves it, so every joint of every later tick is `nan`
-however good the network output is.
+The first tick seeds the filter from the network's own output, not zeros (a
+zero seed would lurch a standing humanoid toward the zero pose), and the
+historical-actions buffer keeps the RAW output, since the graph's
+`historical_processed_actions` input is defined over it.
 
 ## Testing without weights
 


### PR DESCRIPTION
![preservation census](https://raw.githubusercontent.com/cagataycali/robots/assets/docs-policies-census-34501284020/census.png)

**What** `lerobot-local.md` 5,187 -> 1,540 words, `protomotions.md` 2,924 -> 1,403. Each contract stated once. 2 files, +177/-861, no source change.

**Why** Both pages restated every contract three to five times, so no statement read as authoritative. The cut also drops three symbols that do not exist (`norm_stats_filename`, `g1_with_hands`, `g1_29dof_with_hand` - 0 hits in the package), and corrects `load_seconds` to `load_time_s`, the attribute `simulation/base.py` reads via `getattr(policy, "load_time_s", 0.0)`.

**Tests** `mkdocs build --strict` exit 0. `pytest tests/`: 50,647 passed / 308 skipped. `--collect-only` gives 50,955 on this tree and on the base, so no grader was added or removed. Every rewritten fence checked against the real signature: 21/21 `LerobotLocalPolicy` defaults, 5/5 `ProtoMotionsConfig`.