### PR TITLE
fix(policies/protomotions): the state index addresses the state array

### DIFF
--- a/changelog.d/0000-protomotions-state-index-addresses-the-state-array.md
+++ b/changelog.d/0000-protomotions-state-index-addresses-the-state-array.md
@@ -1,0 +1,32 @@
+### Fixed: ProtoMotions reads a flat `observation.state` through the index `set_robot_state_keys` builds
+
+`set_robot_state_keys` built a joint-name -> `observation.state` offset map and
+cached it on the policy, and its docstring said so. Nothing read it. The
+convention that needs it rescanned the key list with `list.index` for every one
+of the 29 joints instead - twice a tick, positions then velocities, for the whole
+rollout. The map is now what the read goes through, and it is rebuilt with the
+list rather than beside it, because a map that outlived its list would address a
+re-ordered feed at the old offsets: a fully-populated but permuted pose, which is
+the one error resolving by name exists to prevent. First occurrence wins, as
+`list.index` answered, so a feed that repeats a key reads the same entry as
+before.
+
+The refusal that fires when the array has no offset for a key named a private
+attribute and prescribed a call the caller had already made:
+
+    KeyError: ProtoMotionsPolicy: joint 'left_hip_pitch_joint.vel' missing from
+    self._robot_state_keys (call set_robot_state_keys).
+
+A joint-name key list addresses positions. `set_robot_state_keys` validates that
+every joint the config names is present, so after a successful call a position is
+always addressable and only a suffixed spelling - a velocity - can be missing;
+repeating the call with the same joint list adds nothing. The refusal now names
+the spelling it could not address, states that the array is addressed by the list
+that method was given and how many keys that list holds, and names the three
+routes that do supply velocities: `dof_vel=` through `get_actions`, per-joint
+`<joint>.vel` keys on the observation, or widening the state array and its key
+list together. Each is driven in
+`tests/policies/protomotions/test_observation_state_reads_the_same_through_every_convention.py`,
+so the message cannot name a route that does not work.
+`docs/policies/protomotions.md` documents the flat-state route beside the
+per-joint one.

--- a/docs/policies/protomotions.md
+++ b/docs/policies/protomotions.md
@@ -87,6 +87,19 @@ Missing signals are refused, not substituted: no anchor pose raises naming the
 key it wanted (`base_quat` stands in only when the config's anchor body *is* the
 floating base), and an absent `<joint>.vel` is refused rather than read as zero.
 
+A runtime that publishes one flat `observation.state` instead of per-joint keys
+is read through the robot's own key list - the list `set_robot_state_keys`
+receives - so a key's position in that list is the offset its value sits at. A
+list of joint names therefore addresses joint *positions* only: it holds no
+offset for `<joint>.vel`, and no further `set_robot_state_keys` call with the
+same joint list can add one. Three routes supply the velocities:
+
+```python
+policy.set_robot_state_keys([*joints, *(f"{j}.vel" for j in joints)])   # widen both
+await policy.get_actions({"observation.state": state}, "", dof_vel=[...])  # or pass them
+await policy.get_actions({**{f"{j}.vel": v for j, v in ...}}, "")          # or per-joint keys
+```
+
 Orientations need not be exactly unit: both rotation helpers normalise their
 input, so a drifted IMU reading or a lerped sample (up to 8% short, which read
 as-is is a heading 6.2 degrees off) gives the unit quaternion's answer:

--- a/strands_robots/policies/protomotions/policy.py
+++ b/strands_robots/policies/protomotions/policy.py
@@ -69,6 +69,30 @@ _GTP_G1_HF_REPO = "cagataydev/protomotions-gtp-unitree-g1"
 _GTP_G1_ONNX_FILENAME = "unified_pipeline.onnx"
 
 
+def _first_index_of_each(keys: list[str]) -> dict[str, int]:
+    """Map each key to its FIRST position in ``keys``.
+
+    This is the addressing map for a flat ``observation.state``: the array is
+    ordered by the robot's own key list, so a key's position in that list is the
+    array offset its value sits at.
+
+    First occurrence wins, which is what ``list.index`` answers. A robot whose
+    feed repeats a key therefore resolves to the same entry through the map as
+    through a rescan of the list, so building the map cannot change which value
+    a joint reads.
+
+    Args:
+        keys: The robot's state-key list, in the order its state array is packed.
+
+    Returns:
+        ``{key: offset}`` covering every distinct key in ``keys``.
+    """
+    index: dict[str, int] = {}
+    for position, key in enumerate(keys):
+        index.setdefault(key, position)
+    return index
+
+
 @runtime_checkable
 class ProtoMotionsSession(Protocol):
     """Injection seam for the ONNX tracker session.
@@ -185,11 +209,16 @@ class ProtoMotionsPolicy(Policy):
         if motion is not None:
             self.load_motion(motion)
 
-        # Cache of joint names -> their index inside a caller-supplied
-        # ``observation.state`` (list-of-values). Recomputed lazily whenever
-        # the robot's state-key list changes.
-        self._state_index_cache: dict[str, int] | None = None
+        # The robot's own key list for a flat ``observation.state``, and the
+        # name -> position map that addresses the array with it. The two are
+        # built together here and rebuilt together in
+        # :meth:`set_robot_state_keys`, because a map that outlived its list
+        # would read the new array at the old list's offsets - the one failure
+        # this lookup exists to prevent. First occurrence wins, matching the
+        # ``list.index`` the map replaces, so a duplicated key resolves to the
+        # same entry either way.
         self._robot_state_keys: list[str] = list(self._config.joint_names)
+        self._state_index_cache: dict[str, int] = _first_index_of_each(self._robot_state_keys)
 
     # ------------------------------------------------------------------
     # Policy interface
@@ -226,10 +255,16 @@ class ProtoMotionsPolicy(Policy):
     def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
         """Resolve the 29 GTP joint names by NAME in the robot's key list.
 
-        The tracker's ONNX input is dof-index-based, so we build a lookup from
-        joint name -> the caller's ``observation.state`` index and cache it.
-        Resolving by name means the tracker's output aligns with the robot's
-        actuators regardless of sim-specific joint ordering or namespacing.
+        The tracker's ONNX input is dof-index-based, so this builds the lookup
+        from joint name -> the caller's ``observation.state`` offset that every
+        later read of that array goes through. Resolving by name means the
+        tracker's output aligns with the robot's actuators regardless of
+        sim-specific joint ordering or namespacing.
+
+        The list and its map are replaced together. A map left over from the
+        previous list would address the new array at the old list's offsets, so
+        a re-ordered feed would be read as though it had not moved - a permuted
+        pose the tracker cannot detect.
 
         Args:
             robot_state_keys: The robot's own joint-name list (as reported by
@@ -251,7 +286,7 @@ class ProtoMotionsPolicy(Policy):
                 "The GTP tracker drives the 29-DOF G1; load unitree_g1."
             )
         self._robot_state_keys = keys
-        self._state_index_cache = {name: keys.index(name) for name in keys}
+        self._state_index_cache = _first_index_of_each(keys)
 
     # ------------------------------------------------------------------
     # Public helpers
@@ -657,18 +692,20 @@ ProtoMotionsConfig.action_ema_alpha` filter state is cleared here for the same
                     out[i] = fill
             return out
 
-        # 3. observation.state matches self._robot_state_keys order.
+        # 3. observation.state is addressed by the robot's own key list, through
+        # the name -> position map built with it. The map is what makes this a
+        # single lookup per joint: rescanning the list per joint is quadratic in
+        # the key count and runs twice a tick (positions, then velocities) for
+        # the whole rollout.
         if state_arr is not None and self._robot_state_keys:
             out = np.zeros(self._config.num_dofs, dtype=np.float32)
             for i, name in enumerate(self._config.joint_names):
                 key = name + suffix
-                if key in self._robot_state_keys:
-                    out[i] = float(state_arr[self._robot_state_keys.index(key)])
+                index = self._state_index_cache.get(key)
+                if index is not None:
+                    out[i] = float(state_arr[index])
                 elif fill is None:
-                    raise KeyError(
-                        f"ProtoMotionsPolicy: joint {key!r} missing from "
-                        f"self._robot_state_keys (call set_robot_state_keys)."
-                    )
+                    raise KeyError(self._unaddressable_state_key_msg(key, suffix))
                 else:
                     out[i] = fill
             return out
@@ -681,3 +718,42 @@ ProtoMotionsConfig.action_ema_alpha` filter state is cleared here for the same
                 f"per-joint keys, or explicit `dof_pos`/`dof_vel` kwargs."
             )
         return np.full(self._config.num_dofs, fill, dtype=np.float32)
+
+    def _unaddressable_state_key_msg(self, key: str, suffix: str) -> str:
+        """Explain why a flat ``observation.state`` holds no value for ``key``.
+
+        The array is addressed by the robot's own key list, so a key absent from
+        that list has no offset to read and no reordering of the array can
+        supply one. What the caller can do depends on which value is missing,
+        and every remedy named here is a surface they can reach:
+        :meth:`get_actions` takes ``dof_pos``/``dof_vel`` outright, the per-joint
+        convention takes the spelling directly on the observation, and the list
+        itself is what :meth:`set_robot_state_keys` was given.
+
+        Naming that method as the *remedy* would be the one thing this message
+        must not do. A runtime reaches this branch having already called it, and
+        successfully: the call validates that every joint this config names is
+        present, so a position is always addressable afterwards and only a
+        suffixed spelling - a velocity - can be missing. Repeating the call with
+        the same joint list cannot add one.
+
+        Args:
+            key: The spelling looked up, e.g. ``"left_hip_pitch_joint.vel"``.
+            suffix: The spelling's suffix (``""`` for a position, ``".vel"``
+                for a velocity), which selects the kwarg named as a remedy.
+
+        Returns:
+            The refusal text. Nothing here names a private attribute: the
+            caller cannot act on one.
+        """
+        kwarg = "dof_vel" if suffix else "dof_pos"
+        return (
+            f"ProtoMotionsPolicy: 'observation.state' carries no {key!r}. The array "
+            f"is addressed by the robot's own state-key list - the one "
+            f"set_robot_state_keys was given, {len(self._robot_state_keys)} keys, "
+            f"none of them {key!r} - so there is no offset in it to read this value "
+            f"from, and that list already resolves every joint position this config "
+            f"names. Supply {kwarg}=[...] through get_actions kwargs, or put "
+            f"per-joint {key!r} keys on the observation, or extend the state array "
+            f"and its key list together with the {suffix!r} spellings."
+        )

--- a/tests/policies/protomotions/test_observation_state_reads_the_same_through_every_convention.py
+++ b/tests/policies/protomotions/test_observation_state_reads_the_same_through_every_convention.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import ast
 import asyncio
 import inspect
+import re
 import textwrap
 from typing import Any
 
@@ -40,6 +41,10 @@ NUM_DOFS = len(JOINT_NAMES)
 # A pose whose every entry is distinct, so a mis-ordered or partially-filled
 # read cannot coincide with the right answer.
 POSE = np.linspace(-0.4, 0.4, NUM_DOFS).astype(np.float32)
+
+# A velocity vector disjoint from POSE, so a velocity read that fell through to
+# the position offsets would be visible rather than coincidentally right.
+VELOCITY = np.linspace(1.0, 2.0, NUM_DOFS).astype(np.float32)
 
 
 class _EchoSession:
@@ -265,11 +270,106 @@ class TestTheRobotStateKeysConvention:
         resolved = _resolved_pose({"observation.state": state.reshape(1, NUM_DOFS)}, policy)
         assert np.array_equal(resolved, POSE)
 
-    def test_a_key_list_naming_no_velocities_names_the_joint_it_cannot_resolve(self):
-        """A key list of joint names cannot answer the ``.vel`` pass."""
+    def test_a_second_key_list_readdresses_the_array(self):
+        """The offsets follow the LATEST list, not the one they were built from.
+
+        Convention 3 reads the array through a name -> offset map. A map that
+        outlived the list it was built from would read the new feed at the old
+        offsets, and because both lists name the same 29 joints the result is a
+        fully-populated but permuted pose - the one error the by-name resolution
+        exists to prevent, and one no downstream check can detect.
+        """
         policy = _policy()
-        with pytest.raises(KeyError, match=r"missing from self\._robot_state_keys"):
+        policy.set_robot_state_keys(list(JOINT_NAMES))
+        reordered = list(reversed(JOINT_NAMES))
+        policy.set_robot_state_keys(reordered)
+        state = np.array([POSE[JOINT_NAMES.index(name)] for name in reordered], dtype=np.float32)
+        assert np.array_equal(_resolved_pose({"observation.state": state}, policy), POSE)
+
+    def test_a_repeated_key_resolves_to_its_first_position(self):
+        """A feed that names a key twice reads the first of the two entries.
+
+        This is what a rescan of the list answers, so it is what the offset map
+        must answer: building the map is not allowed to move which entry a joint
+        reads.
+        """
+        duplicated = [JOINT_NAMES[0], *JOINT_NAMES]
+        policy = _policy()
+        policy.set_robot_state_keys(duplicated)
+        state = np.zeros(len(duplicated), dtype=np.float32)
+        state[0] = POSE[0]
+        state[1] = POSE[0] + 1.0  # the shadowed second entry, deliberately wrong
+        for offset, name in enumerate(JOINT_NAMES[1:], start=2):
+            state[offset] = POSE[JOINT_NAMES.index(name)]
+        assert np.array_equal(_resolved_pose({"observation.state": state}, policy), POSE)
+        assert duplicated.index(JOINT_NAMES[0]) == 0
+
+
+class TestAKeyListCannotAnswerTheVelocityPass:
+    """The refusal for a value the state array has no offset for.
+
+    A joint-name key list addresses joint POSITIONS. ``set_robot_state_keys``
+    validates that every joint this config names is in the list, so after a
+    successful call a position is always addressable and only a suffixed
+    spelling - a velocity - can be missing. The refusal therefore cannot ask for
+    that call: the caller has already made it, and making it again with the same
+    joint list adds nothing.
+    """
+
+    @staticmethod
+    def _velocity_refusal() -> str:
+        policy = _policy()
+        policy.set_robot_state_keys(list(JOINT_NAMES))
+        with pytest.raises(KeyError) as excinfo:
             policy._pack_by_name({"observation.state": POSE}, ".vel")
+        return str(excinfo.value)
+
+    def test_it_names_the_spelling_it_could_not_address(self):
+        assert "left_hip_pitch_joint.vel" in self._velocity_refusal()
+
+    def test_it_does_not_prescribe_the_call_the_caller_already_made(self):
+        """Naming ``set_robot_state_keys`` as the SOURCE of the list is fine.
+
+        Naming it as the remedy is not: the caller reaching this branch has
+        called it, successfully, with a list this policy accepted.
+        """
+        message = self._velocity_refusal()
+        assert "(call set_robot_state_keys)" not in message
+        assert "set_robot_state_keys was given" in message
+
+    def test_it_names_no_private_attribute(self):
+        """A caller cannot act on a name the library does not expose."""
+        message = self._velocity_refusal()
+        # A private name is a leading underscore with no word character before
+        # it; the public ``set_robot_state_keys`` contains ``_robot_state_keys``
+        # as a substring, so a bare substring test would flag the right message.
+        assert re.findall(r"(?<!\w)_\w+", message) == []
+        assert "self." not in message
+
+    @pytest.mark.parametrize(
+        ("remedy", "observation", "kwargs"),
+        [
+            ("dof_vel=[...] through get_actions kwargs", {"observation.state": POSE}, {"dof_vel": VELOCITY}),
+            ("per-joint", {f"{name}.vel": float(v) for name, v in zip(JOINT_NAMES, VELOCITY)}, {}),
+        ],
+    )
+    def test_every_remedy_it_names_resolves_the_velocities(self, remedy, observation, kwargs):
+        """A refusal may only name a route that works. Each is driven here."""
+        assert remedy.split("=")[0].split()[0] in self._velocity_refusal()
+        policy = _policy()
+        policy.set_robot_state_keys(list(JOINT_NAMES))
+        resolved = policy._extract_dof_vel(observation, kwargs)
+        assert np.allclose(resolved, VELOCITY)
+
+    def test_the_widened_state_remedy_resolves_both_passes(self):
+        """The third remedy: extend the array AND its key list together."""
+        assert "extend the state array" in self._velocity_refusal()
+        policy = _policy()
+        policy.set_robot_state_keys([*JOINT_NAMES, *(f"{name}.vel" for name in JOINT_NAMES)])
+        widened = np.concatenate([POSE, VELOCITY])
+        observation = {"observation.state": widened}
+        assert np.array_equal(policy._pack_by_name(observation, ""), POSE)
+        assert np.array_equal(policy._pack_by_name(observation, ".vel"), VELOCITY)
 
 
 class TestAnObservationNoConventionCanAnswer:


### PR DESCRIPTION
![state index addressing](https://raw.githubusercontent.com/cagataycali/robots/media-protomotions-state-index/protomotions_state_index.png)

## What
`set_robot_state_keys` built a joint-name -> `observation.state` offset map and cached it on the policy; nothing read it. The convention that needs it rescanned the key list with `list.index` for every joint, twice a tick. The read now goes through the map, and the map is rebuilt *with* the list -- one left over from a previous list would address a re-ordered feed at the old offsets, giving a fully-populated but permuted pose. First occurrence wins, as `list.index` answered.

## Why
The refusal for a key the array has no offset for named a private attribute and prescribed a call the caller had already made, successfully:

```
KeyError: ProtoMotionsPolicy: joint 'left_hip_pitch_joint.vel' missing from
self._robot_state_keys (call set_robot_state_keys).
```

A joint-name list addresses positions; the call validates that every joint the config names is present, so afterwards only a velocity can be missing and repeating it adds none. It now names the spelling and the three routes that do supply one.

## Tests
5 of 29 cells in `test_observation_state_reads_the_same_through_every_convention.py` fail on `main`. Each named route is driven, so the message cannot name one that does not work. 35.9 -> 15.7 us per tick (58-key list, both passes).