### PR TITLE
fix(hardware): tool execute/start admit a provider that needs no port

### DIFF
--- a/changelog.d/3525-hardware-tool-port-less-provider.md
+++ b/changelog.d/3525-hardware-tool-port-less-provider.md
@@ -1,0 +1,3 @@
+### Fixed: the hardware `Robot` tool can run `mock` and `lerobot_local`
+
+Asking a real arm's agent tool for `execute` or `start` with `policy_provider="mock"` or `"lerobot_local"` was refused every time: the action guard demanded a `policy_port`, and supplying one was then refused because those providers read none. The guard now requires only `instruction`; whether a port is missing, unusable or unread is decided per provider by the same check the Python entry points use, so `groot` without a port is still refused and names the port. The schema text and the robot-control docs table say the same.

--- a/docs/hardware/robot-control.md
+++ b/docs/hardware/robot-control.md
@@ -112,8 +112,8 @@ have performed. Construct a new `Robot` to run another task.
 
 | Action | Blocking? | Needs |
 |--------|-----------|-------|
-| `execute` | Yes | `instruction` + `policy_port` |
-| `start` | No | `instruction` + `policy_port` |
+| `execute` | Yes | `instruction`; `policy_port` as the provider demands (see above) |
+| `start` | No | `instruction`; `policy_port` as the provider demands (see above) |
 | `status` | - | - |
 | `stop` | - | - |
 

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -2782,7 +2782,7 @@ class Robot(TeleopMixin, AgentTool):
             "name": self.tool_name_str,
             "description": f"Universal robot control with async task execution ({self.robot}). "
             f"Actions: execute (blocking), start (async), status, stop. "
-            f"For execute/start actions: instruction and policy_port are required. "
+            f"For execute/start actions: instruction is required; policy_port when the provider dials a server. "
             f"For status/stop actions: no additional parameters needed.",
             "inputSchema": {
                 "json": {
@@ -2800,7 +2800,7 @@ class Robot(TeleopMixin, AgentTool):
                         },
                         "policy_port": {
                             "type": "integer",
-                            "description": "Policy service port (required for execute/start actions)",
+                            "description": "Policy service port. Required by groot and moveit2, read by the other server-dialing providers, refused for providers that build in process (mock, lerobot_local).",
                         },
                         "policy_host": {
                             "type": "string",
@@ -2925,13 +2925,17 @@ class Robot(TeleopMixin, AgentTool):
                 policy_provider = input_data.get("policy_provider", "groot")
                 duration = input_data.get("duration", 30.0)
 
-                if not instruction or not policy_port:
+                # Only ``instruction`` is judged here. Whether a ``policy_port``
+                # is missing, unusable or unread is the named provider's call
+                # (``mock`` and ``lerobot_local`` build without one), and the
+                # dispatcher below asks :meth:`_policy_port_error` that.
+                if not instruction:
                     yield ToolResultEvent(
                         self._make_tool_result(
                             tool_use_id,
                             {
                                 "status": "error",
-                                "content": [{"text": "instruction and policy_port are required for execute action"}],
+                                "content": [{"text": "instruction is required for execute action"}],
                             },
                         )
                     )
@@ -2965,13 +2969,17 @@ class Robot(TeleopMixin, AgentTool):
                 policy_provider = input_data.get("policy_provider", "groot")
                 duration = input_data.get("duration", 30.0)
 
-                if not instruction or not policy_port:
+                # Only ``instruction`` is judged here. Whether a ``policy_port``
+                # is missing, unusable or unread is the named provider's call
+                # (``mock`` and ``lerobot_local`` build without one), and the
+                # dispatcher below asks :meth:`_policy_port_error` that.
+                if not instruction:
                     yield ToolResultEvent(
                         self._make_tool_result(
                             tool_use_id,
                             {
                                 "status": "error",
-                                "content": [{"text": "instruction and policy_port are required for start action"}],
+                                "content": [{"text": "instruction is required for start action"}],
                             },
                         )
                     )

--- a/tests/test_hardware_stream_port_less_provider.py
+++ b/tests/test_hardware_stream_port_less_provider.py
@@ -1,0 +1,105 @@
+"""``Robot.stream`` lets ``execute``/``start`` reach a provider that builds without a port.
+
+The tool's own schema offers ``policy_provider`` values ``mock`` and
+``lerobot_local``, whose registry entries neither require nor read a
+``policy_port``. The ``execute``/``start`` guard nonetheless refused any call
+without one, and the dispatcher then refused any call *with* one for those
+providers (``_policy_port_error``: "declares no policy_port"), so no tool call
+could run them on a real arm. The guard now judges ``instruction`` alone and
+leaves the port to the provider-aware dispatcher.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any, cast
+
+import pytest
+from strands.types.tools import ToolUse
+
+from strands_robots.hardware_robot import Robot as HwRobot
+from strands_robots.hardware_robot import RobotTaskState
+from tests._daemon_executor import DaemonThreadExecutor
+
+
+def _make_robot() -> HwRobot:
+    hw = HwRobot.__new__(HwRobot)
+    hw.tool_name_str = "test_arm"
+    hw.action_horizon = 8
+    hw.data_config = None
+    hw.control_frequency = 30.0
+    hw.action_sleep_time = 1.0 / 30.0
+    hw._task_state = RobotTaskState()
+    hw._executor = DaemonThreadExecutor(max_workers=1, thread_name_prefix="test_arm_executor")
+    hw._shutdown_event = threading.Event()
+    hw._stop_requested = threading.Event()
+    hw._task_admission = threading.Lock()
+    hw._task_claimed = False
+    hw.mesh = None
+    hw.peer_id = None
+    hw.robot = object()
+    return hw
+
+
+@pytest.fixture
+def dispatched(monkeypatch: pytest.MonkeyPatch) -> tuple[HwRobot, list[tuple[str, Any]]]:
+    hw = _make_robot()
+    calls: list[tuple[str, Any]] = []
+
+    def _execute(instruction: str, port: Any, host: str, provider: str, duration: float) -> dict[str, Any]:
+        calls.append(("execute", port))
+        return {"status": "success", "content": [{"text": "done"}]}
+
+    def _start(instruction: str, port: Any, host: str, provider: str, duration: float) -> dict[str, Any]:
+        calls.append(("start", port))
+        return {"status": "success", "content": [{"text": "started"}]}
+
+    hw._execute_task_sync = _execute  # type: ignore[assignment]
+    hw.start_task = _start  # type: ignore[assignment]
+    monkeypatch.setenv("BYPASS_TOOL_CONSENT", "true")
+    return hw, calls
+
+
+def _stream(hw: HwRobot, **inp: Any) -> dict[str, Any]:
+    tool_use = cast(ToolUse, {"toolUseId": "tu", "input": inp})
+
+    async def _run() -> list:
+        return [ev async for ev in hw.stream(tool_use, {})]
+
+    return _run_events(_run)[-1].tool_result
+
+
+def _run_events(coro_fn):  # type: ignore[no-untyped-def]
+    return asyncio.run(coro_fn())
+
+
+@pytest.mark.parametrize("action", ["execute", "start"])
+@pytest.mark.parametrize("provider", ["mock", "lerobot_local"])
+def test_a_port_less_provider_reaches_the_dispatcher_without_a_port(dispatched, action: str, provider: str) -> None:
+    hw, calls = dispatched
+    result = _stream(hw, action=action, instruction="pick", policy_provider=provider)
+
+    assert result["status"] == "success", result
+    assert calls == [(action, None)]
+
+
+@pytest.mark.parametrize("action", ["execute", "start"])
+def test_a_missing_instruction_is_still_refused(dispatched, action: str) -> None:
+    hw, calls = dispatched
+    result = _stream(hw, action=action, policy_provider="mock")
+
+    assert result["status"] == "error"
+    assert "instruction" in result["content"][0]["text"]
+    assert calls == []
+
+
+@pytest.mark.parametrize("action", ["execute", "start"])
+def test_the_real_dispatcher_still_refuses_groot_without_a_port(action: str) -> None:
+    """The judgement moved, it did not vanish: ``groot`` requires a port and says so."""
+    hw = _make_robot()
+    method = hw._execute_task_sync if action == "execute" else hw.start_task
+    result = method("pick", policy_port=None, policy_provider="groot", duration=0.05)
+
+    assert result["status"] == "error"
+    assert "policy_port is required" in result["content"][0]["text"]


### PR DESCRIPTION
**What**

The hardware `Robot` tool's `execute`/`start` actions now admit a `policy_provider` that builds without a `policy_port` (`mock`, `lerobot_local`), leaving the port judgement to the provider-aware dispatcher.

**Why**

`stream` guarded both actions with `if not instruction or not policy_port`, while `_policy_port_error` refuses a supplied port for those same providers, so no tool call could run them. On main, `tests/test_hardware_stream_port_less_provider.py` fails with:

```
AssertionError: {'toolUseId': 'tu', 'status': 'error', 'content': [{'text': 'instruction and policy_port are required for start action'}]}
assert 'error' == 'success'
```

`groot` without a port is still refused by the dispatcher (covered).

**Tests**

`tests/test_hardware_stream_port_less_provider.py` (8 cases); ruff, mypy clean on touched files.
