### PR TITLE
fix(device_connect): a bring-up with no runtime is reported, not handed back

### DIFF
--- a/changelog.d/3531-device-connect-sync-no-runtime-route.md
+++ b/changelog.d/3531-device-connect-sync-no-runtime-route.md
@@ -1,0 +1,18 @@
+### Fixed: a Device Connect bring-up that returns no runtime is reported, not handed back
+
+`init_device_connect_sync` promises a `DeviceRuntime`, and released the loop it
+created when the bring-up *raised* (#3530). A bring-up that finished without
+returning a runtime left the same empty holder, but took neither path: the
+wrapper returned `None` against its own annotation, and the bring-up thread
+parked in `run_forever` on a loop nothing would ever serve on and nothing could
+reach, since the loop and thread are handed to the caller only by being adopted
+onto the returned runtime. Measured, six such attempts left six parked threads,
+six open loops and eighteen descriptors, exactly the leak the raising route no
+longer has.
+
+An empty holder is now a failed bring-up however it came to be empty: the
+release gate on the bring-up thread asks whether a runtime came up rather than
+whether an exception was recorded, and the wrapper raises `RuntimeError` naming
+the missing runtime. That also restores the operator's status line - the
+foreground runner reports a missing runtime as "see the warning above", and on
+this route nothing had logged one.

--- a/strands_robots/device_connect/_impl.py
+++ b/strands_robots/device_connect/_impl.py
@@ -279,16 +279,18 @@ def init_device_connect_sync(
     The runtime stays alive as long as the process (daemon thread).
 
     That outliving is the *successful* outcome, and it is the only one with
-    something to serve. A bring-up that raised built no runtime, so the loop and
-    the thread are unreachable from the caller: the pair is adopted onto the
-    runtime below, on the success path only. Parking that thread in
+    something to serve. A bring-up that produced no runtime -- because it raised,
+    or because it finished without returning one -- left the loop and the thread
+    unreachable from the caller: the pair is adopted onto the runtime below, on
+    the success path only. Parking that thread in
     ``run_forever`` anyway left an idle loop -- and the epoll and self-pipe
     descriptors it holds -- alive for the life of the process, once per failed
     attempt, so a caller retrying an unreachable broker accumulated one parked
     thread and three descriptors per try with no way to reach any of them. The
-    bring-up thread therefore closes its own loop and returns when the bring-up
-    failed, and this call waits :data:`~strands_robots.device_connect._LOOP_JOIN_TIMEOUT_S`
-    for it, so the failure the caller is handed also means the machinery is gone.
+    bring-up thread therefore closes its own loop and returns whenever the
+    holder is empty, and this call waits
+    :data:`~strands_robots.device_connect._LOOP_JOIN_TIMEOUT_S` for it, so the
+    failure the caller is handed also means the machinery is gone.
 
     Same parameters as :func:`init_device_connect`.
 
@@ -299,6 +301,9 @@ def init_device_connect_sync(
         TimeoutError: If the bring-up does not finish within the wrapper's
             budget. The runtime is not returned in that case, so the caller
             is never handed ``None`` in place of a ``DeviceRuntime``.
+        RuntimeError: If the bring-up finished without returning a runtime.
+            Nothing came up, so this is a failed bring-up like any other, and
+            it is reported as one rather than returned as an empty success.
     """
     loop = asyncio.new_event_loop()
     ready = threading.Event()
@@ -331,12 +336,15 @@ def init_device_connect_sync(
     def _run():
         asyncio.set_event_loop(loop)
         loop.run_until_complete(_start())
-        if error_holder[0] is not None:
-            # A failed bring-up has nothing to serve, and the caller never
-            # receives this loop (it is adopted onto the runtime below, which
-            # does not exist on this path). Release it here rather than
-            # cross-thread: this is the thread that owns the loop, so the close
-            # cannot race a runner, and there is no window in which a stop
+        if runtime_holder[0] is None:
+            # No runtime came up, so nothing will ever be served on this loop,
+            # and the caller never receives it either (it is adopted onto the
+            # runtime below, which does not exist on this path). The gate is the
+            # holder rather than the recorded exception because a bring-up can
+            # leave the holder empty without raising, and that route has exactly
+            # as little to serve as the one that raised. Release it here rather
+            # than cross-thread: this is the thread that owns the loop, so the
+            # close cannot race a runner, and there is no window in which a stop
             # scheduled from outside is consumed by the ``run_until_complete``
             # above and leaves ``run_forever`` running with no one left to stop
             # it. Returning also retires the thread.
@@ -357,24 +365,30 @@ def init_device_connect_sync(
     _timeout = _pkg._INIT_TIMEOUT_S
     started = ready.wait(timeout=_timeout)
 
-    # The recorded failure first: ``_start``'s ``finally`` sets the event on both
-    # paths, so a bring-up that failed inside the budget arrives with ``started``
-    # true and its own exception, which names the cause better than the budget.
-    if error_holder[0] is not None:
-        # ``_run`` closes the loop and returns on this path; wait for it so the
-        # exception below is handed over an already-released loop rather than
-        # one closing behind the caller's back. A thread that outlasts the
-        # budget is reported rather than raised over: the caller's failure is
-        # the bring-up's own exception, which names the cause better than a
-        # slow release, and hiding it behind this one would lose it.
+    def _await_release() -> None:
+        """Wait for the bring-up thread to release the loop it owns.
+
+        ``_run`` closes the loop and returns whenever no runtime came up, so
+        waiting here means the failure the caller is handed is over an
+        already-released loop rather than one closing behind its back. A thread
+        that outlasts the budget is reported rather than raised over: the
+        caller's failure names the cause better than a slow release, and hiding
+        it behind this one would lose it.
+        """
         thread.join(timeout=_pkg._LOOP_JOIN_TIMEOUT_S)
         if thread.is_alive():
             logger.warning(
                 "init_device_connect_sync: the bring-up thread did not return within "
-                "%.1fs of a failed bring-up, so the loop it ran on is still open; "
-                "a callback from the partial bring-up is still running on it.",
+                "%.1fs of a bring-up that produced no runtime, so the loop it ran on is "
+                "still open; a callback from the partial bring-up is still running on it.",
                 _pkg._LOOP_JOIN_TIMEOUT_S,
             )
+
+    # The recorded failure first: ``_start``'s ``finally`` sets the event on both
+    # paths, so a bring-up that failed inside the budget arrives with ``started``
+    # true and its own exception, which names the cause better than the budget.
+    if error_holder[0] is not None:
+        _await_release()
         raise error_holder[0]
     if not started:
         raise TimeoutError(
@@ -384,9 +398,21 @@ def init_device_connect_sync(
         )
 
     runtime = runtime_holder[0]
-    if runtime is not None:
-        runtime._loop = loop
-        runtime._thread = thread
+    if runtime is None:
+        # A bring-up that finished without building a runtime is a failed
+        # bring-up: this call promises a ``DeviceRuntime``, and handing back the
+        # empty holder instead is the one outcome a caller cannot act on -- the
+        # foreground runner's status line reports "see the warning above" for a
+        # missing runtime, and on this route nothing logged one.
+        _await_release()
+        raise RuntimeError(
+            "init_device_connect_sync: the Device Connect bring-up finished without "
+            "returning a runtime, so there is nothing to serve. init_device_connect "
+            "returns the runtime it started; a substitute standing in for it must do "
+            "the same."
+        )
+    runtime._loop = loop
+    runtime._thread = thread
     return runtime
 
 

--- a/tests/test_device_connect_sync_bringup_outcomes.py
+++ b/tests/test_device_connect_sync_bringup_outcomes.py
@@ -10,13 +10,17 @@ printing an "is online" line for a runtime that never came up.
 
 The two failure outcomes cross a thread boundary, which is why they are pinned
 here: the recorded exception is re-raised on the caller's thread, and an expired
-budget raises rather than handing back the ``None`` the holder still contains.
+budget raises rather than handing back the ``None`` the holder still contains. A
+bring-up that finishes without returning a runtime leaves that same empty holder,
+so it is reported the same way -- an empty holder is a failed bring-up however it
+came to be empty, and returning it would be the one outcome a caller cannot act
+on, indistinguishable from a runtime that came up.
 
-A failed bring-up also has machinery to give back. The loop and the thread are
-handed to the caller by being adopted onto the returned runtime, so on a failure
-there is nothing to adopt them and nothing to serve on them either -- which is
-why the release is graded here alongside the exception, rather than left to a
-caller that has no handle to release.
+A bring-up that produced no runtime also has machinery to give back. The loop and
+the thread are handed to the caller by being adopted onto the returned runtime, so
+with no runtime there is nothing to adopt them and nothing to serve on them either
+-- which is why the release is graded here alongside the exception, rather than
+left to a caller that has no handle to release.
 
 Nothing here needs a broker, a Docker stack or the Kit runtime: the awaited half
 is substituted, and the wrapper's budget is a module attribute so the expiry
@@ -64,17 +68,30 @@ async def _fails(*_a: Any, **_k: Any) -> Any:
     raise RuntimeError("no broker at tcp://127.0.0.1:7447")
 
 
-def _failing_on(loop_holder: list[Any]) -> Any:
-    """A failing bring-up that first records the loop it is running on.
+#: The two ways a bring-up produces no runtime. Both leave the wrapper's holder
+#: empty, so both owe the caller a raise and owe the loop a release.
+_NO_RUNTIME = ["raises", "returns nothing"]
+
+
+def _without_a_runtime_on(kind: str, loop_holder: list[Any]) -> Any:
+    """A bring-up producing no runtime, recording the loop it is running on.
 
     The wrapper creates that loop itself and only hands it to the caller by
-    adopting it onto the returned runtime, so on the failure path the coroutine
-    is the one place it is observable at all.
+    adopting it onto the returned runtime, so with no runtime the coroutine is
+    the one place the loop is observable at all.
+
+    Args:
+        kind: ``"raises"`` for the way an unreachable broker fails,
+            ``"returns nothing"`` for a bring-up that finishes and hands back
+            no runtime.
+        loop_holder: Receives the loop the bring-up ran on.
     """
 
     async def _bring_up(*_a: Any, **_k: Any) -> Any:
         loop_holder.append(asyncio.get_running_loop())
-        raise RuntimeError("no broker at tcp://127.0.0.1:7447")
+        if kind == "raises":
+            raise RuntimeError("no broker at tcp://127.0.0.1:7447")
+        return None
 
     return _bring_up
 
@@ -151,6 +168,28 @@ class TestEveryBringUpOutcomeReachesTheCaller:
         assert "still running" in message
         assert "broker" in message
 
+    def test_a_bring_up_that_returns_no_runtime_is_reported_as_a_failure(self, monkeypatch):
+        """Nothing came up, so this is a failed bring-up like any other. Handing
+        back the empty holder instead would return ``None`` where the annotation
+        promises a runtime, and read to every caller as a bring-up that worked.
+
+        The refusal names the empty holder and the contract it broke, because
+        this outcome logs nothing else: the foreground runner's status line sends
+        the operator to "the warning above", and on this route the raise is what
+        puts one there.
+        """
+
+        async def _no_runtime(*_a: Any, **_k: Any) -> Any:
+            return None
+
+        with pytest.raises(RuntimeError) as excinfo:
+            _sync(monkeypatch, _no_runtime, budget=30.0)
+
+        message = str(excinfo.value)
+        assert "init_device_connect_sync" in message
+        assert "without returning a runtime" in message
+        assert "nothing to serve" in message
+
     def test_a_failure_inside_the_budget_reports_its_cause_not_the_budget(self, monkeypatch):
         """Guard order: the recorded exception is checked first, so a bring-up
         that failed quickly is never reported as a slow one."""
@@ -202,6 +241,21 @@ class TestTheForegroundRunnerReportsAFailedBringUp:
         failures = [r for r in records if "Device Connect init failed" in r]
         assert failures, records
         assert "did not come up" in failures[0]
+
+    def test_a_bring_up_that_returned_no_runtime_is_reported_to_the_operator(self, monkeypatch):
+        """The status line for a missing runtime sends the operator to "the
+        warning above". Returning the empty holder logged nothing at all, so the
+        line pointed at a warning that was never written; the raise is what puts
+        one there."""
+
+        async def _no_runtime(*_a: Any, **_k: Any) -> Any:
+            return None
+
+        records = self._foreground(monkeypatch, _no_runtime, budget=30.0)
+
+        failures = [r for r in records if "Device Connect init failed" in r]
+        assert failures, records
+        assert "without returning a runtime" in failures[0]
 
     def test_a_failed_bring_up_is_still_reported_to_the_operator(self, monkeypatch):
         """The unchanged half: an exception already reached this warning."""
@@ -295,51 +349,57 @@ class TestTheBudgetIsReadFromTheModuleRatherThanAnInlineLiteral:
         assert module.init_device_connect_sync.__annotations__["return"] == "DeviceRuntime"
 
 
-class TestAFailedBringUpReleasesTheLoopItRanOn:
-    """The machinery a failure leaves behind.
+class TestABringUpWithNoRuntimeReleasesTheLoopItRanOn:
+    """The machinery a bring-up with nothing to serve leaves behind.
 
     The loop and the thread reach the caller one way only: they are adopted onto
-    the runtime the wrapper returns. A bring-up that raised has no runtime, so
-    the pair is unreachable -- and parking the thread in ``run_forever`` anyway
-    kept an idle loop, with the epoll and self-pipe descriptors it holds, alive
-    for the life of the process. Once per failed attempt: a caller retrying an
-    unreachable broker accumulated a parked thread and three descriptors per try
-    with no way to reach any of them.
+    the runtime the wrapper returns. A bring-up that produced no runtime -- by
+    raising, or by finishing and returning none -- leaves the pair unreachable,
+    and parking the thread in ``run_forever`` anyway kept an idle loop, with the
+    epoll and self-pipe descriptors it holds, alive for the life of the process.
+    Once per attempt: a caller retrying an unreachable broker accumulated a
+    parked thread and three descriptors per try with no way to reach any of them.
 
-    The thread that owns the loop closes it and returns instead, and the wrapper
-    waits for that before raising, so the failure the caller is handed also
-    means the machinery is gone.
+    The thread that owns the loop closes it and returns instead, gated on the
+    empty holder rather than on the recorded exception, so neither route can be
+    released while the other is not. The wrapper waits for that before raising,
+    so the failure the caller is handed also means the machinery is gone.
     """
 
-    def test_a_failed_bring_up_closes_the_loop_it_ran_on(self, monkeypatch):
+    @pytest.mark.parametrize("kind", _NO_RUNTIME)
+    def test_a_bring_up_with_no_runtime_closes_the_loop_it_ran_on(self, monkeypatch, kind):
         """No runtime adopted the loop, so nothing else can ever close it."""
         loops: list[Any] = []
 
         with pytest.raises(RuntimeError):
-            _sync(monkeypatch, _failing_on(loops), budget=30.0)
+            _sync(monkeypatch, _without_a_runtime_on(kind, loops), budget=30.0)
 
         assert len(loops) == 1, loops
         assert loops[0].is_closed()
 
-    def test_a_failed_bring_up_leaves_no_thread_parked_on_that_loop(self, monkeypatch):
+    @pytest.mark.parametrize("kind", _NO_RUNTIME)
+    def test_a_bring_up_with_no_runtime_leaves_no_thread_parked_on_that_loop(self, monkeypatch, kind):
         """The thread is retired with the loop: it was started to serve a
         runtime that does not exist, and the caller has no handle to stop it."""
+        loops: list[Any] = []
         before = _runtime_threads()
 
         with pytest.raises(RuntimeError):
-            _sync(monkeypatch, _fails, budget=30.0)
+            _sync(monkeypatch, _without_a_runtime_on(kind, loops), budget=30.0)
 
         assert _runtime_threads() == before
 
-    def test_a_retried_bring_up_does_not_accumulate_loops(self, monkeypatch):
-        """The shape a caller actually hits: an unreachable broker is retried,
-        and each attempt has to release its own loop rather than add one."""
+    @pytest.mark.parametrize("kind", _NO_RUNTIME)
+    def test_a_retried_bring_up_does_not_accumulate_loops(self, monkeypatch, kind):
+        """The shape a caller actually hits: a bring-up that cannot come up is
+        retried, and each attempt has to release its own loop rather than add
+        one."""
         loops: list[Any] = []
         before = _runtime_threads()
 
         for _ in range(3):
             with pytest.raises(RuntimeError):
-                _sync(monkeypatch, _failing_on(loops), budget=30.0)
+                _sync(monkeypatch, _without_a_runtime_on(kind, loops), budget=30.0)
 
         assert len(loops) == 3, loops
         assert [loop.is_closed() for loop in loops] == [True, True, True]


### PR DESCRIPTION
![measured before/after](https://raw.githubusercontent.com/cagataycali/robots/assets/device-connect-no-runtime-route/no-runtime-route.png)

**What** `init_device_connect_sync` returned `None` — against its `-> DeviceRuntime` annotation — when the bring-up built no runtime, parking its thread in `run_forever` on a loop nothing would serve. Closes #3531.

**Why** The loop and thread reach the caller only by adoption onto the returned runtime, so that route left both unreachable: six attempts held six parked threads, six open loops and eighteen descriptors, the leak the raising route no longer has (#3530). It also pointed the foreground runner's "see the warning above" at a warning nothing wrote. The gate now asks whether a runtime came up, not whether an exception was recorded.

**Tests** Five new cells fail on `20a7ea495` (5F/17P), pass after (22P). Full suite 51,546 passed; ruff + mypy clean. +163/-59.