### PR TITLE
fix(drivers/reachy): teardown closes the loop the link ran on

### DIFF
--- a/changelog.d/0000-reachy-cleanup-closes-the-loop-it-opened.md
+++ b/changelog.d/0000-reachy-cleanup-closes-the-loop-it-opened.md
@@ -1,0 +1,21 @@
+### Fixed: the Reachy driver closes the asyncio loop its link ran on
+
+`ReachyDriver` runs its real-time link on a background asyncio loop from
+`asyncio.new_event_loop`, whose documented counterpart is `loop.close()`.
+Teardown called `loop.stop()` instead, which only asks `run_forever` to return
+and leaves the loop's selector and self-pipe open. So every connect/teardown
+cycle abandoned one open loop - on the success path through `cleanup()` and on
+both give-up paths through `_release_link`, where a retried bring-up abandoned
+one per attempt - and Python raised a `ResourceWarning: unclosed event loop` for
+each, reported wherever the collector happened to reclaim it rather than at the
+teardown responsible.
+
+Closing it means waiting for the loop's thread first: `stop()` is asynchronous,
+so the thread is still inside `run_forever` when it returns, and closing a
+running loop raises `RuntimeError`. Teardown now waits for that thread, bounded
+by `_LOOP_JOIN_TIMEOUT_S` so a link callback wedged on a socket read cannot hold
+teardown open for as long as the read takes, and then closes the loop. This is
+what `_loop_thread` was kept for; it had no reader before. A thread that
+outlasts the budget keeps its loop - it is by definition still running, so
+closing it would raise - and that outcome is logged rather than passed off as a
+teardown that finished.

--- a/docs/getting-started/robot-factory.md
+++ b/docs/getting-started/robot-factory.md
@@ -283,6 +283,15 @@ subscribed to a Mini the caller has just been told it is not connected to:
 The reason names the budget that expired rather than the timeout's own message,
 which is empty.
 
+Either way the loop the bring-up opened is closed, not merely stopped. The link runs
+on a background asyncio loop, and `loop.stop()` only asks it to return from
+`run_forever` - the selector and self-pipe it opened are released by `loop.close()`.
+So teardown waits for that thread (up to 5s) and then closes the loop, on the success
+path through `cleanup()` and on both give-up paths, rather than leaving one open loop
+per connect cycle for the garbage collector to complain about later. A thread that
+outlasts the wait keeps its loop, because closing a running loop raises, and that
+outcome is logged instead of reported as a teardown that finished.
+
 `hardware.driver` is optional and validated when the registry loads: a value that is not a
 driver name is refused there, naming the robot, rather than being read as "no preference".
 

--- a/strands_robots/drivers/reachy.py
+++ b/strands_robots/drivers/reachy.py
@@ -130,6 +130,15 @@ _TRANSPORT_MODULE = "strands_robots.device_connect.reachy_transport"
 #: it - the same shape as ``device_connect``'s ``_INIT_TIMEOUT_S``.
 _LINK_START_TIMEOUT_S: float = 10.0
 
+#: How long :meth:`ReachyDriver._stop_loop` waits for the thread running the
+#: link's loop to return from ``run_forever`` before giving up on closing that
+#: loop. A budget rather than an unbounded wait because the thread is only as
+#: free to return as the callbacks on it: a link callback wedged on a socket read
+#: would otherwise hold teardown open for as long as the read takes. Matches
+#: ``_CAMS_REC_JOIN_TIMEOUT_S`` and ``_TELEOP_JOIN_TIMEOUT_S`` in purpose, and is
+#: read off the module for the same reason as the budget above.
+_LOOP_JOIN_TIMEOUT_S: float = 5.0
+
 
 def _resolve_transport() -> Any:
     """Return the Reachy transport module, or a reason naming what failed.
@@ -506,18 +515,66 @@ class ReachyDriver:
             # message: ``str(TimeoutError())`` is the empty string, so reporting
             # it as a cause produced "failed to start: " and told an operator
             # nothing. The budget is the cause, so the budget is what is named.
-            self._release_link(link, future, loop)
+            self._release_link(link, future, loop, thread)
             return (
                 f"link to {self._host}:{self._api_port} did not finish its handshake within {_LINK_START_TIMEOUT_S:g}s"
             )
         except Exception as exc:  # noqa: BLE001 - any link failure is a connect failure
-            self._release_link(link, future, loop)
+            self._release_link(link, future, loop, thread)
             return f"link to {self._host}:{self._api_port} failed to start: {exc}"
         self._loop = loop
         self._loop_thread = thread
         return None
 
-    def _release_link(self, link: Any, future: Future[None], loop: asyncio.AbstractEventLoop) -> None:
+    def _stop_loop(self, loop: asyncio.AbstractEventLoop, thread: threading.Thread) -> None:
+        """Stop the loop running *thread*, wait for it, and close the loop.
+
+        ``asyncio.new_event_loop`` is what :meth:`_start_link` calls to get this
+        loop, and ``loop.close()`` is that call's documented
+        counterpart: it releases the selector and the self-pipe the loop opened.
+        ``loop.stop()`` is not that counterpart - it only asks ``run_forever`` to
+        return. So a teardown that stops without closing abandons an open loop,
+        and Python says so: every connect/teardown cycle raised one
+        ``ResourceWarning: unclosed event loop``, reported not here but wherever
+        the collector happened to reclaim it, which is code that has nothing to
+        do with this driver.
+
+        The wait is not politeness, it is what makes the close legal: closing a
+        loop that is still running raises ``RuntimeError``, and ``stop()`` is
+        asynchronous - it schedules the stop and returns, so the thread is still
+        inside ``run_forever`` when it does. Waiting for the thread is therefore
+        the only way to know the loop has stopped, and it is why the thread
+        handle is kept at all.
+
+        Bounded by :data:`_LOOP_JOIN_TIMEOUT_S`, and a thread that outlasts it
+        keeps its loop: the loop is by definition still running, so closing it
+        would raise, and reporting a teardown that did not happen is worse than
+        one open loop. That outcome is logged rather than raised, because
+        teardown is a caller's last action and has no error to return to.
+
+        Args:
+            loop: The loop to stop and close.
+            thread: The thread running that loop, waited for here.
+        """
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=_LOOP_JOIN_TIMEOUT_S)
+        if thread.is_alive():
+            logger.warning(
+                "%s: the link loop did not stop within %.1fs, so its loop is left open; "
+                "a link callback is still running on it.",
+                self._tool_name,
+                _LOOP_JOIN_TIMEOUT_S,
+            )
+            return
+        loop.close()
+
+    def _release_link(
+        self,
+        link: Any,
+        future: Future[None],
+        loop: asyncio.AbstractEventLoop,
+        thread: threading.Thread,
+    ) -> None:
         """Close whatever a bring-up that will not be adopted already opened.
 
         A ``start`` that raised, or that outran
@@ -542,13 +599,15 @@ class ReachyDriver:
             link: The link whose bring-up failed.
             future: The pending handshake, cancelled here.
             loop: The loop the handshake was submitted to; stopped last.
+            thread: The thread running that loop, so the loop this bring-up
+                opened is closed rather than left for the collector.
         """
         future.cancel()
         try:
             asyncio.run_coroutine_threadsafe(link.stop(), loop).result(timeout=_LINK_START_TIMEOUT_S)
         except Exception as exc:  # noqa: BLE001 - teardown of a failed bring-up must not raise
             logger.debug("%s: stopping the failed link raised: %s", self._tool_name, exc)
-        loop.call_soon_threadsafe(loop.stop)
+        self._stop_loop(loop, thread)
 
     async def get_status(self) -> dict[str, Any]:
         """Report reachability, hardware variant and the latest battery read.
@@ -592,14 +651,21 @@ class ReachyDriver:
         self._stopped = True
 
     def cleanup(self) -> None:
-        """Stop the link and its loop. Idempotent."""
+        """Stop the link, then stop and close the loop it ran on. Idempotent.
+
+        The loop is closed and not merely stopped - see :meth:`_stop_loop` for
+        why the two are different and why closing it means waiting for the
+        thread first. ``_loop`` and ``_loop_thread`` are adopted together by
+        :meth:`_start_link` and cleared together here, so one being set is the
+        same condition as both.
+        """
         if self._link is not None and self._loop is not None:
             try:
                 asyncio.run_coroutine_threadsafe(self._link.stop(), self._loop).result(timeout=5)
             except Exception as exc:  # noqa: BLE001 - teardown must not raise
                 logger.debug("%s: link stop failed during cleanup: %s", self._tool_name, exc)
-        if self._loop is not None:
-            self._loop.call_soon_threadsafe(self._loop.stop)
+        if self._loop is not None and self._loop_thread is not None:
+            self._stop_loop(self._loop, self._loop_thread)
         self._link = None
         self._loop = None
         self._loop_thread = None

--- a/tests/drivers/test_reachy_cleanup_closes_the_loop_it_opened.py
+++ b/tests/drivers/test_reachy_cleanup_closes_the_loop_it_opened.py
@@ -1,0 +1,290 @@
+"""A Reachy teardown closes the loop it opened, and waits so it can.
+
+:meth:`~strands_robots.drivers.reachy.ReachyDriver._start_link` gets its loop
+from ``asyncio.new_event_loop``, whose documented counterpart is
+``loop.close()``. ``loop.stop()`` is not that counterpart: it only asks
+``run_forever`` to return, leaving the loop's selector and self-pipe open. So a
+teardown that stopped without closing abandoned one open loop per
+connect/teardown cycle - on the success path through
+:meth:`ReachyDriver.cleanup` and on both give-up paths through
+:meth:`ReachyDriver._release_link` - and Python raised one
+``ResourceWarning: unclosed event loop`` for each, reported wherever the
+collector happened to reclaim it rather than at the teardown responsible.
+
+Closing it means waiting for the thread first, because closing a running loop
+raises ``RuntimeError`` and ``stop()`` is asynchronous: it schedules the stop
+and returns while the thread is still inside ``run_forever``. That wait is what
+``_loop_thread`` is for, and it is bounded by
+:data:`~strands_robots.drivers.reachy._LOOP_JOIN_TIMEOUT_S` so a wedged link
+callback cannot hold teardown open for as long as its socket read takes.
+
+Every test runs the driver's real loop and thread, with no Reachy attached.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+import logging
+import threading
+import time
+import warnings
+from typing import Any
+
+import pytest
+
+import strands_robots.drivers.reachy as reachy_mod
+from strands_robots.drivers.reachy import ReachyDriver
+
+# A Lite: the variant that needs no Zenoh transport, so the cheapest to bring up.
+_LITE_STATUS: dict[str, Any] = {"wireless_version": False, "motors": "on"}
+
+# Short enough to keep the give-up paths quick, long enough that a loaded machine
+# does not trip them on the healthy control.
+_BUDGET = 0.5
+
+
+class _Link:
+    """A link that comes up cleanly and records the stop asked of it."""
+
+    def __init__(self) -> None:
+        self.stopped = False
+
+    async def start(self, on_joints: Any, on_imu: Any) -> None:
+        """Come up cleanly, keeping the callbacks this double never invokes."""
+
+    async def stop(self) -> None:
+        """Record the stop the driver asked for."""
+        self.stopped = True
+
+    async def send_cmd(self, command: dict[str, Any]) -> None:
+        """Accept a command; the wire format is not this module's subject."""
+
+
+class _RaisingLink(_Link):
+    """Fails the handshake - a daemon that rejects the SDK."""
+
+    async def start(self, on_joints: Any, on_imu: Any) -> None:
+        """Raise instead of handing back."""
+        del on_joints, on_imu
+        raise RuntimeError("handshake rejected")
+
+
+class _SlowLink(_Link):
+    """Takes far longer than any budget to hand back."""
+
+    async def start(self, on_joints: Any, on_imu: Any) -> None:
+        """Wait past the driver's handshake budget."""
+        del on_joints, on_imu
+        await asyncio.sleep(30)
+
+
+class _WedgingLink(_RaisingLink):
+    """A failed bring-up whose ``stop`` leaves the loop behind a blocked callback.
+
+    A link callback wedged on a socket read is what this stands for: the loop
+    thread cannot return from ``run_forever`` until the callback does, so the
+    join budget is the only thing that ends the wait.
+
+    Wedged on the give-up path rather than on :meth:`ReachyDriver.cleanup`
+    because both waits ahead of the join are then :data:`_BUDGET`, which these
+    tests set. The join it is holding is the same
+    :meth:`ReachyDriver._stop_loop` both paths call.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.release = threading.Event()
+        self.wedged = threading.Event()
+
+    async def stop(self) -> None:
+        """Record the stop, then wedge the loop behind a blocking callback."""
+        self.stopped = True
+        asyncio.get_running_loop().call_soon(self._block)
+
+    def _block(self) -> None:
+        """Hold the loop thread until the test lets it go."""
+        self.wedged.set()
+        self.release.wait(timeout=30)
+
+
+def _install(monkeypatch: pytest.MonkeyPatch, link: _Link, *, budget: float = _BUDGET) -> ReachyDriver:
+    """Build a driver whose daemon probe succeeds and whose link is ``link``.
+
+    Args:
+        monkeypatch: pytest's patcher.
+        link: The link double :meth:`ReachyDriver._build_link` will return.
+        budget: Handshake budget to install on the module.
+
+    Returns:
+        An unconnected driver.
+    """
+
+    def _api(host: str, port: int, path: str, method: str = "GET", data: Any = None) -> dict[str, Any]:
+        del host, port, method, data
+        return dict(_LITE_STATUS) if path == reachy_mod._PATH_STATUS else {"ok": True}
+
+    monkeypatch.setattr("strands_robots.device_connect.reachy_transport.api", _api)
+    monkeypatch.setattr(reachy_mod, "_LINK_START_TIMEOUT_S", budget)
+    monkeypatch.setattr(ReachyDriver, "_build_link", lambda self, *, is_lite: link)
+    return ReachyDriver(tool_name="reachy_mini", port="reachy-a.local:8000")
+
+
+def _spy_threads(monkeypatch: pytest.MonkeyPatch, out: list[threading.Thread]) -> None:
+    """Record every thread the driver starts, so an unadopted one can be released.
+
+    A failed bring-up never publishes ``_loop_thread``, so a test that has to let
+    a wedged loop go has no other handle on it.
+
+    Args:
+        monkeypatch: pytest's patcher.
+        out: Collected threads, in the order they were started.
+    """
+
+    class _Recording(threading.Thread):
+        def start(self) -> None:
+            out.append(self)
+            super().start()
+
+    monkeypatch.setattr(reachy_mod.threading, "Thread", _Recording)
+
+
+class TestATornDownDriverLeavesNoOpenLoop:
+    """The success path: the loop is closed, and the thread is gone first."""
+
+    def test_cleanup_closes_the_loop_it_opened(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        driver = _install(monkeypatch, _Link())
+        assert driver.connect_eagerly() is None
+        loop = driver._loop
+        assert loop is not None and not loop.is_closed(), "the double must really bring a loop up"
+        driver.cleanup()
+        assert loop.is_closed()
+
+    def test_the_loop_thread_has_returned_when_cleanup_does(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # ``stop()`` only schedules the stop, so without the wait the thread was
+        # still inside ``run_forever`` here - and a running loop cannot be closed.
+        driver = _install(monkeypatch, _Link())
+        assert driver.connect_eagerly() is None
+        thread = driver._loop_thread
+        assert thread is not None and thread.is_alive()
+        driver.cleanup()
+        assert not thread.is_alive()
+
+    def test_the_link_is_still_stopped_before_its_loop_is(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        link = _Link()
+        driver = _install(monkeypatch, link)
+        assert driver.connect_eagerly() is None
+        driver.cleanup()
+        assert link.stopped, "the link stop must not be skipped by the loop teardown"
+        assert driver._connected is False
+
+    def test_a_second_cleanup_is_still_a_no_op(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Closing an already-closed loop is the one way the new close could turn
+        # an idempotent teardown into a raise.
+        driver = _install(monkeypatch, _Link())
+        assert driver.connect_eagerly() is None
+        driver.cleanup()
+        driver.cleanup()
+        assert driver._loop is None and driver._loop_thread is None
+
+    def test_python_no_longer_complains_about_an_abandoned_loop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The consequence Python itself reports. Nothing may outlive the cycle or
+        # the collector has a live reference and cannot reclaim the loop at all.
+        def cycle() -> None:
+            driver = _install(monkeypatch, _Link())
+            assert driver.connect_eagerly() is None
+            driver.cleanup()
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            cycle()
+            cycle()
+            gc.collect()
+        unclosed = [w for w in caught if "unclosed event loop" in str(w.message)]
+        assert unclosed == [], f"teardown abandoned {len(unclosed)} open loop(s)"
+
+
+class TestAnUnadoptedBringUpLeavesNoOpenLoopEither:
+    """Both give-up paths close the loop the failed bring-up opened."""
+
+    @pytest.mark.parametrize("link", [_RaisingLink(), _SlowLink()], ids=["handshake-raised", "budget-expired"])
+    def test_the_loop_a_failed_bring_up_opened_is_closed(self, monkeypatch: pytest.MonkeyPatch, link: _Link) -> None:
+        driver = _install(monkeypatch, link)
+        loops: list[asyncio.AbstractEventLoop] = []
+        real = ReachyDriver._stop_loop
+
+        def _spy(self: ReachyDriver, loop: asyncio.AbstractEventLoop, thread: threading.Thread) -> None:
+            loops.append(loop)
+            real(self, loop, thread)
+
+        monkeypatch.setattr(ReachyDriver, "_stop_loop", _spy)
+        assert driver.connect_eagerly() is not None, "the double must fail, or it pins nothing"
+        assert driver._loop is None, "an unadopted bring-up must not publish its loop"
+        assert len(loops) == 1 and loops[0].is_closed()
+
+    def test_repeated_failed_bring_ups_abandon_nothing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Every ``connect_eagerly`` builds a fresh loop, so an unclosed one here
+        # accumulated once per retry.
+        def cycle() -> None:
+            driver = _install(monkeypatch, _RaisingLink())
+            for _ in range(3):
+                assert driver.connect_eagerly() is not None
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            cycle()
+            gc.collect()
+        unclosed = [w for w in caught if "unclosed event loop" in str(w.message)]
+        assert unclosed == [], f"three failed bring-ups abandoned {len(unclosed)} open loop(s)"
+
+
+class TestAWedgedLoopDoesNotHoldTeardownOpen:
+    """The budget bounds the wait, and a loop still running is not closed."""
+
+    def test_teardown_returns_on_the_budget_rather_than_the_callback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        link = _WedgingLink()
+        driver = _install(monkeypatch, link)
+        monkeypatch.setattr(reachy_mod, "_LOOP_JOIN_TIMEOUT_S", 0.3)
+        threads: list[threading.Thread] = []
+        _spy_threads(monkeypatch, threads)
+        started = time.monotonic()
+        assert driver.connect_eagerly() is not None
+        elapsed = time.monotonic() - started
+        thread = threads[0]
+        try:
+            assert link.wedged.is_set(), "the callback must really hold the loop, or this pins nothing"
+            assert thread.is_alive()
+            # The link-stop wait plus the join, not the callback's own 30s wait.
+            assert elapsed < _BUDGET + 0.3 + 2.0
+        finally:
+            link.release.set()
+            thread.join(timeout=5)
+
+    def test_a_running_loop_is_left_open_and_said_so(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        link = _WedgingLink()
+        driver = _install(monkeypatch, link)
+        monkeypatch.setattr(reachy_mod, "_LOOP_JOIN_TIMEOUT_S", 0.3)
+        loops: list[asyncio.AbstractEventLoop] = []
+        threads: list[threading.Thread] = []
+        _spy_threads(monkeypatch, threads)
+        real = ReachyDriver._stop_loop
+
+        def _spy(self: ReachyDriver, loop: asyncio.AbstractEventLoop, thread: threading.Thread) -> None:
+            loops.append(loop)
+            real(self, loop, thread)
+
+        monkeypatch.setattr(ReachyDriver, "_stop_loop", _spy)
+        with caplog.at_level(logging.WARNING, logger=reachy_mod.__name__):
+            assert driver.connect_eagerly() is not None
+        try:
+            # Closing a loop that is still running raises, so it keeps its loop -
+            # and the teardown that could not finish is reported rather than
+            # passed off as done.
+            assert len(loops) == 1 and not loops[0].is_closed()
+            assert "did not stop within 0.3s" in caplog.text
+            assert "left open" in caplog.text
+        finally:
+            link.release.set()
+            threads[0].join(timeout=5)


### PR DESCRIPTION
![teardown timeline and measured abandoned-loop counts](https://raw.githubusercontent.com/cagataycali/robots/assets/reachy-loop-close/reachy-loop-close.png)

**What.** `ReachyDriver` runs its link on a background loop from `asyncio.new_event_loop`, whose counterpart is `loop.close()`. Teardown called `loop.stop()`, which only asks `run_forever` to return, so every connect cycle abandoned one open loop -- on the success path through `cleanup()` and on both give-up paths through `_release_link`, one per retry -- and Python raised a `ResourceWarning: unclosed event loop` for each, reported wherever the collector ran rather than at the teardown responsible.

**Why it waits.** `stop()` is asynchronous, so the thread is still inside `run_forever` when it returns, and closing a running loop raises. Teardown now joins that thread, bounded by `_LOOP_JOIN_TIMEOUT_S` as `_TELEOP_JOIN_TIMEOUT_S` and `_CAMS_REC_JOIN_TIMEOUT_S` are, then closes. That is what `_loop_thread` was kept for; it had no reader. A thread that outlasts the budget keeps its loop and logs that.

**Tests.** `tests/drivers/test_reachy_cleanup_closes_the_loop_it_opened.py`, 10 cells; 4 fail on `main`. Full suite 51,510 passed; ruff, mypy clean.

LOC: +393 / -7.