### PR TITLE
feat(simulation): an evaluation reports how close it came and how often it holds

### DIFF
--- a/changelog.d/3521-eval-peak-reward-and-pass-hat-k.md
+++ b/changelog.d/3521-eval-peak-reward-and-pass-hat-k.md
@@ -1,0 +1,59 @@
+### Added: an evaluation reports how close it came, and how often it can be relied on
+
+`PolicyRunner.evaluate` reported a total reward and a success rate. Neither answers
+the two questions a reader of a failing evaluation actually has.
+
+**`max_step_reward` per attempt, `avg_max_step_reward` in the aggregate.** On a
+dense-reward task the running total is partly a step count: a long flailing attempt
+accrues more shaped reward than a short one that nearly finished, so the total
+ranks them backwards. The peak single-step reward is the signal that separates
+"never approached" from "approached and missed". Measured on `go2_walk_forward`
+with the mock policy over 3 attempts, the total is 500.25 and the peak is 0.51 -
+the same rollout, and only one of those numbers says anything about proximity.
+LeRobot has reported both since it shipped (`avg_sum_reward` beside
+`avg_max_reward` in `src/lerobot/scripts/lerobot_eval.py`); this package reported
+only the total.
+
+`None` for an attempt that ended before `on_step` scored anything, and the
+aggregate averages only the attempts that scored, rather than reading an unscored
+attempt as a peak of zero and dragging the average toward it for a reason unrelated
+to proximity.
+
+**`pass_hat_k`.** A success rate answers how often a policy works. It does not
+answer whether it can be relied on repeatedly, and for anything driven in a loop
+that is the deployable question: a policy at 60% clears five consecutive attempts
+about 8% of the time. Two checkpoints at the same mean - one consistent, one
+erratic - were indistinguishable in the payload.
+
+Estimated as `C(c, k) / C(n, k)` for `c` successes out of `n` completed attempts,
+which is the unbiased probability that a uniformly drawn `k`-subset of the attempts
+observed is all successes. Deliberately **not** `success_rate ** k`. That form
+assumes attempts are independent, and attempts on one policy against one scene are
+correlated by construction - a systematic grasp offset fails every attempt rather
+than a fixed fraction of them - so it reports a reliability the run never
+demonstrated. On 3 successes out of 5 the two disagree by half, 0.30 against 0.36,
+and the exponential form is the optimistic one, which is the direction that costs a
+deployment decision rather than merely being wrong.
+
+Keys above `episodes_completed` are absent rather than `0.0`: a run of 3 attempts
+has not measured a 5-streak, and a zero there would read as measured unreliability
+instead of an unasked question, so a reader comparing runs of different lengths
+would be comparing a measurement against an absence. Capped at `k=8`, beyond which
+the estimate is dominated by its own variance at the episode counts an evaluation
+runs; a reader needing more can compute it from `n_success` and
+`episodes_completed`, both of which are in the same payload. Keys are strings
+because the payload is JSON and an int-keyed dict changes shape on serialisation -
+which is where an agent reads it.
+
+Neither this package nor LeRobot reported any repeated-trial figure before this;
+`pass@k` / `pass^k` appears nowhere in LeRobot's eval path, checked at `b6ec006`.
+
+Pinned by `tests/simulation/test_eval_reliability_and_peak_reward.py`, which uses a
+`constant`-reward probe task so the peak is a value the test chose rather than a
+property of a scene - a shaped term would leave a failure unattributable between
+the arithmetic under test and the physics. It asserts the peak is below the total
+over a multi-step attempt (a field aliasing the total passes an equality check on a
+single-step episode and fails that one), the exponential form is pinned as a
+difference rather than left as a comment, monotonicity in `k` is asserted because a
+hand-rolled combinatorial formula is easy to get subtly wrong, and the payload's
+`pass_hat_k` is round-tripped through JSON.

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -199,6 +199,51 @@ OnFrame = Callable[[int, dict[str, Any], dict[str, Any]], None]
 # success_fn(observation) -> bool
 SuccessFn = Callable[[dict[str, Any]], bool]
 
+#: Largest ``k`` reported by :func:`pass_hat_k`. Beyond a handful of consecutive
+#: attempts the estimate is dominated by its own variance on the episode counts an
+#: evaluation actually runs, and a reader who needs more can compute it from
+#: ``n_success`` and ``episodes_completed``, which are both in the same result.
+_PASS_HAT_K_MAX = 8
+
+
+def pass_hat_k(n_completed: int, n_success: int, k_max: int = _PASS_HAT_K_MAX) -> dict[int, float]:
+    """Probability that ``k`` attempts drawn without replacement all succeed.
+
+    A success rate answers "how often does this work". It does not answer "can I
+    rely on it", and for anything driven repeatedly those are different questions:
+    a policy at 60% has a roughly 8% chance of clearing five consecutive attempts.
+    Reporting only the mean invites a deployment decision the mean does not
+    support.
+
+    Estimated as ``C(c, k) / C(n, k)`` for ``c`` successes out of ``n`` completed
+    attempts, which is the unbiased probability that a uniformly drawn ``k``-subset
+    of the attempts observed is all successes. Deliberately not ``success_rate **
+    k``: that form assumes the attempts are independent, and evaluation attempts on
+    one policy and one scene are correlated by construction (a systematic grasp
+    offset fails every attempt, not a fixed fraction of them), so it reports a
+    reliability the run never demonstrated. The subset form makes no independence
+    claim; it only describes the attempts that were run.
+
+    Args:
+        n_completed: Attempts that ran to a verdict. ``k`` above this is undefined
+            rather than zero - a run of 3 attempts says nothing about 5 in a row -
+            so those keys are absent instead of present and misleading.
+        n_success: Attempts among them that succeeded.
+        k_max: Largest ``k`` to report, clamped to ``n_completed``.
+
+    Returns:
+        ``{k: probability}`` for each ``k`` from 1 up to ``min(k_max,
+        n_completed)``. Empty when no attempt completed, since there is nothing to
+        draw a subset from. ``k=1`` equals the success rate by construction, and is
+        included as the anchor that makes the rest of the row readable.
+    """
+    if n_completed <= 0:
+        return {}
+    upper = min(k_max, n_completed)
+    return {
+        k: (0.0 if n_success < k else math.comb(n_success, k) / math.comb(n_completed, k)) for k in range(1, upper + 1)
+    }
+
 
 def _criterion_verdict(
     check: Callable[[Any], bool],
@@ -3247,7 +3292,24 @@ class PolicyRunner:
             ``rtc_avg_inference_ms``, ``rtc_max_inference_ms``) so inference
             cost and latency masking are provable from the payload. When
             ``spec`` is used, it also contains ``cumulative_reward`` and
-            ``avg_reward`` fields per episode and aggregate.
+            ``avg_reward`` fields per episode and aggregate, plus
+            ``max_step_reward`` per episode and ``avg_max_step_reward`` in the
+            aggregate: the peak single-step reward, kept beside the running total
+            because the total is partly a step count, so on a dense-reward task a
+            long flailing attempt out-totals a short one that nearly finished.
+            ``max_step_reward`` is ``None`` for an attempt that ended before any
+            step was scored, and ``avg_max_step_reward`` averages only the
+            attempts that scored one (``None`` when none did) rather than reading
+            an unscored attempt as a peak of zero.
+
+            ``pass_hat_k`` maps ``k`` (as a string, since the payload is JSON) to
+            the probability that ``k`` attempts drawn from those run are all
+            successes - see :func:`pass_hat_k`. It answers whether a policy can be
+            relied on repeatedly, which ``success_rate`` does not: at a 60% rate,
+            five consecutive attempts succeed about 8% of the time. Keys above
+            ``episodes_completed`` are absent rather than ``0.0``, because a short
+            run has not measured a long streak and a zero would read as though it
+            had.
 
             Every payload carries ``success_measured`` (bool): ``True`` when a
             success criterion was in force (a ``spec`` or a non-``None``
@@ -3922,6 +3984,14 @@ class PolicyRunner:
                 failure = False
                 steps = 0
                 cumulative_reward = 0.0
+                # Peak single-step reward, kept beside the running total because the
+                # two answer different questions on a failed attempt: the total says
+                # how much shaped reward accrued over however many steps ran, so a
+                # long flailing episode can out-total a short one that nearly
+                # finished. The peak says how close the attempt ever came. ``None``
+                # until a step scores, so an attempt that ended before ``on_step``
+                # ran reports "no step was scored" rather than a fabricated 0.0.
+                max_step_reward: float | None = None
                 last_info: dict[str, Any] = {}
 
                 for _ in range(max_steps):
@@ -4026,7 +4096,11 @@ class PolicyRunner:
                                     "status": "error",
                                     "content": [{"text": f"on_step failed in {spec_name}: {e}"}],
                                 }
-                            cumulative_reward += float(info.reward)
+                            step_reward = float(info.reward)
+                            cumulative_reward += step_reward
+                            max_step_reward = (
+                                step_reward if max_step_reward is None else max(max_step_reward, step_reward)
+                            )
                             last_info = dict(info.info) if info.info else {}
                             if info.done:
                                 stop_episode = True
@@ -4059,7 +4133,9 @@ class PolicyRunner:
                                 "status": "error",
                                 "content": [{"text": f"on_step failed in {spec_name}: {e}"}],
                             }
-                        cumulative_reward += float(info.reward)
+                        step_reward = float(info.reward)
+                        cumulative_reward += step_reward
+                        max_step_reward = step_reward if max_step_reward is None else max(max_step_reward, step_reward)
                         last_info = dict(info.info) if info.info else {}
                         if info.done:
                             break
@@ -4081,6 +4157,7 @@ class PolicyRunner:
                         "success": success,
                         "failure": failure,
                         "cumulative_reward": round(cumulative_reward, 4),
+                        "max_step_reward": (None if max_step_reward is None else round(max_step_reward, 4)),
                         "seed": episode_seed,
                         "info": last_info,
                     }
@@ -4124,6 +4201,12 @@ class PolicyRunner:
         success_rate = n_success / max(n_completed, 1)
         avg_steps = sum(r["steps"] for r in results) / max(n_completed, 1)
         avg_reward = sum(r["cumulative_reward"] for r in results) / max(n_completed, 1)
+        # Averaged over the attempts that actually scored a step. An attempt that
+        # ended before ``on_step`` ran carries ``None`` and is excluded rather than
+        # counted as 0.0, which would drag the peak toward zero for a reason that has
+        # nothing to do with how close any attempt came.
+        _peaks = [r["max_step_reward"] for r in results if r["max_step_reward"] is not None]
+        avg_max_step_reward = round(sum(_peaks) / len(_peaks), 4) if _peaks else None
 
         return {
             "status": "error" if recording_save_error is not None else "success",
@@ -4154,6 +4237,8 @@ class PolicyRunner:
                         "n_failure": n_failure,
                         "avg_steps": round(avg_steps, 1),
                         "avg_reward": round(avg_reward, 4),
+                        "avg_max_step_reward": avg_max_step_reward,
+                        "pass_hat_k": {str(k): round(v, 4) for k, v in pass_hat_k(n_completed, n_success).items()},
                         "max_steps": max_steps,
                         "seed": seed,
                         "benchmark_class": spec_name,

--- a/tests/simulation/test_eval_reliability_and_peak_reward.py
+++ b/tests/simulation/test_eval_reliability_and_peak_reward.py
@@ -1,0 +1,233 @@
+"""An evaluation reports how close it came and how often it can be relied on.
+
+Two additions to the metrics :meth:`PolicyRunner.evaluate` returns, both of which
+answer a question the existing fields cannot:
+
+* **``max_step_reward``** (per attempt) and **``avg_max_step_reward``**. The
+  running total says how much shaped reward accrued over however many steps ran,
+  so on a dense-reward task a long flailing attempt out-totals a short one that
+  nearly finished - the total is partly a step count. The peak single-step reward
+  says how close the attempt ever came, which is the signal that separates "never
+  approached" from "approached and missed". LeRobot reports the same pair
+  (``avg_sum_reward`` beside ``avg_max_reward`` in
+  ``src/lerobot/scripts/lerobot_eval.py``); this package reported only the total.
+
+* **``pass_hat_k``**. A success rate answers how often a policy works and does not
+  answer whether it can be relied on repeatedly, which for anything driven in a
+  loop is the deployable question: a policy at 60% clears five consecutive
+  attempts about 8% of the time. Neither this package nor LeRobot reported any
+  repeated-trial figure, so a reader comparing two checkpoints at the same mean
+  had nothing distinguishing a consistent one from an erratic one.
+
+The estimator is the subset form, ``C(c, k) / C(n, k)``, and **not**
+``success_rate ** k``. That distinction is the point of most of this module rather
+than a detail: the exponential form assumes attempts are independent, and attempts
+on one policy against one scene are correlated by construction - a systematic
+grasp offset fails every attempt rather than a fixed fraction of them - so it
+reports a reliability the run never demonstrated. Measured on 3 successes out of
+5, the two disagree by half (0.36 against 0.30 at ``k=2``), and the exponential
+form is the optimistic one, which is the direction that costs a deployment
+decision.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from strands_robots.simulation.policy_runner import _PASS_HAT_K_MAX, pass_hat_k
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.benchmark import _BENCHMARK_REGISTRY  # noqa: E402
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+_ROBOT_XML = """
+<mujoco model="peak_reward_probe">
+  <worldbody>
+    <body name="base" pos="0 0 0">
+      <joint name="j1" type="hinge" axis="0 0 1" range="-3 3"/>
+      <geom name="link1" type="capsule" fromto="0 0 0 0 0 0.2" size="0.02"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="a1" joint="j1" kp="10"/>
+  </actuator>
+</mujoco>
+"""
+
+#: The per-step reward the probe task pays. Every step scores exactly this, so the
+#: peak is knowable in advance and the assertion is on a value rather than a range.
+_STEP_REWARD = 0.25
+
+#: Steps the probe task allows. Small, because what is under test is the arithmetic
+#: over the rollout rather than the rollout.
+_MAX_STEPS = 4
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Leave the module-global benchmark registry as it was found."""
+    before = dict(_BENCHMARK_REGISTRY)
+    yield
+    _BENCHMARK_REGISTRY.clear()
+    _BENCHMARK_REGISTRY.update(before)
+
+
+@pytest.fixture
+def sim():
+    engine = Simulation()
+    yield engine
+    engine.destroy()
+
+
+@pytest.fixture
+def constant_reward_task(tmp_path: Path, sim):
+    """A task paying a known constant reward per step, never succeeding.
+
+    ``constant`` is used rather than a distance or velocity term so the peak is a
+    value this module chose: a shaped term would make the assertion depend on the
+    probe's physics, and a failure would then be unattributable between the
+    arithmetic under test and the scene.
+    """
+    sim.create_world()
+    robot_xml = tmp_path / "probe.xml"
+    robot_xml.write_text(_ROBOT_XML)
+    sim.add_robot("arm1", urdf_path=str(robot_xml))
+
+    spec_path = tmp_path / "constant_reward.json"
+    spec_path.write_text(
+        json.dumps(
+            {
+                "name": "constant-reward-probe",
+                "default_robot": "arm1",
+                "supported_robots": [],
+                "max_steps": _MAX_STEPS,
+                "dense_reward": [{"predicate": "constant", "value": _STEP_REWARD}],
+            }
+        )
+    )
+    result = sim.register_benchmark_from_file("constant-reward-probe", str(spec_path))
+    assert result.get("status") != "error", result
+    return "constant-reward-probe"
+
+
+def _metrics(result: dict) -> dict:
+    assert result.get("status") != "error", result
+    return next(c["json"] for c in result["content"] if "json" in c)
+
+
+class TestPeakStepRewardIsReportedBesideTheTotal:
+    """The peak is what says how close an attempt came; the total cannot."""
+
+    def test_each_attempt_reports_the_peak_step_reward(self, sim, constant_reward_task) -> None:
+        metrics = _metrics(sim.evaluate_benchmark(constant_reward_task, policy_provider="mock", n_episodes=2, seed=0))
+        assert metrics["episodes"], "no attempts completed"
+        for row in metrics["episodes"]:
+            assert row["max_step_reward"] == pytest.approx(_STEP_REWARD), (
+                f"attempt {row['episode']} reports peak {row['max_step_reward']}, expected the constant "
+                f"{_STEP_REWARD} this task pays every step"
+            )
+
+    def test_the_peak_is_not_the_total(self, sim, constant_reward_task) -> None:
+        """The assertion that makes the field worth having.
+
+        With a constant reward the total is the peak times the step count, so a
+        field that merely aliased the total would satisfy the test above on a
+        single-step episode and fail here.
+        """
+        metrics = _metrics(sim.evaluate_benchmark(constant_reward_task, policy_provider="mock", n_episodes=1, seed=0))
+        row = metrics["episodes"][0]
+        assert row["steps"] > 1, "probe ran a single step, so this comparison proves nothing"
+        assert row["cumulative_reward"] == pytest.approx(_STEP_REWARD * row["steps"]), (
+            "the total is no longer the per-step reward accumulated, so the probe's premise is broken"
+        )
+        assert row["max_step_reward"] < row["cumulative_reward"], (
+            f"peak {row['max_step_reward']} is not below total {row['cumulative_reward']} over "
+            f"{row['steps']} steps, so the peak is aliasing the total"
+        )
+
+    def test_the_aggregate_averages_the_peaks(self, sim, constant_reward_task) -> None:
+        metrics = _metrics(sim.evaluate_benchmark(constant_reward_task, policy_provider="mock", n_episodes=3, seed=0))
+        assert metrics["avg_max_step_reward"] == pytest.approx(_STEP_REWARD)
+        assert metrics["avg_max_step_reward"] != pytest.approx(metrics["avg_reward"]), (
+            "the peak aggregate equals the total aggregate, so one of them is not measuring what it names"
+        )
+
+
+class TestPassHatKDescribesRepeatedAttempts:
+    """The subset estimator, and the independence assumption it declines to make."""
+
+    @pytest.mark.parametrize(
+        ("n", "c", "k", "expected"),
+        [
+            # C(3,2)/C(5,2) = 3/10. The exponential form would give 0.36.
+            (5, 3, 2, 0.30),
+            (5, 3, 3, 0.10),
+            (5, 5, 4, 1.00),  # every attempt succeeded: every subset does too
+            (5, 0, 1, 0.00),  # none did
+            (4, 2, 1, 0.50),  # k=1 is the success rate by construction
+        ],
+    )
+    def test_the_subset_probability_is_exact(self, n: int, c: int, k: int, expected: float) -> None:
+        assert pass_hat_k(n, c)[k] == pytest.approx(expected)
+
+    def test_k_of_one_is_the_success_rate(self) -> None:
+        """The anchor that makes the rest of the row readable."""
+        for n, c in ((10, 7), (5, 1), (3, 3), (8, 0)):
+            assert pass_hat_k(n, c)[1] == pytest.approx(c / n), f"k=1 disagrees with the success rate at {c}/{n}"
+
+    def test_it_is_not_the_exponential_form(self) -> None:
+        """Pinned as a difference, because the exponential form is the tempting one.
+
+        ``success_rate ** k`` assumes independent attempts. It is also the
+        optimistic direction, which is what makes substituting it expensive rather
+        than merely wrong.
+        """
+        n, c = 5, 3
+        subset = pass_hat_k(n, c)[2]
+        exponential = (c / n) ** 2
+        assert subset == pytest.approx(0.30)
+        assert exponential == pytest.approx(0.36)
+        assert subset < exponential, "the subset form is no longer the conservative one; re-derive before trusting it"
+
+    def test_more_consecutive_attempts_is_never_more_likely(self) -> None:
+        """Monotonicity, which a hand-rolled formula is easy to get wrong."""
+        for n, c in ((10, 6), (8, 7), (6, 3)):
+            values = [v for _, v in sorted(pass_hat_k(n, c).items())]
+            assert values == sorted(values, reverse=True), f"pass^k rises with k at {c}/{n}: {values}"
+
+    def test_k_beyond_the_attempts_run_is_absent_not_zero(self) -> None:
+        """A run of 3 attempts says nothing about 5 in a row, so it must not answer.
+
+        Reporting 0.0 there would read as measured unreliability rather than as an
+        unasked question, and a reader comparing two runs of different lengths
+        would be comparing a measurement against an absence.
+        """
+        row = pass_hat_k(3, 3)
+        assert set(row) == {1, 2, 3}, f"expected k=1..3 for 3 attempts, got {sorted(row)}"
+        assert row[3] == pytest.approx(1.0), "3 of 3 succeeded, so 3 in a row is certain among them"
+
+    def test_no_completed_attempts_reports_nothing(self) -> None:
+        assert pass_hat_k(0, 0) == {}, "there is no subset to draw from zero attempts"
+
+    def test_the_reported_range_is_capped(self) -> None:
+        """Bounded so a long run does not emit an unbounded row of tiny numbers."""
+        assert set(pass_hat_k(50, 40)) == set(range(1, _PASS_HAT_K_MAX + 1))
+
+    def test_the_evaluation_reports_it_with_string_keys(self, sim, constant_reward_task) -> None:
+        """JSON object keys are strings, and this dict travels in a tool result.
+
+        Asserted because an int-keyed dict survives an in-process assertion and
+        changes shape the moment the result is serialised, which is where an agent
+        reads it.
+        """
+        metrics = _metrics(sim.evaluate_benchmark(constant_reward_task, policy_provider="mock", n_episodes=2, seed=0))
+        row = metrics["pass_hat_k"]
+        assert row, "no pass_hat_k reported"
+        assert all(isinstance(key, str) for key in row), f"pass_hat_k keys are not strings: {sorted(row)}"
+        assert json.loads(json.dumps(row)) == row, "pass_hat_k does not survive a JSON round trip"
+        # The probe never satisfies a success condition, so every k is 0.0.
+        assert set(row.values()) == {0.0}, f"probe task cannot succeed, so every k should be 0.0: {row}"


### PR DESCRIPTION
## What this adds

`PolicyRunner.evaluate` reported a total reward and a success rate. Neither answers the two questions a reader of a *failing* evaluation actually has: how close did it come, and can I rely on it.

### `max_step_reward` per attempt, `avg_max_step_reward` in the aggregate

On a dense-reward task the running total is partly a step count. A long flailing attempt accrues more shaped reward than a short one that nearly finished, so **the total ranks them backwards.** The peak single-step reward is the signal that separates "never approached" from "approached and missed".

Measured on `go2_walk_forward` with the mock policy over 3 attempts: total **500.25**, peak **0.51**. Same rollout, and only one of those numbers says anything about proximity.

LeRobot has reported both since it shipped (`avg_sum_reward` beside `avg_max_reward` in `src/lerobot/scripts/lerobot_eval.py`); this package reported only the total.

`None` for an attempt that ended before `on_step` scored anything, and the aggregate averages only the attempts that scored, rather than reading an unscored attempt as a peak of zero and dragging the average down for a reason unrelated to proximity.

### `pass_hat_k`

A success rate answers how often a policy works. It does not answer whether it can be relied on **repeatedly**, and for anything driven in a loop that is the deployable question: a policy at 60% clears five consecutive attempts about 8% of the time. Two checkpoints at the same mean, one consistent and one erratic, were indistinguishable in the payload.

**The estimator is the subset form, `C(c, k) / C(n, k)`, and deliberately not `success_rate ** k`.** This is the part most worth reviewing. The exponential form assumes attempts are independent, and attempts on one policy against one scene are correlated by construction: a systematic grasp offset fails *every* attempt rather than a fixed fraction of them. So it reports a reliability the run never demonstrated. On 3 successes out of 5 the two disagree by half, **0.30 against 0.36**, and the exponential form is the optimistic one, which is the direction that costs a deployment decision rather than merely being wrong.

Keys above `episodes_completed` are **absent rather than `0.0`**: a run of 3 attempts has not measured a 5-streak, and a zero there would read as measured unreliability instead of an unasked question, so a reader comparing runs of different lengths would be comparing a measurement against an absence. Capped at `k=8`, beyond which the estimate is dominated by its own variance at the episode counts an evaluation runs; a reader needing more can compute it from `n_success` and `episodes_completed`, both in the same payload. Keys are strings because the payload is JSON and an int-keyed dict changes shape on serialisation, which is where an agent reads it.

Neither this package nor LeRobot reported any repeated-trial figure before this. `pass@k` / `pass^k` appears nowhere in LeRobot's eval path, checked at `b6ec006`.

## Tests

`tests/simulation/test_eval_reliability_and_peak_reward.py`, 15 tests, GL-free.

It uses a `constant`-reward probe task so the peak is a value the test chose rather than a property of a scene: a shaped term would leave a failure unattributable between the arithmetic under test and the physics.

Four assertions worth calling out, because each pins something a plausible implementation gets wrong:

- **The peak is below the total** over a multi-step attempt. A field that merely aliased the total passes an equality check on a single-step episode and fails this one.
- **The exponential form is pinned as a difference**, not left as a comment, so substituting it fails rather than silently changing the semantics.
- **Monotonicity in `k`** is asserted, because a hand-rolled combinatorial formula is easy to get subtly wrong in a way no single case reveals.
- **The payload round-trips through JSON**, since an int-keyed dict survives an in-process assertion and changes shape exactly where an agent reads it.

Plus: `k=1` equals the success rate by construction, `k` beyond the attempts run is absent, zero completed attempts reports `{}`, and the reported range is capped.

## Verification

- 15 new tests passing
- 132 tests in the files most likely to be affected, **including `test_multi_episode_payload_shape_parity.py`**, all pass
- `ruff check`, `ruff format --check`, `mypy` clean
- `hatch run whole-tree-check`: 101 graders, 4,330 passed, 50 skipped, 0 failed
- Full unit suite compared against a stashed baseline: **93 failures on both sides, zero difference in either direction.** Those are pre-existing MuJoCo rendering/recording failures on a machine with software GL, plus six `gr00t_inference` tests wanting network and a token.

Additive only: no existing field changed name, type or meaning. The `Returns:` block of `evaluate` documents both new fields and why each exists.

Independent of #3520 (notebook series evaluation); the two touch disjoint files and can merge in either order.

The changelog fragment follows in the next push, once this PR has a number.
