### PR TITLE
fix(tools): lerobot_train reads dataset_root only when it starts a run

### DIFF
--- a/changelog.d/3505-lerobot-train-dataset-root-only-on-start.md
+++ b/changelog.d/3505-lerobot-train-dataset-root-only-on-start.md
@@ -1,0 +1,9 @@
+### Fixed: `lerobot_train` no longer demands a dataset to report on a run
+
+`dataset_root` was the tool's only required parameter, yet `status`, `stop` and
+`list` never read it - they look a session up by name. An agent asked to check
+on a training run therefore had to invent a dataset path before the call was
+accepted, and `lerobot_train(action="list")` from Python raised `TypeError`
+instead of listing anything. `dataset_root` is now optional; `start` still
+refuses to launch without it, naming the parameter, and the three session verbs
+answer without it.

--- a/strands_robots/tools/lerobot_train.py
+++ b/strands_robots/tools/lerobot_train.py
@@ -790,7 +790,7 @@ def build_train_command(
 
 @tool(context=True)
 def lerobot_train(
-    dataset_root: str,
+    dataset_root: str | None = None,
     tool_context: ToolContext | None = None,
     policy_type: str = "act",
     pretrained_path: str | None = None,
@@ -865,6 +865,8 @@ def lerobot_train(
 
     Args:
         dataset_root: Local LeRobot v3 dataset directory (must contain meta/info.json).
+            Read by ``start`` only, which refuses to launch without it; ``status``,
+            ``stop`` and ``list`` look a session up by name and never read it.
         policy_type: Policy architecture (act, diffusion, vqbet, tdmpc, smolvla,
             pi0, pi05, pi0_fast, groot, xvla, ...).
         pretrained_path: HF id or local path to initialize weights from (gated
@@ -958,6 +960,11 @@ def lerobot_train(
                 return {"status": "error", "content": [{"text": flag_error}]}
 
             # Preflight: lerobot must be importable and the dataset must exist.
+            if not dataset_root:
+                return {
+                    "status": "error",
+                    "content": [{"text": "dataset_root required for start action"}],
+                }
             try:
                 import lerobot  # noqa: F401
             except ImportError as e:

--- a/tests/tools/test_lerobot_train.py
+++ b/tests/tools/test_lerobot_train.py
@@ -510,6 +510,35 @@ def test_status_requires_session_name(tmp_path: Path) -> None:
     _assert_ascii(_texts(result))
 
 
+def test_session_verbs_do_not_require_a_dataset_root() -> None:
+    """``status``/``stop``/``list`` look a session up by name and never read the dataset.
+
+    ``dataset_root`` was the tool's one required parameter, so an agent had to
+    invent a dataset path to ask about a run, and a Python caller of
+    ``lerobot_train(action="list")`` got a ``TypeError`` instead of a result.
+    Only ``start`` reads it, so only ``start`` is refused without it.
+    """
+    required = lerobot_train.tool_spec["inputSchema"]["json"].get("required") or []
+    assert "dataset_root" not in required
+
+    listed = lerobot_train(action="list")
+    assert listed["status"] == "success"
+    assert tool_json(listed)["count"] == 0
+
+    status = lerobot_train(action="status", session_name="nope")
+    assert status["status"] == "error"
+    assert "not found" in _texts(status)
+
+    stop = lerobot_train(action="stop", session_name="nope")
+    assert stop["status"] == "error"
+    assert "not found" in _texts(stop)
+
+    start = lerobot_train(action="start")
+    assert start["status"] == "error"
+    assert "dataset_root required" in _texts(start)
+    _assert_ascii(_texts(listed) + _texts(status) + _texts(stop) + _texts(start))
+
+
 def test_unknown_action_errors(tmp_path: Path) -> None:
     root = _write_dataset(tmp_path / "ds")
     result = lerobot_train(action="frobnicate", dataset_root=str(root))


### PR DESCRIPTION
**What**

`lerobot_train` no longer requires `dataset_root` for `status`, `stop` and `list`; only `start` reads it and only `start` is refused without it.

**Why**

`dataset_root` was the tool's one required parameter, so an agent had to invent a dataset path to ask about a run, and `lerobot_train(action="list")` from Python raised `TypeError` instead of answering. On main the new test fails at:

```
assert "dataset_root" not in required
AssertionError: assert 'dataset_root' not in ['dataset_root']
```

**Tests**

`tests/tools/test_lerobot_train.py::test_session_verbs_do_not_require_a_dataset_root`; ruff, mypy clean on touched files.
