### PR TITLE
docs(stream_dataset): drop a documented RuntimeError the code cannot raise

### DIFF
--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -1477,9 +1477,12 @@ class DatasetRecordingMixin:
                 ``1`` to read in capture order),
                 ``drop_videos`` (proprio-only,
                 torchcodec-free; requires ``delta_timestamps`` with at least one
-                non-video key, else ValueError), ``repo_type`` (``"dataset"`` or
-                ``"bucket"``; ``"bucket"`` requires lerobot>=0.6.1, else
-                RuntimeError).
+                non-video key, else ValueError), ``repo_type`` (``"dataset"``
+                or ``"bucket"``, forwarded unconditionally: every
+                lerobot-bearing extra floors lerobot at
+                ``BUCKET_STREAMING_MIN_LEROBOT``, whose constructor accepts the
+                keyword, so a below-floor install surfaces lerobot's own
+                ``TypeError`` naming it rather than a refusal from here).
 
         Returns:
             A :class:`~strands_robots.streaming_dataset.StreamingDatasetReader`.

--- a/tests/test_stream_dataset_documents_the_bucket_outcome.py
+++ b/tests/test_stream_dataset_documents_the_bucket_outcome.py
@@ -1,0 +1,64 @@
+"""``stream_dataset`` must not document a refusal it cannot raise.
+
+``repo_type="bucket"`` reaches lerobot's ``StreamingLeRobotDataset``
+unconditionally - the forwarding is pinned by
+``tests/test_streaming_dataset.py::test_open_forwards_every_knob_to_the_constructor``,
+because a dropped ``repo_type`` would silently read the versioned dataset
+namespace instead of the requested bucket. There is therefore no version probe
+left to refuse a below-floor lerobot, and the outcome on one is lerobot's own
+``TypeError`` for an unexpected keyword.
+
+The facade's docstring is the only place a caller learns which failure to
+handle, so naming ``RuntimeError`` there sends them to write an ``except``
+clause that can never run while the real ``TypeError`` escapes it.
+"""
+
+import pytest
+
+import strands_robots.streaming_dataset as sd
+from strands_robots import Simulation
+
+
+class _BelowFloorStreaming:
+    """A pre-``BUCKET_STREAMING_MIN_LEROBOT`` ``StreamingLeRobotDataset``.
+
+    Its constructor predates ``repo_type``, which is exactly what a below-floor
+    lerobot presents to the forwarding call.
+    """
+
+    def __init__(
+        self,
+        repo_id,
+        root=None,
+        tolerance_s=1e-4,
+        streaming=True,
+        buffer_size=1000,
+        max_num_shards=16,
+        seed=42,
+        shuffle=True,
+        return_uint8=True,
+    ):
+        self.repo_id = repo_id
+        self.fps = 30
+        self.num_frames = 1
+        self.num_episodes = 1
+
+
+def test_a_below_floor_lerobot_surfaces_its_own_typeerror(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The bucket request is forwarded, so the constructor rejects the keyword."""
+    monkeypatch.setattr(sd, "StreamingLeRobotDataset", _BelowFloorStreaming, raising=False)
+
+    with pytest.raises(TypeError, match="repo_type"):
+        sd.StreamingDatasetReader.open("org/ds", repo_type="bucket", validate_deltas=False)
+
+
+def test_the_facade_does_not_promise_a_refusal_it_cannot_raise() -> None:
+    """The documented ``repo_type`` outcome names the exception callers can catch."""
+    clause = (Simulation.stream_dataset.__doc__ or "").split("``repo_type``", 1)[-1]
+
+    assert "RuntimeError" not in clause, (
+        "stream_dataset documents RuntimeError for repo_type, but the keyword is "
+        "forwarded unconditionally and a below-floor lerobot raises TypeError: "
+        "callers would guard the wrong exception"
+    )
+    assert "TypeError" in clause, "the documented repo_type outcome must name the exception that is raised"


### PR DESCRIPTION
![documented refusal vs raised exception](https://raw.githubusercontent.com/cagataycali/robots/assets/stream-dataset-bucket-refusal-34505140229/bucket_refusal.png)

**What** `Simulation.stream_dataset` documented `repo_type="bucket"` as raising `RuntimeError` on a lerobot below the bucket-streaming floor. Nothing raises it: `StreamingDatasetReader.open` forwards `repo_type` unconditionally (pinned by `test_open_forwards_every_knob_to_the_constructor`, since a dropped `repo_type` would silently read the versioned dataset namespace instead of the bucket), so a below-floor install surfaces lerobot's own `TypeError`. The docstring is where a caller learns which failure to handle, so an `except RuntimeError` guard never runs while the `TypeError` escapes it. The same claim was corrected in `docs/recording.md`; this docstring was the last copy.

**Why** One probe in both trees raises `TypeError(... unexpected keyword argument 'repo_type')`. Text only: the module's compiled bytecode is byte-identical to main's (10,476 bytes each).

**Tests** New pin: pre-fix 1 failed / 1 passed, post-fix 2 passed. Full `tests/`: 50,621 passed, 308 skipped, 96.01% coverage. The lone failure was `test_recorder_capture_rate_survives_a_wall_clock_step[backward_2s]`, a wall-clock pacer premise flaking under three concurrent suites (load 7.4) with a different frame count each time; pristine `main` passed it 6/6 and this branch changes no bytecode. `ruff check`/`format` clean, `mypy` Success on 1,938 files.