### PR TITLE
fix(simulation/isaac): an integer knob that falls back to its default says so

### DIFF
--- a/changelog.d/3512-isaac-env-int-knobs-report-their-fallback.md
+++ b/changelog.d/3512-isaac-env-int-knobs-report-their-fallback.md
@@ -1,0 +1,16 @@
+### Fixed: an Isaac integer knob that falls back to its default says so
+
+`_env_int` resolves three step counts - `STRANDS_ISAAC_CAMERA_WARMUP_STEPS`,
+`SO101_RECORD_CONVERGE` and `SO101_IDLE_CONVERGE` - and substituted the default
+for every value it could not honor without a word, while the neighbouring
+`_env_float` reports each of its own rejections and states why: a knob whose
+effect is only visible several calls away leaves the operator nothing to correct
+against when the substitution is silent. A typo (`3O`), a float spelling
+(`10.0`) or a non-positive count now logs a warning naming the variable, the
+value and the substitute; the accepted domain is unchanged and blank or unset
+stays quiet. `STRANDS_ISAAC_CAMERA_WARMUP_STEPS` is the count of render-bearing
+steps `add_camera` takes so a new camera's first frame is real rather than the
+pipeline's empty buffer, and its documentation says to raise it on a slow GPU -
+so an operator who did and mistyped it got an empty first frame with nothing
+naming the knob. Pinned by
+`tests/simulation/isaac/test_env_int_knobs_report_their_fallback.py`.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -122,7 +122,7 @@ other spelling is refused. See
 | `STRANDS_ISAAC_NUCLEUS_URL` | Override the Omniverse Nucleus server URL (when `nucleus_url` is not passed) | unset (Isaac defaults) |
 | `STRANDS_ISAAC_HEADLESS` | On forces headless; off forces a window | unset (uses `headless` kwarg) |
 | `STRANDS_ISAAC_RTX_PATHTRACING` | On forces `render_mode="rtx_pathtracing"`; off leaves `render_mode` alone | unset |
-| `STRANDS_ISAAC_CAMERA_WARMUP_STEPS` | Render-bearing world steps `add_camera` takes before returning, so a new RTX camera's first `get_rgba()` is a real frame rather than the empty buffer the pipeline returns until it has been stepped. Raise on a slow GPU. Positive integer; anything else falls back to the default | `10` |
+| `STRANDS_ISAAC_CAMERA_WARMUP_STEPS` | Render-bearing world steps `add_camera` takes before returning, so a new RTX camera's first `get_rgba()` is a real frame rather than the empty buffer the pipeline returns until it has been stepped. Raise on a slow GPU. Positive integer; anything else is reported with a warning naming the variable and falls back to the default | `10` |
 
 </details>
 

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -109,12 +109,38 @@ def _quat_wxyz_to_rotmat(quat: np.ndarray) -> np.ndarray:
 
 
 def _env_int(name: str, default: int) -> int:
-    """Read a small positive int from the environment (fallback to ``default``)."""
-    try:
-        v = int(os.environ.get(name, ""))
-        return v if v > 0 else default
-    except (TypeError, ValueError):
+    """Read a small positive int from the environment (fallback to ``default``).
+
+    Every rejection is reported, for the reason :func:`_env_float` below gives
+    for its own: substituting the default in silence leaves the operator's
+    model of the knob wrong with nothing to correct it against. The three
+    knobs this resolver serves are step counts whose effect is only visible
+    several calls away - ``STRANDS_ISAAC_CAMERA_WARMUP_STEPS`` decides whether
+    a new camera's first frame is real or the pipeline's empty buffer - so a
+    typo (``3O``), a float spelling (``10.0``) or a non-positive count that
+    fell back unreported surfaced as a wrong frame rather than as a
+    misconfigured variable. The accepted domain is unchanged: what ``int()``
+    parses and ``> 0`` admits.
+
+    Args:
+        name: Environment variable to read. Unset, empty or unusable falls back.
+        default: Value applied when the variable names no usable count.
+
+    Returns:
+        The override when it is a positive whole number, else ``default``.
+    """
+    raw = os.environ.get(name, "")
+    if raw.strip() == "":
         return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.warning("%s=%r is not a whole number; using %r", name, raw, default)
+        return default
+    if value <= 0:
+        logger.warning("Isaac simulation: %s must be > 0, got %r; using %r", name, value, default)
+        return default
+    return value
 
 
 def _env_float(name: str, default: float) -> float:

--- a/tests/simulation/isaac/test_env_int_knobs_report_their_fallback.py
+++ b/tests/simulation/isaac/test_env_int_knobs_report_their_fallback.py
@@ -1,0 +1,163 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""An Isaac integer knob that falls back to its default says so.
+
+:func:`~strands_robots.simulation.isaac.simulation._env_int` resolves three
+step counts - ``STRANDS_ISAAC_CAMERA_WARMUP_STEPS``, ``SO101_RECORD_CONVERGE``
+and ``SO101_IDLE_CONVERGE`` - and substituted the default for every value it
+could not honor without a word, while :func:`_env_float` eight lines below it
+reports each of its own rejections and states why: a knob whose effect is only
+visible several calls away leaves the operator nothing to correct against when
+the substitution is silent. Measured on the two resolvers side by side, same
+raw value, same process:
+
+==========  =============  ======================  =============  ============
+raw         ``_env_int``   int log                 ``_env_float`` float log
+==========  =============  ======================  =============  ============
+``3O``      10             (silent)                1.0            not a number
+``10.0``    10             (silent)                10.0           (honored)
+``0``       10             (silent)                1.0            must be > 0
+``-3``      10             (silent)                1.0            must be > 0
+``"  "``    10             (silent)                1.0            (silent)
+``5``       5              (silent)                5.0            (silent)
+==========  =============  ======================  =============  ============
+
+The first four int rows are the defect. ``STRANDS_ISAAC_CAMERA_WARMUP_STEPS``
+is the count of render-bearing steps ``add_camera`` takes so a new RTX camera's
+first ``get_rgba()`` is a real frame rather than the pipeline's empty buffer,
+and its documentation says to raise it on a slow GPU - so an operator who did
+and mistyped it got the default count and an empty first frame, with nothing
+naming the variable. The blank and unset rows are controls: not setting a knob
+is not a misconfiguration and must stay quiet, as it does for the float.
+
+The accepted domain is deliberately unchanged. ``10.0`` is still refused, as
+:func:`~strands_robots.mesh.core._parse_positive_int_env` refuses it, because
+this is a whole-number knob read from a string; what changed is that the
+refusal is now reported. Solver-free: the resolver reads the environment and
+the logger only, so no Isaac Sim Kit runtime is touched.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import strands_robots.simulation.isaac.simulation as isaac_module
+from strands_robots.simulation.isaac.simulation import _env_float, _env_int
+
+WARMUP_ENV = "STRANDS_ISAAC_CAMERA_WARMUP_STEPS"
+DEFAULT_WARMUP = 10
+
+NOT_A_WHOLE_NUMBER = ["3O", "ten", "1e2", "10.0", "inf", "nan"]
+NOT_POSITIVE = ["0", "-3", "-0"]
+BLANK = ["", "  ", "\t"]
+
+
+@pytest.fixture(autouse=True)
+def _clear_knob(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The knob must not be inherited from the runner running these tests."""
+    monkeypatch.delenv(WARMUP_ENV, raising=False)
+
+
+def _warnings(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+
+
+class TestAnUnusableCountIsReportedBeforeItFallsBack:
+    """The defect: the default applied in silence."""
+
+    @pytest.mark.parametrize("raw", NOT_A_WHOLE_NUMBER)
+    def test_a_value_int_cannot_parse_names_the_variable_and_the_value(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, raw: str
+    ) -> None:
+        monkeypatch.setenv(WARMUP_ENV, raw)
+        with caplog.at_level("WARNING", logger=isaac_module.__name__):
+            assert _env_int(WARMUP_ENV, DEFAULT_WARMUP) == DEFAULT_WARMUP
+        messages = _warnings(caplog)
+        assert len(messages) == 1, messages
+        assert WARMUP_ENV in messages[0] and repr(raw) in messages[0], messages
+
+    @pytest.mark.parametrize("raw", NOT_POSITIVE)
+    def test_a_non_positive_count_names_the_bound(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, raw: str
+    ) -> None:
+        monkeypatch.setenv(WARMUP_ENV, raw)
+        with caplog.at_level("WARNING", logger=isaac_module.__name__):
+            assert _env_int(WARMUP_ENV, DEFAULT_WARMUP) == DEFAULT_WARMUP
+        messages = _warnings(caplog)
+        assert len(messages) == 1, messages
+        assert WARMUP_ENV in messages[0] and "> 0" in messages[0], messages
+
+    @pytest.mark.parametrize("raw", NOT_A_WHOLE_NUMBER + NOT_POSITIVE)
+    def test_the_report_states_the_value_that_is_used_instead(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, raw: str
+    ) -> None:
+        """Naming the substitute is what lets the operator predict the run."""
+        monkeypatch.setenv(WARMUP_ENV, raw)
+        with caplog.at_level("WARNING", logger=isaac_module.__name__):
+            _env_int(WARMUP_ENV, 7)
+        assert any("using 7" in m for m in _warnings(caplog)), _warnings(caplog)
+
+
+class TestTheAcceptedDomainIsUnchanged:
+    """Over-reach controls: only the silence moved."""
+
+    @pytest.mark.parametrize(("raw", "expected"), [("5", 5), (" 7 ", 7), ("+12", 12), ("1", 1)])
+    def test_a_positive_whole_number_is_honored_without_a_warning(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, raw: str, expected: int
+    ) -> None:
+        monkeypatch.setenv(WARMUP_ENV, raw)
+        with caplog.at_level("WARNING", logger=isaac_module.__name__):
+            assert _env_int(WARMUP_ENV, DEFAULT_WARMUP) == expected
+        assert _warnings(caplog) == []
+
+    @pytest.mark.parametrize("raw", BLANK)
+    def test_a_blank_value_is_unset_and_stays_quiet(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, raw: str
+    ) -> None:
+        """Not setting a knob is not a misconfiguration."""
+        monkeypatch.setenv(WARMUP_ENV, raw)
+        with caplog.at_level("WARNING", logger=isaac_module.__name__):
+            assert _env_int(WARMUP_ENV, DEFAULT_WARMUP) == DEFAULT_WARMUP
+        assert _warnings(caplog) == []
+
+    def test_an_unset_variable_resolves_to_the_default_without_a_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level("WARNING", logger=isaac_module.__name__):
+            assert _env_int(WARMUP_ENV, DEFAULT_WARMUP) == DEFAULT_WARMUP
+        assert _warnings(caplog) == []
+
+    @pytest.mark.parametrize("raw", ["10.0", "1e2"])
+    def test_a_float_spelling_is_still_refused_not_widened(self, monkeypatch: pytest.MonkeyPatch, raw: str) -> None:
+        """A whole-number knob read from a string keeps ``int()``'s domain, as
+        the mesh's ``_parse_positive_int_env`` does; only the report is new.
+        """
+        monkeypatch.setenv(WARMUP_ENV, raw)
+        assert _env_int(WARMUP_ENV, DEFAULT_WARMUP) == DEFAULT_WARMUP
+
+
+class TestTheTwoResolversReportTheSameClassOfInput:
+    """The two knob resolvers in one module cannot diverge on whether a
+    rejection is reported: a value neither can honor is reported by both, and
+    a blank neither treats as set is reported by neither.
+    """
+
+    @pytest.mark.parametrize("raw", ["3O", "0", "-3"])
+    def test_a_value_both_refuse_is_reported_by_both(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, raw: str
+    ) -> None:
+        monkeypatch.setenv(WARMUP_ENV, raw)
+        with caplog.at_level("WARNING", logger=isaac_module.__name__):
+            _env_int(WARMUP_ENV, DEFAULT_WARMUP)
+            _env_float(WARMUP_ENV, 1.0)
+        assert len(_warnings(caplog)) == 2, _warnings(caplog)
+
+    @pytest.mark.parametrize("raw", BLANK)
+    def test_a_blank_is_reported_by_neither(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, raw: str
+    ) -> None:
+        monkeypatch.setenv(WARMUP_ENV, raw)
+        with caplog.at_level("WARNING", logger=isaac_module.__name__):
+            _env_int(WARMUP_ENV, DEFAULT_WARMUP)
+            _env_float(WARMUP_ENV, 1.0)
+        assert _warnings(caplog) == []


### PR DESCRIPTION
**What** `_env_int` in `strands_robots/simulation/isaac/simulation.py` resolves three step counts - `STRANDS_ISAAC_CAMERA_WARMUP_STEPS`, `SO101_RECORD_CONVERGE`, `SO101_IDLE_CONVERGE` - and substituted the default for every value it could not honor without a word. `_env_float`, eight lines below it, reports each of its own rejections, and its docstring states why: a knob whose effect is only visible several calls away leaves the operator nothing to correct against when the substitution is silent. `STRANDS_ISAAC_CAMERA_WARMUP_STEPS` is the count of render-bearing steps `add_camera` takes so a new RTX camera's first `get_rgba()` is a real frame rather than the pipeline's empty buffer, and `docs/reference/configuration.md` says to raise it on a slow GPU - so an operator who did and mistyped it got the default count and an empty first frame, with nothing naming the variable.

**Measured** on `main` @ `09a28da8`, same raw value through both resolvers in one process:

| raw | `_env_int` | int log | `_env_float` | float log |
|---|---|---|---|---|
| `3O` | 10 | (silent) | 1.0 | `is not a number; using 1.0` |
| `10.0` | 10 | (silent) | 10.0 | (honored) |
| `0` | 10 | (silent) | 1.0 | `must be > 0` |
| `-3` | 10 | (silent) | 1.0 | `must be > 0` |
| `"  "` | 10 | (silent) | 1.0 | (silent) |
| `5` | 5 | (silent) | 5.0 | (silent) |

The first four int rows are the defect. The last two are controls and are unchanged.

**Change** `_env_int` takes `_env_float`'s shape: blank is unset and stays quiet; a value `int()` cannot parse warns naming the variable, the raw value and the substitute; a non-positive count warns naming the `> 0` bound. The accepted domain is deliberately unchanged - `10.0` is still refused, as `mesh.core._parse_positive_int_env` refuses it, because this is a whole-number knob read from a string; only the report is new. Docs row for `STRANDS_ISAAC_CAMERA_WARMUP_STEPS` now says the fallback is reported.

**Tests** `tests/simulation/isaac/test_env_int_knobs_report_their_fallback.py`: 34 cells, solver-free. 21 fail on the pre-fix code (the silence), 13 controls pass on both trees (honored values, blank, unset, float spelling still refused). A third class grades the two resolvers together so they cannot diverge again on whether a rejection is reported. The existing `TestTheIntResolverNeedsNoSuchBound` control in `test_idle_render_period_is_a_finite_span.py` stays green (67 passed across both files).

**Whole-tree graders** run on branch and base with the same environment: failure set byte-identical (56 failed / 149 errors, every one a missing optional dependency - `lerobot`, `mujoco`, `torch`, `awsiot`). `ruff check`, `ruff format --check`, `mypy` clean on the two edited Python files.

**Overlap** `check_merge_base_overlap.py --paths` names #3343 on `isaac/simulation.py`. Read its head `0afaa60e`: it leaves `_env_int` byte-identical (moved from line 111 to 142, not edited) and its nearest hunks are at lines 37-88 and 286+, so the two do not touch. Whichever lands second absorbs the other cleanly.

**Round log**
- R0: opened as draft so the fragment lands before the branch is marked ready.