### PR TITLE
fix(simulation/mujoco): the add_robot deprecation notice is per call

### DIFF
--- a/changelog.d/3523-add-robot-deprecation-notice-is-per-call.md
+++ b/changelog.d/3523-add-robot-deprecation-notice-is-per-call.md
@@ -1,0 +1,17 @@
+### Fixed: the add_robot deprecation notice reaches only the call that earned it
+
+`MuJoCoSimEngine.add_robot` carried the "resolved via deprecated
+name-as-registry-key fallback" notice on the engine instead of in the call. It
+was armed during model resolution and disarmed only by the success return, so
+any error exit between the two -- a mesh asset the downloader cannot resolve, an
+injection the recompiler refuses, an unexpected compile crash -- left it armed
+for the NEXT `add_robot` to print.
+
+The result was a false deprecation warning against a caller who had done exactly
+what the message advises: `add_robot(name="arm_two", data_config="so100")`
+returned success with `Warning: Hint: add_robot(name='so100') resolved via
+deprecated name-as-registry-key fallback`, naming the robot from the earlier
+failed call rather than the one just added.
+
+The notice is a call-local now, so it cannot outlive its call. The deprecated
+form that succeeds still warns, unchanged.

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1885,6 +1885,13 @@ class MuJoCoSimEngine(
         model source". The bare model-source message is kept only when no
         ``name`` was supplied at all.
 
+        Resolving the model from ``name`` is a DEPRECATED fallback, and the
+        success message carries a ``Warning:`` line naming the ``data_config=``
+        form to use instead. That notice belongs to the call that used the
+        fallback and to no other: it is not reported on a later call that
+        resolved its model correctly, including when the deprecated call it
+        came from failed.
+
         A model source that is SUPPLIED but empty (``urdf_path=""`` /
         ``data_config=""``) is refused naming THAT parameter, rather than read
         as omitted. Read by truthiness the two were indistinguishable, so an
@@ -2019,6 +2026,15 @@ class MuJoCoSimEngine(
         #      fallback kept for one release with a DeprecationWarning).
         # Pass `data_config` for new code; the `name`-as-registry-key path
         # will be removed.
+        #
+        # The deprecation notice is per-call state, so it is carried in a local
+        # and not on the engine: an attribute armed here is only disarmed by the
+        # success return below, so any error exit between the two (a mesh the
+        # downloader cannot resolve, an injection the recompiler refuses, an
+        # unexpected compile crash) left it armed for the NEXT add_robot to
+        # report - accusing a caller that passed data_config= correctly, and
+        # naming the earlier robot.
+        deprecation_hint: str | None = None
         resolved_path = urdf_path
         if not resolved_path and data_config:
             resolved_path = resolve_model(data_config)
@@ -2037,7 +2053,7 @@ class MuJoCoSimEngine(
                     name,
                     name,
                 )
-                self._add_robot_deprecation_hint: str | None = (
+                deprecation_hint = (
                     f"Hint: add_robot(name='{name}') resolved via deprecated "
                     f"name-as-registry-key fallback. Prefer: "
                     f"add_robot(name='<instance_label>', data_config='{name}')."
@@ -2204,9 +2220,7 @@ class MuJoCoSimEngine(
 
             source = f"data_config='{data_config}'" if data_config else os.path.basename(resolved_path)
             mesh_line = f"\nMesh peer: {robot.peer_id}" if robot.peer_id else ""
-            hint = getattr(self, "_add_robot_deprecation_hint", None)
-            self._add_robot_deprecation_hint = None
-            hint_line = f"\nWarning: {hint}" if hint else ""
+            hint_line = f"\nWarning: {deprecation_hint}" if deprecation_hint else ""
             return {
                 "status": "success",
                 "content": [

--- a/tests/simulation/mujoco/test_add_robot_failure_cleanup.py
+++ b/tests/simulation/mujoco/test_add_robot_failure_cleanup.py
@@ -15,6 +15,15 @@ The observable proof of a clean rollback is that the *same name* adds
 successfully right after a failed attempt: a leaked registry entry or an orphan
 left in the spec would make the retry error out. These tests pin the three
 cleanup branches; each fails if its ``pop``/``del`` were dropped.
+
+A third piece of per-call state used to outlive a failed call: the notice that
+the model was resolved through the deprecated name-as-registry-key fallback.
+It was armed during resolution and disarmed only by the success return, so
+every error exit in between left it armed on the engine and the NEXT successful
+``add_robot`` printed it - telling a caller who passed ``data_config=``
+correctly that they had used a deprecated form, and naming the earlier robot
+rather than the one just added. The notice is call-local now; these tests pin
+that it reaches the call that earned it and no other.
 """
 
 from __future__ import annotations
@@ -97,3 +106,64 @@ class TestAddRobotFailureCleanup:
         retry = sim.add_robot("so100")
         assert retry["status"] == "success"
         assert "so100" in sim._world.robots
+
+
+class TestDeprecationNoticeIsPerCall:
+    """The name-as-registry-key notice reaches only the call that earned it."""
+
+    @staticmethod
+    def _fail_ensure_meshes(sim, monkeypatch):
+        monkeypatch.setattr(
+            sim,
+            "_ensure_meshes",
+            lambda *a, **k: {"status": "error", "content": [{"text": "asset download failed"}]},
+        )
+
+    @staticmethod
+    def _refuse_inject(sim, monkeypatch):
+        monkeypatch.setattr(sim_mod, "inject_robot_into_scene", lambda *a, **k: False)
+
+    @staticmethod
+    def _crash_inject(sim, monkeypatch):
+        def boom(*a, **k):
+            raise RuntimeError("simulated compile crash")
+
+        monkeypatch.setattr(sim_mod, "inject_robot_into_scene", boom)
+
+    @pytest.mark.parametrize(
+        "break_it",
+        [_fail_ensure_meshes, _refuse_inject, _crash_inject],
+        ids=["mesh_asset_failure", "inject_refusal", "inject_crash"],
+    )
+    def test_a_failed_deprecated_add_does_not_warn_the_next_caller(self, sim, monkeypatch, break_it):
+        # A deprecated positional add that fails after resolution...
+        break_it.__func__(sim, monkeypatch)
+        failed = sim.add_robot("so100")
+        assert failed["status"] == "error"
+
+        # ...must not put its notice on the next call, which named an instance
+        # label and passed the model through data_config= exactly as advised.
+        monkeypatch.undo()
+        clean = sim.add_robot(name="arm_two", data_config="so100")
+        assert clean["status"] == "success"
+        text = clean["content"][0]["text"]
+        assert "Warning" not in text, f"stale notice leaked into a correct call: {text}"
+        assert "deprecated" not in text
+        # The leaked notice also named the wrong robot: the one that failed.
+        assert "so100'" not in text.replace("data_config='so100'", "")
+
+    def test_the_deprecated_form_that_succeeds_still_warns(self, sim):
+        # Essence check: dropping the engine attribute must not drop the notice.
+        result = sim.add_robot("so100")
+
+        assert result["status"] == "success"
+        text = result["content"][0]["text"]
+        assert "Warning" in text
+        assert "deprecated name-as-registry-key fallback" in text
+        assert "add_robot(name='<instance_label>', data_config='so100')" in text
+
+    def test_a_correct_add_never_warns(self, sim):
+        result = sim.add_robot(name="arm_one", data_config="so100")
+
+        assert result["status"] == "success"
+        assert "Warning" not in result["content"][0]["text"]


### PR DESCRIPTION
![add_robot deprecation notice: before and after](https://raw.githubusercontent.com/cagataycali/robots/assets/add-robot-notice/add_robot_notice.png)

**What.** `add_robot` carried the "resolved via deprecated name-as-registry-key fallback" notice on the engine: armed during model resolution, disarmed only by the success return. Every error exit between the two left it armed for the NEXT call to print.

**Why.** A caller passing `data_config=` exactly as the notice advises got accused of the deprecated form, naming the earlier failed robot (above). It is call-local now, so it cannot outlive its call. Engine code nets -2 lines.

**Tests.** All three error exits between arming and consumption (mesh asset failure, injection refusal, injection crash), added to the existing "leaks nothing" file; 3 fail pre-fix. The deprecated form that succeeds still warns. Full suite 51,463 passed / 316 skipped, coverage 96.04%.