### PR TITLE
fix(mesh): leaving the mesh waits for the loops that publish on it

### DIFF
--- a/changelog.d/3519-mesh-stop-waits-for-its-loops.md
+++ b/changelog.d/3519-mesh-stop-waits-for-its-loops.md
@@ -1,0 +1,24 @@
+### Fixed: leaving the mesh waits for the loops that publish on it
+
+`Mesh.start` launches nine background sensor loops - heartbeat, state, and the
+seven `SensorLoopsMixin` loops - and ten with camera publishing enabled,
+collecting each on a roster. `Mesh.stop` set the stop flag and then immediately
+undeclared the subscribers, dropped the session reference and logged `off mesh`,
+without waiting for any of them. The roster was appended to at four sites and
+read at none.
+
+Each loop is paced on a shared stop event and notices a stop within 10ms of its
+next tick boundary, but a tick already inside `publish()` is not interrupted by
+the flag. So `stop()` returned with all nine loops still running, and an in-flight
+tick landed on the wire *after* the peer announced it had left, through a session
+reference the peer had already given back - a publish on a session whose last
+reference may have closed it. The same gap made a stopped peer's loops able to
+publish into whatever the process wired up next.
+
+`stop()` now joins the loops before releasing what they publish through. The
+budget is a named `LOOP_JOIN_TIMEOUT_S` spent across the loops rather than per
+loop, since they wind down in parallel and a per-loop budget would let one wedged
+driver read cost nine times as long. A loop that outlasts it is still free to
+publish once more, so it is named at WARNING with the count and the budget rather
+than the stop being announced as having happened - the same posture the mesh input
+publisher and the teleop mixin already take for the single loop each of them owns.

--- a/docs/mesh.md
+++ b/docs/mesh.md
@@ -311,6 +311,13 @@ change, or a hub that went away and came back. The peer keeps its identity
 across it: the `peer_id` is unchanged, and an engaged e-stop lockout stays
 engaged, so a network blip is not a way to forget a stop.
 
+`stop()` waits for the sensor loops before it releases anything they publish
+through, so by the time it returns the peer really is off the wire rather than
+merely flagged as gone. The wait is bounded and shared across the loops: a sensor
+read that blocks - a serial bus that stopped answering is the ordinary cause -
+holds one tick open past the budget, and that loop is then named at WARNING as
+still able to publish once more, instead of the stop being reported as complete.
+
 What does not survive is your own `subscribe()` topics. `start()` re-declares
 the peer's built-in topics from the table above; the subscribers `subscribe()`
 returned are undeclared with the session reference and their callbacks are not

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -218,6 +218,15 @@ RESUME_REPLAY_CACHE_MAX: int = _parse_positive_int_env("STRANDS_MESH_RESUME_REPL
 #: ``reason`` beside it is the exception's type name, which is bounded already.
 MAX_DEGRADED_DETAIL_LEN: int = 256
 
+#: Total budget for joining the sensor loops :meth:`Mesh.start` launched, spent
+#: across all of them rather than per loop: the loops wind down in parallel and
+#: notice the stop within 10ms (:class:`~strands_robots.mesh.pacing.Ticker`), so
+#: a per-loop budget would let one wedged driver read cost nine times this. Named
+#: so the docstring, the WARNING and the tests read one value. Matches
+#: :data:`strands_robots.mesh.input._INPUT_JOIN_TIMEOUT_S` and
+#: :data:`strands_robots.teleop_mixin._TELEOP_JOIN_TIMEOUT_S` in purpose.
+LOOP_JOIN_TIMEOUT_S: float = 2.0
+
 
 def _resume_freshness_window_s() -> float:
     """Lazy resolver for ``STRANDS_MESH_RESUME_FRESHNESS_S``.
@@ -953,6 +962,13 @@ class Mesh(SensorLoopsMixin):
     def stop(self) -> None:
         """Stop all loops and release the session reference.
 
+        Waits for the loops :meth:`start` launched before releasing anything they
+        publish through, so a tick already inside :meth:`publish` cannot land on
+        the wire after this peer has announced it left. The wait is bounded by
+        :data:`LOOP_JOIN_TIMEOUT_S` and shared across the loops; a sensor read
+        that blocks past it leaves its loop free to publish once more, and that
+        loop is named at WARNING rather than the stop being reported as complete.
+
         Drops every :meth:`subscribe` subscription and clears :attr:`inbox`:
         the subscribers are undeclared with the session reference, and the
         ``(topic, callback)`` pairs behind them are not retained, so
@@ -965,6 +981,8 @@ class Mesh(SensorLoopsMixin):
                 return
             self._running = False
             self._stop_event.set()
+
+        self._join_loops()
 
         with _LOCAL_ROBOTS_LOCK:
             _LOCAL_ROBOTS.pop(self.peer_id, None)
@@ -1027,6 +1045,41 @@ class Mesh(SensorLoopsMixin):
             self._has_session_ref = False
 
         logger.info("[mesh] %s off mesh", self.peer_id)
+
+    def _join_loops(self) -> None:
+        """Wait for the loops :meth:`start` launched, then say what did not stop.
+
+        Called by :meth:`stop` before it undeclares the subscribers and drops the
+        session reference, because that is what the loops publish through: a tick
+        already inside :meth:`publish` when the flag flipped would otherwise land
+        on the wire after this peer announced it had left, using a session
+        reference it no longer holds.
+
+        ``join()`` returns ``None`` whether or not a thread finished, so the
+        liveness read after it is the only thing that tells a stopped loop from
+        one that outlasted :data:`LOOP_JOIN_TIMEOUT_S`. A driver whose sensor read
+        blocks past that budget - a serial read on a wedged bus is the ordinary
+        case - leaves its loop free to publish once more after :meth:`stop`
+        returns, so that outcome is logged at WARNING naming the loops rather than
+        being announced as a stop that happened. The roster is left in place: a
+        caller can read :attr:`_threads` for those handles, and :meth:`start`
+        rebuilds it on a rejoin.
+        """
+        deadline = time.monotonic() + LOOP_JOIN_TIMEOUT_S
+        for thread in list(self._threads):
+            thread.join(timeout=max(0.0, deadline - time.monotonic()))
+        if late := [t.name for t in self._threads if t.is_alive()]:
+            logger.warning(
+                "[mesh] %s: %d of %d loop(s) did not stop within %.1fs and may "
+                "publish once more after stop() returns: %s. A sensor read that "
+                "blocks - a serial bus that stopped answering is the ordinary "
+                "cause - is what holds a tick open past the budget.",
+                self.peer_id,
+                len(late),
+                len(self._threads),
+                LOOP_JOIN_TIMEOUT_S,
+                ", ".join(late),
+            )
 
     @property
     def alive(self) -> bool:

--- a/tests/mesh/test_stop_waits_for_the_loops_it_started.py
+++ b/tests/mesh/test_stop_waits_for_the_loops_it_started.py
@@ -1,0 +1,221 @@
+"""``Mesh.stop`` waits for the sensor loops before releasing what they publish through.
+
+:meth:`~strands_robots.mesh.core.Mesh.start` launches nine background loops
+(heartbeat, state, and the seven :class:`~strands_robots.mesh.sensors.SensorLoopsMixin`
+loops), collecting them on a roster; ten with camera publishing enabled. Each is
+paced by a :class:`~strands_robots.mesh.pacing.Ticker` on a shared stop event, so
+each notices a stop within 10ms of the *next* tick boundary - but a tick already
+inside ``publish()`` when the flag flipped is not interrupted by it.
+
+:meth:`~strands_robots.mesh.core.Mesh.stop` used to flip the flag and immediately
+undeclare the subscribers, drop the session reference and log ``off mesh``. So an
+in-flight tick landed on the wire after the peer announced it had left, through a
+session reference the peer no longer held - and ``stop()`` returned with every loop
+it started still running. The roster was collected at four sites and read at none.
+
+Pinned here: every loop is joined before the teardown that follows, the join is
+bounded so one wedged sensor read cannot wedge ``stop()``, the budget is spent
+across the loops rather than per loop, and a loop that outlasts it is named at
+WARNING rather than being announced as a stop that happened.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import strands_robots.mesh.core as core_mod
+import strands_robots.mesh.session as session_mod
+from strands_robots.mesh.core import Mesh
+
+#: Loops ``start()`` launches unconditionally, by roster thread-name suffix.
+ALWAYS_ON_LOOPS = (
+    "heartbeat",
+    "state",
+    "pose",
+    "health",
+    "imu",
+    "odom",
+    "lidar",
+    "hand",
+    "map-info",
+)
+
+PEER = "peer-a"
+
+
+class _FakeRobot:
+    """The smallest robot the loops can read without a driver or a transport."""
+
+    tool_name_str = "fakebot"
+
+    def get_task_status(self) -> dict[str, Any]:
+        return {"status": "idle"}
+
+    def get_features(self) -> dict[str, Any]:
+        return {"foo": "bar"}
+
+
+@contextmanager
+def running_mesh(
+    on_put: Callable[[str, dict[str, Any]], None] | None = None,
+    on_release: Callable[[], None] | None = None,
+) -> Iterator[Mesh]:
+    """Yield a started :class:`Mesh` whose transport is a mock.
+
+    Args:
+        on_put: Called for every publish, so a test can hold one tick open or
+            record the order publishes land in.
+        on_release: Called when ``stop()`` drops the session reference.
+
+    Yields:
+        The started mesh. Always stopped again on the way out, so a test that
+        leaves a loop wedged still cannot leak it into a later test.
+    """
+    session = MagicMock()
+    with (
+        patch.object(session_mod, "get_session", return_value=session),
+        patch.object(session_mod, "current_session", return_value=session),
+        patch.object(core_mod, "get_session", return_value=session),
+        patch.object(core_mod, "current_session", return_value=session),
+        patch.object(core_mod, "release_session", side_effect=on_release),
+        patch.object(core_mod, "put", side_effect=on_put),
+    ):
+        mesh = Mesh(_FakeRobot(), peer_id=PEER, peer_type="robot")
+        mesh.start()
+        try:
+            yield mesh
+        finally:
+            if mesh.alive:
+                mesh.stop()
+
+
+@pytest.fixture(autouse=True)
+def _startable_mesh(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Let ``start()`` past the ACL posture gate, and pace the loops fast."""
+    monkeypatch.setenv("STRANDS_MESH_LOCAL_DEV", "true")
+    monkeypatch.setenv("STRANDS_MESH_HEALTH_HZ", "50")
+
+
+def _tick_holder(topic_suffix: str) -> tuple[Any, Any, list[str], threading.Event, threading.Event]:
+    """Build the put/release hooks that hold one tick of ``topic_suffix`` open."""
+    entered, release = threading.Event(), threading.Event()
+    order: list[str] = []
+    lock = threading.Lock()
+
+    def on_put(key: str, _data: dict[str, Any]) -> None:
+        if key.endswith(f"/{topic_suffix}") and not entered.is_set():
+            entered.set()
+            release.wait(10)
+            with lock:
+                order.append("publish-landed")
+
+    def on_release() -> None:
+        with lock:
+            order.append("session-released")
+
+    return on_put, on_release, order, entered, release
+
+
+def test_the_roster_holds_every_loop_start_launched() -> None:
+    """The join can only cover the loops ``start()`` actually recorded."""
+    with running_mesh() as mesh:
+        names = {t.name for t in mesh._threads}
+    assert names == {f"mesh-{loop}-{PEER}" for loop in ALWAYS_ON_LOOPS}
+
+
+def test_no_loop_is_still_running_when_stop_returns() -> None:
+    """``stop()`` does not announce a stop it has not waited for."""
+    with running_mesh() as mesh:
+        mesh.stop()
+        still_running = [t.name for t in mesh._threads if t.is_alive()]
+    assert still_running == []
+
+
+def test_an_in_flight_publish_lands_before_stop_returns() -> None:
+    """A tick inside ``publish()`` finishes while ``stop()`` is still waiting."""
+    on_put, on_release, order, entered, release = _tick_holder("health")
+    with running_mesh(on_put=on_put, on_release=on_release) as mesh:
+        mesh._read_health = lambda: {"peer_id": PEER, "battery_pct": 42.0}  # type: ignore[method-assign]
+        assert entered.wait(5), "the health loop never reached publish()"
+        threading.Timer(0.2, release.set).start()
+        mesh.stop()
+        assert "publish-landed" in order, "stop() returned while a publish was in flight"
+
+
+def test_an_in_flight_publish_lands_before_the_session_reference_is_dropped() -> None:
+    """No loop publishes through a session reference the peer has given back."""
+    on_put, on_release, order, entered, release = _tick_holder("health")
+    with running_mesh(on_put=on_put, on_release=on_release) as mesh:
+        mesh._read_health = lambda: {"peer_id": PEER, "battery_pct": 42.0}  # type: ignore[method-assign]
+        assert entered.wait(5), "the health loop never reached publish()"
+        threading.Timer(0.2, release.set).start()
+        mesh.stop()
+    assert order == ["publish-landed", "session-released"]
+
+
+def test_the_camera_loop_is_joined_like_the_always_on_loops(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The opt-in loop is on the roster, so waiting covers it too."""
+    monkeypatch.setenv("STRANDS_MESH_CAMERA_HZ", "20")
+    with running_mesh() as mesh:
+        assert f"mesh-camera-{PEER}" in {t.name for t in mesh._threads}
+        mesh.stop()
+        assert [t.name for t in mesh._threads if t.is_alive()] == []
+
+
+def test_a_wedged_loop_is_named_rather_than_wedging_stop(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A sensor read that never returns costs the budget, not the process."""
+    monkeypatch.setattr(core_mod, "LOOP_JOIN_TIMEOUT_S", 0.3)
+    on_put, _on_release, _order, entered, release = _tick_holder("health")
+    with caplog.at_level("WARNING"), running_mesh(on_put=on_put) as mesh:
+        mesh._read_health = lambda: {"peer_id": PEER, "battery_pct": 42.0}  # type: ignore[method-assign]
+        assert entered.wait(5), "the health loop never reached publish()"
+        start = time.monotonic()
+        mesh.stop()
+        elapsed = time.monotonic() - start
+        release.set()
+    assert elapsed < 3.0, f"stop() waited {elapsed:.1f}s on a wedged loop"
+    assert f"mesh-health-{PEER}" in caplog.text
+    assert "0.3s" in caplog.text
+
+
+def test_the_budget_is_spent_across_the_loops_not_once_per_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Three wedged loops cost one budget: they wind down in parallel."""
+    monkeypatch.setattr(core_mod, "LOOP_JOIN_TIMEOUT_S", 0.4)
+    wedged = threading.Event()
+    entered = threading.Semaphore(0)
+    held = {"health", "imu", "odom"}
+
+    def on_put(key: str, _data: dict[str, Any]) -> None:
+        if key.rsplit("/", 1)[-1] in held:
+            entered.release()
+            wedged.wait(10)
+
+    with running_mesh(on_put=on_put) as mesh:
+        mesh._read_health = lambda: {"peer_id": PEER, "battery_pct": 1.0}  # type: ignore[method-assign]
+        mesh._read_imu = lambda: {"peer_id": PEER, "accel": [0.0, 0.0, 9.8]}  # type: ignore[method-assign]
+        mesh._read_odom = lambda: {"peer_id": PEER, "x": 0.0}  # type: ignore[method-assign]
+        for _ in range(len(held)):
+            assert entered.acquire(timeout=5), "not every held loop reached publish()"
+        start = time.monotonic()
+        mesh.stop()
+        elapsed = time.monotonic() - start
+        wedged.set()
+    assert elapsed < 3 * 0.4, f"{elapsed:.2f}s looks like one budget per loop, not one shared"
+
+
+def test_a_peer_whose_loops_are_idle_stops_promptly() -> None:
+    """The ordinary path still returns at once - waiting is not a new delay."""
+    with running_mesh() as mesh:
+        start = time.monotonic()
+        mesh.stop()
+        elapsed = time.monotonic() - start
+    assert elapsed < 1.0, f"an idle peer took {elapsed:.2f}s to stop"

--- a/tests/mesh/test_zenoh_lifecycle_error_classification.py
+++ b/tests/mesh/test_zenoh_lifecycle_error_classification.py
@@ -56,6 +56,9 @@ def _bare_mesh_for_stop(subs=None, safety_publishers=None):
     mesh._running = True
     mesh._lifecycle_lock = threading.RLock()
     mesh._stop_event = MagicMock()
+    # No loop was launched, so the roster stop() joins is empty - but it must be
+    # present, like every other attribute stop() reads on this bare instance.
+    mesh._threads = []
     mesh._subs_lock = threading.RLock()
     mesh._subs = list(subs or [])
     mesh._user_subs = set()


### PR DESCRIPTION
![Mesh.stop timeline, measured on both trees](https://raw.githubusercontent.com/cagataycali/robots/artifacts-mesh-stop-joins-loops/mesh_stop_joins_loops.png)

## What

`Mesh.start` launches nine loops (heartbeat, state, and the seven `SensorLoopsMixin` loops; ten with camera publishing on) and collects each on a roster. The roster was appended to at four sites and read at none: `stop()` set the stop flag, then immediately undeclared the subscribers, dropped the session reference and logged `off mesh`.

## Why

Each loop is paced on a shared stop event and notices a stop within 10 ms of its *next* tick boundary, but a tick already inside `publish()` is not interrupted by the flag. Measured with a health tick held open 300 ms: `stop()` returned in 0.000 s with all 9 loops running, and the publish landed 300 ms later, after the session reference had been given back.

`stop()` now joins the loops first. The budget is a named `LOOP_JOIN_TIMEOUT_S` spent *across* the loops, not per loop, since they wind down in parallel. A loop that outlasts it is named at WARNING with the count and the budget, rather than the stop being reported as complete - the posture `mesh.input` and `teleop_mixin` already take for the single loop each of them owns.

## Tests

8 cells in `tests/mesh/test_stop_waits_for_the_loops_it_started.py`; 6 fail on `upstream/main`. The 2 that pass there are the controls: the roster is built correctly on both trees, and an idle peer's `stop()` was fast and stays fast. Full suite 51,387 passed / 316 skipped / 0 failed, coverage 96.04%; ruff + mypy clean on 1,969 files.