### PR TITLE
fix(device_connect): a failed bring-up releases the loop it ran on

### DIFF
--- a/changelog.d/3530-device-connect-failed-bringup-releases-its-loop.md
+++ b/changelog.d/3530-device-connect-failed-bringup-releases-its-loop.md
@@ -1,0 +1,20 @@
+### Fixed: a failed Device Connect bring-up releases the loop it ran on
+
+`init_device_connect_sync` starts `init_device_connect` on a daemon thread and
+parks that thread in `run_forever`, so the runtime it built can outlive the
+call. The loop and the thread reach the caller one way only: they are adopted
+onto the returned runtime. A bring-up that raised has no runtime, so both were
+unreachable - and the thread parked anyway, keeping an idle event loop, and the
+epoll and self-pipe descriptors it holds, alive for the life of the process,
+once per failed attempt. Six retries of an unreachable broker left six parked
+threads, six open loops and eighteen held descriptors, none of them reachable
+from the caller that was handed the failure.
+
+The bring-up thread now closes its own loop and returns when the bring-up
+failed - on the thread that owns the loop, where the close cannot race a runner
+- and the wrapper waits `_LOOP_JOIN_TIMEOUT_S` for it before raising, so the
+failure the caller receives also means the machinery is gone. A thread that
+outlasts that budget is logged and keeps its loop: closing a running loop
+raises, and reporting a release that did not happen is worse than one open
+loop. The expired-budget outcome is unchanged - that bring-up is still running,
+so there is nothing there to release.

--- a/strands_robots/device_connect/__init__.py
+++ b/strands_robots/device_connect/__init__.py
@@ -84,6 +84,19 @@ __all__ = [
 _INIT_TIMEOUT_S: float = 30.0
 
 
+# How long ``init_device_connect_sync`` waits for the bring-up thread to return
+# after a *failed* bring-up, before reporting that it did not. That thread owns
+# the loop it created and closes it on its way out, so the wait is what makes
+# the release observable to the caller that is about to be handed the failure.
+# A budget rather than an unbounded wait: the thread is only as free to return
+# as the coroutine it just ran, and a partially-built runtime whose teardown
+# blocks would otherwise hold a failed ``init_device_connect_sync`` open for as
+# long as that takes. Same family as ``mesh.input._INPUT_JOIN_TIMEOUT_S`` and
+# ``drivers.reachy._LOOP_JOIN_TIMEOUT_S``, and defined here for the same reason
+# as the budget above: it is a float literal that needs no extra to read.
+_LOOP_JOIN_TIMEOUT_S: float = 5.0
+
+
 # Map each name callers reach through the package to the module it lives in.
 # The public :data:`__all__` names are the documented API; the additional
 # private names below are module-level symbols ``_impl`` defines or re-exports

--- a/strands_robots/device_connect/_impl.py
+++ b/strands_robots/device_connect/_impl.py
@@ -278,6 +278,18 @@ def init_device_connect_sync(
     returns immediately - matching the Zenoh mesh ``init_mesh()`` pattern.
     The runtime stays alive as long as the process (daemon thread).
 
+    That outliving is the *successful* outcome, and it is the only one with
+    something to serve. A bring-up that raised built no runtime, so the loop and
+    the thread are unreachable from the caller: the pair is adopted onto the
+    runtime below, on the success path only. Parking that thread in
+    ``run_forever`` anyway left an idle loop -- and the epoll and self-pipe
+    descriptors it holds -- alive for the life of the process, once per failed
+    attempt, so a caller retrying an unreachable broker accumulated one parked
+    thread and three descriptors per try with no way to reach any of them. The
+    bring-up thread therefore closes its own loop and returns when the bring-up
+    failed, and this call waits :data:`~strands_robots.device_connect._LOOP_JOIN_TIMEOUT_S`
+    for it, so the failure the caller is handed also means the machinery is gone.
+
     Same parameters as :func:`init_device_connect`.
 
     Raises:
@@ -319,6 +331,17 @@ def init_device_connect_sync(
     def _run():
         asyncio.set_event_loop(loop)
         loop.run_until_complete(_start())
+        if error_holder[0] is not None:
+            # A failed bring-up has nothing to serve, and the caller never
+            # receives this loop (it is adopted onto the runtime below, which
+            # does not exist on this path). Release it here rather than
+            # cross-thread: this is the thread that owns the loop, so the close
+            # cannot race a runner, and there is no window in which a stop
+            # scheduled from outside is consumed by the ``run_until_complete``
+            # above and leaves ``run_forever`` running with no one left to stop
+            # it. Returning also retires the thread.
+            loop.close()
+            return
         loop.run_forever()
 
     thread = threading.Thread(target=_run, daemon=True, name="device-connect-runtime")
@@ -338,6 +361,20 @@ def init_device_connect_sync(
     # paths, so a bring-up that failed inside the budget arrives with ``started``
     # true and its own exception, which names the cause better than the budget.
     if error_holder[0] is not None:
+        # ``_run`` closes the loop and returns on this path; wait for it so the
+        # exception below is handed over an already-released loop rather than
+        # one closing behind the caller's back. A thread that outlasts the
+        # budget is reported rather than raised over: the caller's failure is
+        # the bring-up's own exception, which names the cause better than a
+        # slow release, and hiding it behind this one would lose it.
+        thread.join(timeout=_pkg._LOOP_JOIN_TIMEOUT_S)
+        if thread.is_alive():
+            logger.warning(
+                "init_device_connect_sync: the bring-up thread did not return within "
+                "%.1fs of a failed bring-up, so the loop it ran on is still open; "
+                "a callback from the partial bring-up is still running on it.",
+                _pkg._LOOP_JOIN_TIMEOUT_S,
+            )
         raise error_holder[0]
     if not started:
         raise TimeoutError(

--- a/tests/test_device_connect_sync_bringup_outcomes.py
+++ b/tests/test_device_connect_sync_bringup_outcomes.py
@@ -12,6 +12,12 @@ The two failure outcomes cross a thread boundary, which is why they are pinned
 here: the recorded exception is re-raised on the caller's thread, and an expired
 budget raises rather than handing back the ``None`` the holder still contains.
 
+A failed bring-up also has machinery to give back. The loop and the thread are
+handed to the caller by being adopted onto the returned runtime, so on a failure
+there is nothing to adopt them and nothing to serve on them either -- which is
+why the release is graded here alongside the exception, rather than left to a
+caller that has no handle to release.
+
 Nothing here needs a broker, a Docker stack or the Kit runtime: the awaited half
 is substituted, and the wrapper's budget is a module attribute so the expiry
 arm resolves in milliseconds instead of the shipped 30 seconds.
@@ -24,6 +30,7 @@ import asyncio
 import importlib
 import logging
 import pathlib
+import threading
 import types
 from typing import Any
 
@@ -55,6 +62,26 @@ async def _completes(*_a: Any, **_k: Any) -> Any:
 async def _fails(*_a: Any, **_k: Any) -> Any:
     """A bring-up that fails the way an unreachable broker does."""
     raise RuntimeError("no broker at tcp://127.0.0.1:7447")
+
+
+def _failing_on(loop_holder: list[Any]) -> Any:
+    """A failing bring-up that first records the loop it is running on.
+
+    The wrapper creates that loop itself and only hands it to the caller by
+    adopting it onto the returned runtime, so on the failure path the coroutine
+    is the one place it is observable at all.
+    """
+
+    async def _bring_up(*_a: Any, **_k: Any) -> Any:
+        loop_holder.append(asyncio.get_running_loop())
+        raise RuntimeError("no broker at tcp://127.0.0.1:7447")
+
+    return _bring_up
+
+
+def _runtime_threads() -> list[Any]:
+    """The wrapper's bring-up threads that are still alive."""
+    return [t for t in threading.enumerate() if t.name == "device-connect-runtime"]
 
 
 async def _never_finishes(*_a: Any, **_k: Any) -> Any:
@@ -266,3 +293,93 @@ class TestTheBudgetIsReadFromTheModuleRatherThanAnInlineLiteral:
         module = _dc()
 
         assert module.init_device_connect_sync.__annotations__["return"] == "DeviceRuntime"
+
+
+class TestAFailedBringUpReleasesTheLoopItRanOn:
+    """The machinery a failure leaves behind.
+
+    The loop and the thread reach the caller one way only: they are adopted onto
+    the runtime the wrapper returns. A bring-up that raised has no runtime, so
+    the pair is unreachable -- and parking the thread in ``run_forever`` anyway
+    kept an idle loop, with the epoll and self-pipe descriptors it holds, alive
+    for the life of the process. Once per failed attempt: a caller retrying an
+    unreachable broker accumulated a parked thread and three descriptors per try
+    with no way to reach any of them.
+
+    The thread that owns the loop closes it and returns instead, and the wrapper
+    waits for that before raising, so the failure the caller is handed also
+    means the machinery is gone.
+    """
+
+    def test_a_failed_bring_up_closes_the_loop_it_ran_on(self, monkeypatch):
+        """No runtime adopted the loop, so nothing else can ever close it."""
+        loops: list[Any] = []
+
+        with pytest.raises(RuntimeError):
+            _sync(monkeypatch, _failing_on(loops), budget=30.0)
+
+        assert len(loops) == 1, loops
+        assert loops[0].is_closed()
+
+    def test_a_failed_bring_up_leaves_no_thread_parked_on_that_loop(self, monkeypatch):
+        """The thread is retired with the loop: it was started to serve a
+        runtime that does not exist, and the caller has no handle to stop it."""
+        before = _runtime_threads()
+
+        with pytest.raises(RuntimeError):
+            _sync(monkeypatch, _fails, budget=30.0)
+
+        assert _runtime_threads() == before
+
+    def test_a_retried_bring_up_does_not_accumulate_loops(self, monkeypatch):
+        """The shape a caller actually hits: an unreachable broker is retried,
+        and each attempt has to release its own loop rather than add one."""
+        loops: list[Any] = []
+        before = _runtime_threads()
+
+        for _ in range(3):
+            with pytest.raises(RuntimeError):
+                _sync(monkeypatch, _failing_on(loops), budget=30.0)
+
+        assert len(loops) == 3, loops
+        assert [loop.is_closed() for loop in loops] == [True, True, True]
+        assert _runtime_threads() == before
+
+    def test_a_release_that_outlasts_its_budget_is_reported(self, monkeypatch, caplog):
+        """A thread still running the loop cannot have it closed under it, so
+        that outcome is logged rather than silently taken for a release.
+
+        The double is a thread that has not returned: it ignores the join budget
+        and reports itself alive, which is what a bring-up whose partial teardown
+        is still on the loop looks like to this code.
+        """
+
+        class _NeverReturns(threading.Thread):
+            def join(self, timeout: float | None = None) -> None:
+                del timeout  # a thread that never returns outlasts any budget
+                self.was_joined = True
+
+            def is_alive(self) -> bool:
+                return True
+
+        monkeypatch.setattr(threading, "Thread", _NeverReturns)
+        monkeypatch.setattr(_dc(), "_LOOP_JOIN_TIMEOUT_S", 0.05)
+
+        with caplog.at_level(logging.WARNING, logger="strands_robots.device_connect._impl"):
+            with pytest.raises(RuntimeError) as excinfo:
+                _sync(monkeypatch, _fails, budget=30.0)
+
+        assert "no broker" in str(excinfo.value)
+        warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+        assert warnings, caplog.records
+        assert "did not return within 0.1s" in warnings[0]
+        assert "still open" in warnings[0]
+
+    def test_the_release_budget_reads_without_the_device_connect_extra(self):
+        """It is a float on the package, next to the bring-up budget, so a
+        caller (or this file) can read and substitute it without the extra."""
+        module = _dc()
+
+        budget = module._LOOP_JOIN_TIMEOUT_S
+        assert isinstance(budget, float)
+        assert 0.0 < budget < float("inf")


### PR DESCRIPTION
![failed bring-up census](https://raw.githubusercontent.com/cagataycali/robots/assets/failed-bringup-release/failed-bringup-release.png)

**What** `init_device_connect_sync` parks its bring-up thread in `run_forever` so the runtime can outlive the call. That loop and thread reach the caller only by being adopted onto the returned runtime, so a bring-up that *raised* left both unreachable and parked anyway.

**Why** Six retries of an unreachable broker measured six parked threads, six open loops and 18 held descriptors, none reachable. The thread now closes its own loop and returns on the failure path, and the wrapper waits `_LOOP_JOIN_TIMEOUT_S` for it before raising; a thread that outlasts the budget is logged and keeps its loop (closing a running loop raises). The expired-budget path is unchanged.

**Tests** 5 cells appended to `tests/test_device_connect_sync_bringup_outcomes.py`, all 5 failing pre-fix: loop closed, no thread left, three retries accumulate nothing, an outlasted budget is reported, budget readable without the extra.

LOC delta: +50 source / +117 tests / +21 changelog, -0.