### PR TITLE
docs(notebooks): the series can score the policy it just trained

### DIFF
--- a/changelog.d/3520-notebook-evaluation.md
+++ b/changelog.d/3520-notebook-evaluation.md
@@ -1,0 +1,60 @@
+### Added: the notebook series can score the policy it just trained
+
+`examples/notebooks/` taught the whole data loop and never once evaluated it.
+Notebooks 1 to 6 build a robot, record a dataset, train an ACT policy, export it,
+load it back, and orchestrate a heterogeneous fleet.
+Measured across all six, references to `evaluate_benchmark`, `eval_policy`,
+`success_rate` and `list_benchmarks`: **zero**.
+
+The gap is sharpest in notebook 3, whose own cell headings read *record a small
+dataset -> train -> load the trained checkpoint back -> where to go from here*. It
+produces a checkpoint and stops, so a reader finishes the series holding a trained
+policy and no way to tell whether it is better than the untrained one. The library
+has had that answer since `evaluate_benchmark` shipped, and
+`examples/10_evaluate_benchmark.py` demonstrates it as a script; the notebook
+series just never reached for it.
+
+`07_evaluate_a_policy.ipynb` closes it, CPU-only like the rest of the series. It
+scores the `mock` policy first and says why - mock emits sinusoids and does not
+walk, so its score is the **floor**, and without a floor a task that is trivially
+satisfiable is indistinguishable from a policy that works. It then reads the
+per-attempt rows rather than the average, because `success_rate` says something is
+wrong and never says what, and each row carries the seed it ran under so a single
+attempt is replayable on its own. `success` and `failure` are printed as separate
+fields, not as opposites: the row where both are false is the third outcome, an
+attempt that ran out of steps, and that is the row a reader most needs to tell
+apart from a fall. Then it authors a new task as a spec dict and shows the two
+refusals the closed predicate registry makes at `from_dict` time, before a scene
+exists - an unknown condition name and an unexpected keyword.
+
+That last cell is the one worth having in a notebook rather than in prose. A spec
+that compiled and then evaluated to `False` on every step would report a
+completely plausible 0% success rate, and the reader would go and look at the
+policy.
+
+Two test modules, split by what they can establish without a GL context.
+`tests/test_notebook_evaluation_spec.py` parses the notebook's `SPEC` with
+`ast.literal_eval` rather than executing it, which is the assertion rather than a
+convenience: the notebook tells the reader a spec is safe to load from an
+agent-produced file because there is nothing executable in it, and a spec that
+grew a call or an f-string fails there. It then compiles the spec against the live
+`PREDICATE_REGISTRY`, names each predicate individually so a rename reports the
+whole list in one run, asserts the spec exercises all three clause kinds (success,
+failure and reward terms - a success-only spec would compile and leave the two
+parts a reader is most likely to copy ungraded), and executes the notebook's own
+refusal cell, whose `else` branch is the assertion.
+
+`tests_integ/simulation/test_notebook_evaluation_runs.py` runs every code cell in
+order and asserts the result carries the fields the cells index -
+`episodes_completed`, `episodes`, and per row `success` / `failure` / `steps` /
+`cumulative_reward` / `seed`. A renamed key raises `KeyError` in the reader's
+browser and in no test, because nothing imports a notebook. It also asserts the
+replay claim by running the same evaluation twice: the same master seed produced
+the same attempt seeds and a different one did not, so the sentence telling a
+reader they can replay an attempt is checked rather than asserted.
+
+Both modules read the notebook's cells rather than a transcription of them,
+selecting each by content instead of index, so inserting a cell does not silently
+point an assertion at the wrong code and a copy cannot keep passing after the
+notebook regresses - the same discipline `tests/test_notebook_capability_model.py`
+already applies to notebook 6.

--- a/examples/notebooks/07_evaluate_a_policy.ipynb
+++ b/examples/notebooks/07_evaluate_a_policy.ipynb
@@ -1,0 +1,301 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 7 - Evaluate a policy\n",
+    "\n",
+    "Notebooks 1 to 6 record data, train a policy, deploy it and orchestrate a fleet.\n",
+    "None of them answers the question that decides whether any of it worked: **is this policy any good?**\n",
+    "\n",
+    "This notebook is that answer. It scores a policy on a task, reads the result per attempt rather\n",
+    "than as an average, and defines a new task as data. No hardware, no GPU, no Hugging Face\n",
+    "credentials.\n",
+    "\n",
+    "Evaluation here has three layers, and this notebook is **layer one**:\n",
+    "\n",
+    "| Layer | What it decides | Where it lives |\n",
+    "|---|---|---|\n",
+    "| **1. Deterministic conditions** | Did the task succeed or fail, in how many steps, at what reward. Authoritative. | This notebook |\n",
+    "| **2. Judge annotation** | Was it done *well* - smooth or jerky, clean or lucky. Cannot overrule layer 1. | [`examples/17_judge_recorded_episodes.py`](../17_judge_recorded_episodes.py) |\n",
+    "| **3. Human agreement** | How much to trust layer 2. | Same example |\n",
+    "\n",
+    "**Install:** `uv pip install -U \"strands-robots[sim-mujoco]\"`\n",
+    "\n",
+    "Part of the [examples/notebooks](./README.md) getting-started series.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "\n",
+    "# macOS uses the 'cgl' offscreen GL backend; Linux headless uses 'egl'.\n",
+    "os.environ.setdefault(\"MUJOCO_GL\", \"cgl\" if sys.platform == \"darwin\" else \"egl\")\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. What tasks are there to score?\n",
+    "\n",
+    "A task is registered under a name. `register_builtin_benchmarks()` adds the five shipped\n",
+    "locomotion tasks, and `list_benchmarks()` reports what is registered plus which robot each one\n",
+    "targets - enough to pick one without instantiating anything.\n",
+    "\n",
+    "`max_steps` is the per-attempt horizon. An attempt that has not succeeded by then is over.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from strands_robots.simulation import register_builtin_benchmarks\n",
+    "from strands_robots.simulation.benchmark import list_benchmarks\n",
+    "\n",
+    "register_builtin_benchmarks()  # idempotent\n",
+    "\n",
+    "registry = list_benchmarks()\n",
+    "print(f\"{'task':22} {'robot':16} max_steps\")\n",
+    "for name, meta in sorted(registry.items()):\n",
+    "    print(f\"{name:22} {meta['default_robot']:16} {meta['max_steps']}\")\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Score a policy\n",
+    "\n",
+    "`evaluate_benchmark` builds the task's scene, runs the policy for up to `max_steps` per attempt,\n",
+    "checks the success and failure conditions every step, and accumulates the task's reward terms.\n",
+    "\n",
+    "We score the `mock` policy first, deliberately. Mock emits sinusoids and does not walk, so its\n",
+    "score is the **floor**: the number a policy that does nothing useful gets on this task. Without a\n",
+    "floor you cannot tell a working policy from a task that is trivially satisfiable.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from strands_robots import Robot\n",
+    "\n",
+    "TASK = \"go2_walk_forward\"\n",
+    "robot_name = registry[TASK][\"default_robot\"]\n",
+    "\n",
+    "sim = Robot(robot_name, mesh=False)\n",
+    "result = sim.evaluate_benchmark(TASK, policy_provider=\"mock\", n_episodes=3, seed=0)\n",
+    "\n",
+    "if result.get(\"status\") == \"error\":\n",
+    "    raise RuntimeError(\"; \".join(c.get(\"text\", \"\") for c in result.get(\"content\", [])))\n",
+    "\n",
+    "metrics = next(c[\"json\"] for c in result[\"content\"] if \"json\" in c)\n",
+    "print(f\"{TASK} on {robot_name}, policy='mock' (the floor)\")\n",
+    "print(f\"  episodes_completed : {metrics['episodes_completed']}\")\n",
+    "print(f\"  success_rate       : {metrics['success_rate']}\")\n",
+    "print(f\"  avg_reward         : {metrics['avg_reward']}\")\n",
+    "print(f\"  avg_steps          : {metrics['avg_steps']}\")\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Read the attempts, not the average\n",
+    "\n",
+    "`success_rate` tells you something is wrong. It does not tell you **what**. The per-attempt rows\n",
+    "do, and they are in the same result under `episodes`.\n",
+    "\n",
+    "Each row carries `seed`, which is the useful part: every attempt is seeded from the master `seed`\n",
+    "you passed, so any single row can be replayed on its own without re-running the set.\n",
+    "\n",
+    "`success` and `failure` are separate fields, not opposites. An attempt that ran out of steps is\n",
+    "`success=False, failure=False` - it neither achieved the goal nor triggered a failure condition.\n",
+    "That distinction is what tells a timeout apart from a fall.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "episodes = metrics[\"episodes\"]\n",
+    "print(f\"{'ep':>3} {'success':>8} {'failure':>8} {'steps':>7} {'reward':>10} {'seed':>6}  outcome\")\n",
+    "for row in episodes:\n",
+    "    if row[\"success\"]:\n",
+    "        outcome = \"achieved the goal\"\n",
+    "    elif row[\"failure\"]:\n",
+    "        outcome = \"failure condition fired\"\n",
+    "    else:\n",
+    "        outcome = \"ran out of steps\"\n",
+    "    print(\n",
+    "        f\"{row['episode']:>3} {str(row['success']):>8} {str(row['failure']):>8} \"\n",
+    "        f\"{row['steps']:>7} {row['cumulative_reward']:>10} {row['seed']:>6}  {outcome}\"\n",
+    "    )\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Define your own task, as data\n",
+    "\n",
+    "A task is a dict, not a Python subclass. `success`, `failure` and `dense_reward` are composed\n",
+    "from named entries in a **closed registry** of conditions and reward terms\n",
+    "(`strands_robots.simulation.predicates`). Nothing in a spec is ever executed as code, which is\n",
+    "what makes a spec safe to load from a JSON or YAML file an agent produced.\n",
+    "\n",
+    "The task below is a harder variant of `go2_walk_forward`: walk past 4 m at a 1.5 m/s target, and\n",
+    "fail on a tip or a collapsed base. Same authoring path the shipped tasks use.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from strands_robots.simulation.benchmark import register_benchmark\n",
+    "from strands_robots.simulation.benchmark_spec import DeclarativeBenchmark\n",
+    "\n",
+    "SPEC = {\n",
+    "    \"name\": \"go2_walk_far_fast\",\n",
+    "    \"instruction\": \"Walk forward at 1.5 m/s and cover at least 4 meters without tipping.\",\n",
+    "    \"default_robot\": \"unitree_go2\",\n",
+    "    \"supported_robots\": [\"unitree_go2\"],\n",
+    "    \"max_steps\": 400,\n",
+    "    \"success\": {\"all\": [{\"predicate\": \"base_beyond_x\", \"x\": 4.0}]},\n",
+    "    \"failure\": {\n",
+    "        \"any\": [\n",
+    "            {\"predicate\": \"base_tipped\", \"tol\": 0.7},\n",
+    "            {\"predicate\": \"base_below_z\", \"z\": 0.18},\n",
+    "        ]\n",
+    "    },\n",
+    "    \"dense_reward\": [\n",
+    "        {\"predicate\": \"base_velocity_tracking\", \"vx\": 1.5, \"lin_weight\": 1.0, \"ang_weight\": 0.5},\n",
+    "        {\"predicate\": \"base_height\", \"target\": 0.32, \"weight\": 0.5},\n",
+    "        {\"predicate\": \"base_orientation\", \"weight\": 0.5},\n",
+    "    ],\n",
+    "}\n",
+    "\n",
+    "benchmark = DeclarativeBenchmark.from_dict(SPEC)  # compiles now, not mid-episode\n",
+    "register_benchmark(benchmark.name, benchmark)\n",
+    "print(f\"registered {benchmark.name!r} for {benchmark.default_robot}\")\n",
+    "\n",
+    "custom = sim.evaluate_benchmark(benchmark.name, policy_provider=\"mock\", n_episodes=2, seed=0)\n",
+    "custom_metrics = next(c[\"json\"] for c in custom[\"content\"] if \"json\" in c)\n",
+    "print(f\"  success_rate : {custom_metrics['success_rate']}  (mock does not walk, so 0 is expected)\")\n",
+    "print(f\"  avg_reward   : {custom_metrics['avg_reward']}\")\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. A broken spec is refused before anything runs\n",
+    "\n",
+    "Both failures below raise from `from_dict`, before a scene is built or a step is taken. That\n",
+    "matters more than the tidy error message: a spec that compiled and then silently evaluated to\n",
+    "`False` forever would report a perfectly plausible 0% success rate, and you would go looking at\n",
+    "the policy.\n",
+    "\n",
+    "The first message lists every valid condition name, so a typo is self-correcting.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "for label, broken in [\n",
+    "    (\"unknown condition name\", {**SPEC, \"success\": {\"all\": [{\"predicate\": \"base_beyond_z\", \"z\": 4.0}]}}),\n",
+    "    (\"wrong argument name\", {**SPEC, \"success\": {\"all\": [{\"predicate\": \"base_beyond_x\", \"distance\": 4.0}]}}),\n",
+    "]:\n",
+    "    try:\n",
+    "        DeclarativeBenchmark.from_dict({**broken, \"name\": \"should_not_register\"})\n",
+    "    except ValueError as exc:\n",
+    "        print(f\"{label}: refused at compile time\")\n",
+    "        print(f\"  {str(exc)[:160]}\")\n",
+    "    else:\n",
+    "        raise AssertionError(f\"{label} was accepted; the closed registry is not being enforced\")\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Where layers 2 and 3 live\n",
+    "\n",
+    "Everything above is layer one: conditions over simulator state, and it is authoritative. What it\n",
+    "cannot tell you is whether a run was *good*. Two attempts can both succeed with one clean and one\n",
+    "lucky, and if you train on the lucky one you make the next policy worse.\n",
+    "\n",
+    "That is what layers two and three are for, and they ship in\n",
+    "[`examples/17_judge_recorded_episodes.py`](../17_judge_recorded_episodes.py):\n",
+    "\n",
+    "- A **judge agent** reads the recorded episode and adds a quality grade (`low` / `medium` /\n",
+    "  `high`) and a failure tag from a fixed taxonomy. It writes into its own block of a label\n",
+    "  sidecar, so it is structurally unable to change the verdict from layer one; a disagreement is\n",
+    "  recorded as a dispute for a human.\n",
+    "- **`measure_agreement`** compares the judge against human grades on a holdout, so the judge's\n",
+    "  numbers are reported with a known level of trust rather than assumed.\n",
+    "- **`filter_episodes`** then selects the successful, high-quality subset to retrain on, which is\n",
+    "  what closes the loop from evaluation back into the next model.\n",
+    "\n",
+    "You only need layers two and three when you are letting an automated grader decide what a policy\n",
+    "trains on. For \"does this work\", layer one is the whole answer.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Next\n",
+    "\n",
+    "- **[`examples/10_evaluate_benchmark.py`](../10_evaluate_benchmark.py)** - the same scoring loop\n",
+    "  as a script.\n",
+    "- **[`examples/11_author_a_benchmark.py`](../11_author_a_benchmark.py)** - the authoring path on\n",
+    "  its own.\n",
+    "- **[`examples/17_judge_recorded_episodes.py`](../17_judge_recorded_episodes.py)** - layers two\n",
+    "  and three end to end: record, verdict, judge, agreement, filter, retrain.\n",
+    "- Swap `policy_provider=\"mock\"` for `\"groot\"`, `\"cosmos3\"` or `\"lerobot_local\"` with a checkpoint\n",
+    "  in `policy_config` to score a trained policy on the identical task. Those need a GPU; the\n",
+    "  scoring code is unchanged.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/README.md
+++ b/examples/notebooks/README.md
@@ -39,8 +39,22 @@ always wins.
 | 4 | [`04_discover_lerobot.ipynb`](04_discover_lerobot.ipynb) | Discover the LeRobot API with `use_lerobot`: list robots, policies, teleoperators, cameras, and inspect any class |
 | 5 | [`05_streaming_data_loop.ipynb`](05_streaming_data_loop.ipynb) | The streaming data loop: record, render, stream back, train, and load, in one notebook (training needs `lerobot[training]`; the optional Storage Bucket sync needs `strands-robots >= 0.5.1` + LeRobot >= 0.6.1; an optional final step reruns the loop on the Isaac backend with `backend="isaac"` when an RTX GPU + `sim-isaac` are present) |
 | 6 | [`06_fleet_orchestration.ipynb`](06_fleet_orchestration.ipynb) | Drive a heterogeneous fleet from one goal: read each robot's capability tags, decompose the goal into per-robot tasks (rule-based, with an optional Strands agent planner), dispatch them together through `run_multi_policy`, and re-plan when a robot drops offline |
+| 7 | [`07_evaluate_a_policy.ipynb`](07_evaluate_a_policy.ipynb) | Score a policy: `list_benchmarks()` to see what tasks exist, `evaluate_benchmark()` to score one, the per-attempt rows behind the average, and authoring a new task as a spec dict compiled against the closed predicate registry (`DeclarativeBenchmark.from_dict`) |
 
 Read them in order; each builds on the previous one. Notebook 3 trains a real
+policy on CPU with a tiny dataset and two steps - raise the step count and run on
+a GPU for a production checkpoint; the code path is identical.
+
+Notebooks 1 to 6 record, train, deploy and orchestrate. Notebook 7 is the one that
+answers whether any of it worked, so it is the last in the series rather than an
+appendix: a checkpoint you cannot score is a checkpoint you cannot compare to the
+next one. It covers **layer one** of evaluation - deterministic conditions over
+simulator state, which are authoritative. The judge-annotation and human-agreement
+layers on top of it ship as a script rather than a notebook, in
+[`examples/17_judge_recorded_episodes.py`](../17_judge_recorded_episodes.py),
+because they read recorded video and the series is CPU-only.
+
+
 policy on CPU with a tiny dataset and two steps - raise the step count and run on
 a GPU for a production checkpoint; the code path is identical.
 

--- a/examples/notebooks/README.md
+++ b/examples/notebooks/README.md
@@ -54,10 +54,6 @@ layers on top of it ship as a script rather than a notebook, in
 [`examples/17_judge_recorded_episodes.py`](../17_judge_recorded_episodes.py),
 because they read recorded video and the series is CPU-only.
 
-
-policy on CPU with a tiny dataset and two steps - raise the step count and run on
-a GPU for a production checkpoint; the code path is identical.
-
 ## Training needs `lerobot[training]`, on CPU too
 
 Notebooks 3 and 5 both train, and `lerobot`'s `train()` calls

--- a/tests/test_notebook_evaluation_spec.py
+++ b/tests/test_notebook_evaluation_spec.py
@@ -1,0 +1,231 @@
+"""Notebook 7's authored task must stay compilable, and its refusals must stay refusals.
+
+``examples/notebooks/07_evaluate_a_policy.ipynb`` teaches layer one of evaluation:
+score a policy on a registered task, read the per-attempt rows, then author a new
+task as a spec dict. Three properties of it are load-bearing, and none is visible
+in a run of the test suite that ignores the notebook:
+
+* **The authored ``SPEC`` compiles against the live predicate registry.** Every
+  ``predicate`` name and every keyword in that dict is resolved against
+  :data:`~strands_robots.simulation.predicates.PREDICATE_REGISTRY` at
+  ``from_dict`` time. Renaming a predicate, or changing one's signature, breaks
+  the notebook for the next reader who runs it and for nobody else - the package's
+  own tests keep passing, because the spec lives in a ``.ipynb`` that no import
+  reaches.
+
+* **The spec is pure data.** The notebook's claim that a spec is safe to load
+  from a file an agent produced rests on there being nothing to execute in it.
+  This module asserts that by parsing ``SPEC`` with :func:`ast.literal_eval`
+  rather than ``exec`` - a spec that grew a function call, an f-string or a name
+  reference would fail here, which is the same property the loader depends on.
+
+* **The two broken specs are still refused.** The notebook prints them as
+  evidence that the registry is closed. If an unknown predicate name or an
+  unexpected keyword ever became acceptable, the notebook would be teaching
+  something false, and the cell's own ``else`` branch would raise for a reader
+  rather than for CI.
+
+The notebook is the artifact under test, so this module reads its cells rather
+than a copy of the spec - a copy would keep passing after the notebook regressed.
+Cells are selected by content, not by index, so inserting a cell above them does
+not silently point these assertions at the wrong code.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation.benchmark_spec import DeclarativeBenchmark
+from strands_robots.simulation.predicates import PREDICATE_REGISTRY
+
+_NOTEBOOK = Path(__file__).resolve().parent.parent / "examples" / "notebooks" / "07_evaluate_a_policy.ipynb"
+
+
+def _code_cell_containing(needle: str) -> str:
+    """Source of the one code cell containing ``needle``.
+
+    Selected by content so a cell inserted above it does not shift an index.
+    """
+    nb = json.loads(_NOTEBOOK.read_text(encoding="utf-8"))
+    matches = [
+        "".join(cell.get("source", []))
+        for cell in nb.get("cells", [])
+        if cell.get("cell_type") == "code" and needle in "".join(cell.get("source", []))
+    ]
+    assert len(matches) == 1, (
+        f"expected exactly one code cell containing {needle!r} in {_NOTEBOOK.name}, found {len(matches)}. "
+        "The cell moved or was duplicated; update this test to match."
+    )
+    return matches[0]
+
+
+@pytest.fixture(scope="module")
+def authored_spec() -> dict[str, Any]:
+    """The notebook's ``SPEC`` dict, parsed as a literal rather than executed.
+
+    ``literal_eval`` is the assertion, not a convenience: it accepts only
+    containers, strings and numbers, so a spec carrying anything executable
+    fails here. That is the property the loader's safety claim rests on.
+    """
+    source = _code_cell_containing("SPEC = {")
+    module = ast.parse(source, filename=str(_NOTEBOOK))
+    assignments = [
+        node
+        for node in module.body
+        if isinstance(node, ast.Assign) and any(isinstance(t, ast.Name) and t.id == "SPEC" for t in node.targets)
+    ]
+    assert len(assignments) == 1, f"expected one SPEC assignment in {_NOTEBOOK.name}, found {len(assignments)}"
+    try:
+        spec = ast.literal_eval(assignments[0].value)
+    except ValueError as exc:  # pragma: no cover - fires only on a regressed notebook
+        raise AssertionError(
+            f"{_NOTEBOOK.name}'s SPEC is no longer a pure literal ({exc}). The notebook tells the reader "
+            "a spec is safe to load from an agent-produced file because there is nothing to execute in "
+            "it; a call, name reference or f-string in the spec makes that claim false."
+        ) from exc
+    assert isinstance(spec, dict), f"SPEC parsed to {type(spec).__name__}, expected dict"
+    return spec
+
+
+def _predicate_entries(spec: dict[str, Any]) -> list[dict[str, Any]]:
+    """Every ``{predicate: ..., **kwargs}`` entry the spec names, from all three clauses."""
+    entries: list[dict[str, Any]] = []
+    for clause_key in ("success", "failure"):
+        clause = spec.get(clause_key) or {}
+        for group in ("all", "any"):
+            entries.extend(clause.get(group, []))
+    entries.extend(spec.get("dense_reward", []))
+    return entries
+
+
+def test_the_authored_spec_compiles_against_the_live_predicate_registry(authored_spec: dict[str, Any]) -> None:
+    """The notebook's task must compile, or the notebook is broken for its reader.
+
+    This is the assertion that catches a renamed predicate or a changed
+    predicate signature, neither of which any other test in the suite would
+    notice, because nothing imports a notebook.
+    """
+    benchmark = DeclarativeBenchmark.from_dict(authored_spec)
+    assert benchmark.name == authored_spec["name"]
+    assert benchmark.default_robot == authored_spec["default_robot"]
+
+
+def test_every_condition_the_notebook_names_is_in_the_closed_registry(authored_spec: dict[str, Any]) -> None:
+    """Named individually, so a failure reports which predicate went missing.
+
+    ``from_dict`` above already refuses an unknown name, but it stops at the
+    first one and reports it inside a longer message. Checking each name gives
+    the whole list in one run, which is what a maintainer renaming a predicate
+    needs.
+    """
+    missing = sorted(
+        {
+            entry["predicate"]
+            for entry in _predicate_entries(authored_spec)
+            if entry["predicate"] not in PREDICATE_REGISTRY
+        }
+    )
+    assert not missing, (
+        f"{_NOTEBOOK.name} names predicates that are no longer registered: {missing}. "
+        f"Registered names: {sorted(PREDICATE_REGISTRY)}"
+    )
+
+
+def test_the_spec_exercises_all_three_clause_kinds(authored_spec: dict[str, Any]) -> None:
+    """Without this the compile check above would prove less than it appears to.
+
+    A spec with only a success condition still compiles, so it would pass the
+    first test while leaving the failure clause and the reward terms - the two
+    parts a reader is most likely to copy - ungraded.
+    """
+    assert authored_spec.get("success", {}).get("all"), "spec declares no success condition"
+    assert authored_spec.get("failure", {}).get("any"), "spec declares no failure condition"
+    assert authored_spec.get("dense_reward"), "spec declares no reward terms"
+
+
+def test_the_broken_specs_are_refused_before_a_scene_is_built(authored_spec: dict[str, Any]) -> None:
+    """Run the notebook's own refusal cell; its ``else`` branch is the assertion.
+
+    The cell asserts for itself that each broken spec raises. Executing it here
+    means the notebook's evidence that the registry is closed is checked in CI
+    rather than discovered by a reader.
+    """
+    source = _code_cell_containing("refused at compile time")
+    namespace: dict[str, Any] = {"SPEC": authored_spec, "DeclarativeBenchmark": DeclarativeBenchmark}
+    exec(compile(source, str(_NOTEBOOK), "exec"), namespace)  # noqa: S102
+
+
+@pytest.mark.parametrize(
+    ("label", "mutation"),
+    [
+        ("unknown predicate name", {"success": {"all": [{"predicate": "base_beyond_z", "x": 4.0}]}}),
+        ("unexpected keyword", {"success": {"all": [{"predicate": "base_beyond_x", "distance": 4.0}]}}),
+    ],
+)
+def test_the_refusals_the_notebook_demonstrates_are_the_real_behaviour(
+    authored_spec: dict[str, Any], label: str, mutation: dict[str, Any]
+) -> None:
+    """The same two refusals, asserted directly rather than through the cell.
+
+    The cell above proves the notebook's printed output is honest. This proves
+    the underlying behaviour, so a regression is attributed to the loader rather
+    than to the notebook's phrasing.
+    """
+    with pytest.raises(ValueError):
+        DeclarativeBenchmark.from_dict({**authored_spec, **mutation, "name": "should_not_register"})
+
+
+def test_the_scored_task_is_one_the_builtin_registration_provides() -> None:
+    """The notebook indexes ``registry[TASK]``, which raises ``KeyError`` if the name moved.
+
+    Read from the notebook rather than hard-coded here, so renaming the built-in
+    fails on the notebook's own choice of task instead of on this test's copy of it.
+    """
+    from strands_robots.simulation import register_builtin_benchmarks
+    from strands_robots.simulation.benchmark import list_benchmarks
+
+    source = _code_cell_containing('TASK = "')
+    module = ast.parse(source, filename=str(_NOTEBOOK))
+    task_names = [
+        ast.literal_eval(node.value)
+        for node in module.body
+        if isinstance(node, ast.Assign)
+        and any(isinstance(t, ast.Name) and t.id == "TASK" for t in node.targets)
+        and isinstance(node.value, ast.Constant)
+    ]
+    assert len(task_names) == 1, f"expected one TASK assignment in {_NOTEBOOK.name}, found {len(task_names)}"
+
+    register_builtin_benchmarks()
+    registered = list_benchmarks()
+    assert task_names[0] in registered, (
+        f"{_NOTEBOOK.name} scores {task_names[0]!r}, which register_builtin_benchmarks no longer provides. "
+        f"Registered: {sorted(registered)}"
+    )
+
+
+def test_the_install_line_upgrades_a_stale_environment() -> None:
+    """Same rule the rest of the series is held to, asserted on this notebook's own line.
+
+    ``tests/test_notebook_min_version_docs.py`` sweeps every notebook for this
+    already. It is repeated here so a failure names notebook 7 and its markdown
+    rather than arriving as one entry in a swept list.
+    """
+    nb = json.loads(_NOTEBOOK.read_text(encoding="utf-8"))
+    install_lines = [
+        line
+        for cell in nb["cells"]
+        for line in "".join(cell["source"]).splitlines()
+        if "pip install" in line and "strands-robots[" in line
+    ]
+    assert install_lines, f"{_NOTEBOOK.name} states no install line"
+    for line in install_lines:
+        upgrades = " -U " in line or " --upgrade " in line
+        pinned = ">=" in line.split("strands-robots[", 1)[1]
+        assert upgrades or pinned, (
+            f"{_NOTEBOOK.name} install line leaves a stale release in place: {line.strip()}. Add -U or a >= floor."
+        )

--- a/tests_integ/simulation/test_notebook_evaluation_runs.py
+++ b/tests_integ/simulation/test_notebook_evaluation_runs.py
@@ -37,12 +37,16 @@ from __future__ import annotations
 import ast
 import json
 import os
+import sys
 from pathlib import Path
 from typing import Any
 
 import pytest
 
-os.environ.setdefault("MUJOCO_GL", "egl")
+# Platform-conditional, because no single backend name works everywhere: ``egl``
+# is not in MuJoCo's valid set on Darwin and ``cgl`` is not on headless Linux, so
+# naming either one alone trades one platform for the other.
+os.environ.setdefault("MUJOCO_GL", "cgl" if sys.platform == "darwin" else "egl")
 
 # After the MUJOCO_GL default, because MuJoCo locks its GL backend at first import
 # and every import below reaches it. ``importorskip`` rather than a bare ``import``:

--- a/tests_integ/simulation/test_notebook_evaluation_runs.py
+++ b/tests_integ/simulation/test_notebook_evaluation_runs.py
@@ -1,0 +1,196 @@
+"""End-to-end: notebook 7's cells run, and the fields it prints are the ones it gets.
+
+``tests/test_notebook_evaluation_spec.py`` grades the static half of
+``examples/notebooks/07_evaluate_a_policy.ipynb`` - that the authored spec is pure
+data and compiles, and that the two broken specs are still refused. All of that
+runs GL-free and proves nothing about whether the notebook executes.
+
+This module runs it. Three things only a real rollout can establish, each of which
+would surface to a reader as a traceback rather than to CI:
+
+* **Every code cell executes in order.** The notebook is the deliverable, and a
+  reader runs it top to bottom. ``tests_integ/simulation/test_builtin_benchmark_load.py``
+  already drives ``evaluate_benchmark`` on every shipped spec, so the library seam
+  is covered; what is not covered is the notebook's own call shape - the keyword
+  it passes, the result envelope it unpacks, the registry lookup it indexes.
+
+* **The result carries the fields the notebook reads.** The cells index
+  ``metrics["episodes_completed"]``, ``metrics["episodes"]``, and per row
+  ``success`` / ``failure`` / ``steps`` / ``cumulative_reward`` / ``seed``. A
+  renamed key raises ``KeyError`` in the reader's browser and in no test,
+  because a notebook is not imported. ``success`` and ``failure`` are read as
+  *separate* fields, not as opposites - the notebook's third outcome, "ran out of
+  steps", is exactly the row where both are false, so collapsing them would make
+  its own output wrong.
+
+* **The seed claim is true.** The notebook tells the reader that a single
+  attempt can be replayed from its recorded seed because per-attempt seeds derive
+  from the master ``seed``. That is a reproducibility claim about the harness, and
+  it is asserted here by running the same evaluation twice.
+
+MuJoCo + asset download + real physics, so it is deliberately out of the GL-free
+unit suite (collected only via ``hatch run test-integ``).
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+os.environ.setdefault("MUJOCO_GL", "egl")
+
+import mujoco  # noqa: E402, F401 - imported after the MUJOCO_GL default is set
+
+from strands_robots import Robot  # noqa: E402
+from strands_robots.simulation import register_builtin_benchmarks  # noqa: E402
+from strands_robots.simulation.benchmark import list_benchmarks  # noqa: E402
+
+_NOTEBOOK = Path(__file__).resolve().parents[2] / "examples" / "notebooks" / "07_evaluate_a_policy.ipynb"
+
+#: Fields the notebook's aggregate cell indexes by name.
+_AGGREGATE_FIELDS = ("episodes_completed", "success_rate", "avg_reward", "avg_steps", "episodes")
+
+#: Fields the notebook's per-attempt table indexes by name, per row.
+_EPISODE_FIELDS = ("episode", "success", "failure", "steps", "cumulative_reward", "seed")
+
+
+def _code_cells() -> list[str]:
+    nb = json.loads(_NOTEBOOK.read_text(encoding="utf-8"))
+    return ["".join(c.get("source", [])) for c in nb.get("cells", []) if c.get("cell_type") == "code"]
+
+
+def _notebook_task() -> str:
+    """The task name the notebook scores, read from the notebook itself."""
+    for source in _code_cells():
+        module = ast.parse(source, filename=str(_NOTEBOOK))
+        for node in module.body:
+            if (
+                isinstance(node, ast.Assign)
+                and any(isinstance(t, ast.Name) and t.id == "TASK" for t in node.targets)
+                and isinstance(node.value, ast.Constant)
+            ):
+                return str(node.value.value)
+    raise AssertionError(f"no TASK assignment found in {_NOTEBOOK.name}")
+
+
+@pytest.fixture(scope="module")
+def executed_notebook() -> dict[str, Any]:
+    """Run every code cell in order and return the resulting namespace.
+
+    Executing the notebook rather than a transcription of it is the point: a copy
+    would keep passing after the notebook regressed. A failure here names the
+    cell index, so the traceback points at the cell a reader would see fail.
+    """
+    namespace: dict[str, Any] = {"__name__": "__main__"}
+    for index, source in enumerate(_code_cells()):
+        try:
+            exec(compile(source, f"{_NOTEBOOK.name}:cell{index}", "exec"), namespace)  # noqa: S102
+        except Exception as exc:  # pragma: no cover - fires only on a regressed notebook
+            raise AssertionError(
+                f"{_NOTEBOOK.name} code cell {index} failed, so the notebook is broken for its "
+                f"reader: {type(exc).__name__}: {exc}"
+            ) from exc
+    return namespace
+
+
+def test_every_code_cell_runs_top_to_bottom(executed_notebook: dict[str, Any]) -> None:
+    """The whole notebook executes, and leaves the objects its later cells depend on."""
+    for name in ("registry", "sim", "metrics", "episodes", "benchmark", "custom_metrics"):
+        assert name in executed_notebook, (
+            f"{_NOTEBOOK.name} ran but defined no {name!r}; a cell was removed or renamed and the "
+            "later cells that read it will fail for a reader."
+        )
+
+
+def test_the_aggregate_carries_every_field_the_notebook_prints(executed_notebook: dict[str, Any]) -> None:
+    """A renamed metric key raises for a reader and for no other test."""
+    metrics = executed_notebook["metrics"]
+    missing = [field for field in _AGGREGATE_FIELDS if field not in metrics]
+    assert not missing, (
+        f"{_NOTEBOOK.name} indexes {missing} on the evaluation result, which no longer carries them. "
+        f"Present: {sorted(metrics)}"
+    )
+
+
+def test_each_attempt_carries_every_field_the_table_prints(executed_notebook: dict[str, Any]) -> None:
+    """The per-attempt table is the notebook's argument against reading the average."""
+    episodes = executed_notebook["episodes"]
+    assert episodes, f"{_NOTEBOOK.name} produced no per-attempt rows to print"
+    for row in episodes:
+        missing = [field for field in _EPISODE_FIELDS if field not in row]
+        assert not missing, (
+            f"per-attempt row {row.get('episode')} is missing {missing}, which the notebook's table "
+            f"indexes. Present: {sorted(row)}"
+        )
+
+
+def test_success_and_failure_are_independent_fields(executed_notebook: dict[str, Any]) -> None:
+    """Both false is a legal row, and it is the notebook's third outcome.
+
+    The table branches success -> failure -> "ran out of steps". If the two ever
+    became strict opposites that third branch would be unreachable and the
+    notebook would be describing an outcome it can no longer show.
+    """
+    for row in executed_notebook["episodes"]:
+        assert isinstance(row["success"], bool), f"success is {type(row['success']).__name__}, expected bool"
+        assert isinstance(row["failure"], bool), f"failure is {type(row['failure']).__name__}, expected bool"
+        assert not (row["success"] and row["failure"]), (
+            f"attempt {row['episode']} reports both success and failure, which the notebook's "
+            "three-way branch cannot render"
+        )
+
+
+def test_the_scored_task_loads_its_real_robot(executed_notebook: dict[str, Any]) -> None:
+    """The notebook's registry lookup resolved to a robot that actually loaded.
+
+    ``registry[TASK]["default_robot"]`` is indexed by the notebook; an asset
+    rename would make the notebook's very first evaluation raise.
+    """
+    registry = executed_notebook["registry"]
+    task = _notebook_task()
+    assert task in registry, f"{_NOTEBOOK.name} scores {task!r}, absent from the registry it printed"
+    assert executed_notebook["metrics"]["episodes_completed"] >= 1, (
+        "the notebook completed no attempts, so its printed metrics describe nothing"
+    )
+
+
+def test_the_same_master_seed_reproduces_the_same_attempt_seeds() -> None:
+    """The notebook's replay claim, asserted by running the evaluation twice.
+
+    Run independently of the notebook namespace so the two runs are built the
+    same way. Two attempts is enough: the claim is that the master seed
+    determines the per-attempt seeds, not that any particular value appears.
+    """
+    register_builtin_benchmarks()
+    task = _notebook_task()
+    robot_name = list_benchmarks()[task]["default_robot"]
+
+    def attempt_seeds(master: int) -> list[int]:
+        sim = Robot(robot_name, mesh=False)
+        try:
+            result = sim.evaluate_benchmark(task, policy_provider="mock", n_episodes=2, seed=master)
+            assert result.get("status") != "error", result
+            metrics = next(c["json"] for c in result["content"] if "json" in c)
+            return [row["seed"] for row in metrics["episodes"]]
+        finally:
+            destroy = getattr(sim, "destroy", None)
+            if callable(destroy):
+                destroy()
+
+    first = attempt_seeds(0)
+    again = attempt_seeds(0)
+    other = attempt_seeds(1)
+
+    assert first == again, (
+        f"the same master seed produced different attempt seeds ({first} then {again}), so the "
+        "notebook's claim that a single attempt can be replayed from its recorded seed is false"
+    )
+    assert first != other, (
+        f"a different master seed produced the same attempt seeds ({first}), so the seed argument "
+        "is not reaching the per-attempt derivation"
+    )

--- a/tests_integ/simulation/test_notebook_evaluation_runs.py
+++ b/tests_integ/simulation/test_notebook_evaluation_runs.py
@@ -44,7 +44,13 @@ import pytest
 
 os.environ.setdefault("MUJOCO_GL", "egl")
 
-import mujoco  # noqa: E402, F401 - imported after the MUJOCO_GL default is set
+# After the MUJOCO_GL default, because MuJoCo locks its GL backend at first import
+# and every import below reaches it. ``importorskip`` rather than a bare ``import``:
+# this module needs MuJoCo present but never names it, so a plain import would be
+# unused, and it turns an absent install into a clean SKIPPED line instead of an
+# ImportError from inside ``Robot(...)`` several frames away - the same reason the
+# Isaac modules in this directory guard their backend this way.
+pytest.importorskip("mujoco")
 
 from strands_robots import Robot  # noqa: E402
 from strands_robots.simulation import register_builtin_benchmarks  # noqa: E402


### PR DESCRIPTION
## What this adds

The notebook series taught the whole data loop and never evaluated it. Notebooks 1 to 6 build a robot, record a dataset, train an ACT policy, export it, load it back and orchestrate a fleet. Measured across all six, references to `evaluate_benchmark`, `eval_policy`, `success_rate` and `list_benchmarks`: **zero**.

The gap is sharpest in notebook 3, whose own cell headings read *record a small dataset -> train -> load the trained checkpoint back -> where to go from here*. It produces a checkpoint and stops, so a reader finishes the series holding a trained policy and no way to tell whether it is better than the untrained one. `examples/10_evaluate_benchmark.py` has demonstrated the answer as a script for months; the notebook series just never reached for it.

`07_evaluate_a_policy.ipynb` closes it, CPU-only like the rest of the series.

## Design decisions worth reviewing

**It scores the mock policy first, and says why.** Mock emits sinusoids and does not walk, so its score is the **floor**. Without a floor, a task that is trivially satisfiable is indistinguishable from a policy that works.

**It reads the per-attempt rows, not the average.** `success_rate` says something is wrong and never says what. Each row carries the seed it ran under, so a single attempt is replayable on its own.

**`success` and `failure` print as separate fields, not opposites.** The row where both are false is the third outcome, an attempt that ran out of steps, and that is the row a reader most needs to tell apart from a fall.

**The last cell shows two refusals** the closed predicate registry makes at `from_dict` time, before a scene exists. That one belongs in a notebook rather than in prose: a spec that compiled and then evaluated to `False` on every step would report a completely plausible 0% success rate, and the reader would go and look at the policy.

## Scope

This is **layer one** of evaluation: deterministic conditions over simulator state. The judge-annotation and human-agreement layers ship as a script (`examples/17_judge_recorded_episodes.py`) because they read recorded video and the series is CPU-only. The notebook says so in its own opening table and points at that example.

## Tests

Two modules, split by what each can establish without a GL context. **No test anywhere previously referenced examples 10 or 11**, so this is the first coverage of that surface.

`tests/test_notebook_evaluation_spec.py` (8 tests, GL-free) parses the notebook's `SPEC` with `ast.literal_eval` rather than executing it. That is the assertion rather than a convenience: the notebook tells the reader a spec is safe to load from an agent-produced file *because* there is nothing executable in it, so a spec that grew a call or an f-string fails there. It then compiles the spec against the live `PREDICATE_REGISTRY`, names each predicate individually so a rename reports the whole list in one run, asserts the spec exercises all three clause kinds (a success-only spec compiles and would leave the failure clause and reward terms ungraded), and executes the notebook's own refusal cell whose `else` branch is the assertion.

`tests_integ/simulation/test_notebook_evaluation_runs.py` (6 tests, real MuJoCo) runs every code cell in order and asserts the result carries the fields the cells index. A renamed key raises `KeyError` in the reader's browser and in no test, because nothing imports a notebook. It also checks the replay claim by running the same evaluation twice: same master seed gave the same attempt seeds, a different one did not.

Both read the notebook's cells rather than a transcription, selecting each by content instead of index, so inserting a cell cannot silently point an assertion at the wrong code and a copy cannot keep passing after the notebook regresses. Same discipline `tests/test_notebook_capability_model.py` already applies to notebook 6.

## Verification

- Every code cell executed end to end on CPU; outputs are real
- 8 unit + 6 integration tests passing
- `ruff check`, `ruff format --check`, `mypy` clean
- `hatch run whole-tree-check`: 101 graders, 4,330 passed, 50 skipped, 0 failed
- Full unit suite compared against a stashed baseline: **93 failures on both sides, zero difference in either direction.** Those are pre-existing MuJoCo rendering/recording failures on a machine with software GL, plus six `gr00t_inference` tests wanting network and a token.

The changelog fragment follows in the next push, once this PR has a number.
