### PR TITLE
fix(tools): a camera capture's inline image keeps the frame's pixels

### DIFF
--- a/changelog.d/3533-camera-inline-image-keeps-the-captured-pixels.md
+++ b/changelog.d/3533-camera-inline-image-keeps-the-captured-pixels.md
@@ -1,0 +1,18 @@
+### Fixed: `lerobot_camera` returns the captured frame's own pixels
+
+A `capture` / `capture_batch` result carries the saved file *and* an inline copy
+of the frame for the model to look at. The inline copy was encoded as JPEG for
+every `format` the encoder's branch did not name - so a caller who chose a
+lossless container got a lossy image back, silently, under `status="success"`.
+
+Measured against a captured 8x6 frame, `format="bmp"` - one of the three the
+tool's own docstring lists - wrote a real BMP to disk and handed back a JPEG
+whose pixels differed from the frame by up to 213 of 255. `format="tiff"`,
+`"webp"` and `"gif"` reached the same fallback: OpenCV wrote each container
+faithfully, and the half of the result an agent actually reads was the half that
+discarded the frame.
+
+JPEG is now the answer to a JPEG request and to nothing else; every other
+spelling is carried back as PNG, which is lossless and which the Converse API
+accepts. `format="jpg"` and `format="png"` are unchanged, and no request that
+worked before is refused - the file on disk is written exactly as it was.

--- a/strands_robots/tools/lerobot_camera.py
+++ b/strands_robots/tools/lerobot_camera.py
@@ -84,8 +84,42 @@ REALSENSE_SDK_ABSENT = (
 logger = logging.getLogger(__name__)
 
 
+#: The ``format`` spellings whose inline copy is encoded as JPEG. Every other
+#: spelling gets PNG - see :func:`_frame_to_image_content` for why the set is
+#: this way round rather than a default.
+_INLINE_JPEG_FORMATS: frozenset[str] = frozenset({"jpg", "jpeg"})
+
+
 def _frame_to_image_content(frame: np.ndarray, format: str = "jpg") -> dict[str, Any]:
-    """Convert a numpy frame to image content format for Converse API."""
+    """Encode *frame* as Converse-API image content, keeping its pixels.
+
+    The Converse API carries a fixed set of encodings, so a capture saved in a
+    container it does not accept still has to be re-encoded for the inline copy.
+    The only thing that decision can cost is pixels, so JPEG is used when - and
+    only when - a JPEG was asked for; every other spelling is carried as PNG,
+    which is lossless and which the API accepts.
+
+    Reading it the other way round, as a default, made the lossy codec the
+    answer to every spelling the branch did not name. Measured on ``20a7ea49``
+    against a captured 8x6 frame, ``format="bmp"`` - one of the three the tool's
+    own docstring lists - wrote a real BMP to disk and handed back a JPEG whose
+    pixels differ from the frame by up to 213 of 255, under ``status="success"``
+    and an "Image Capture Success!" summary that says nothing about it. A caller
+    selects a lossless container precisely so that the frame survives, and the
+    half of the result a model actually looks at was the half that discarded it.
+    ``format="tiff"``, ``"webp"`` and ``"gif"`` reached the same fallback.
+
+    ``format="jpg"`` and ``format="png"`` are unchanged, which is every spelling
+    the fallback was not answering.
+
+    Args:
+        frame: The captured frame, RGB (or any shape OpenCV can encode as-is).
+        format: The caller's requested image format, compared case-insensitively.
+
+    Returns:
+        Converse image content, or text content naming the failure when the
+        frame cannot be encoded at all.
+    """
     try:
         # Convert RGB to BGR for OpenCV encoding
         if len(frame.shape) == 3 and frame.shape[2] == 3:
@@ -93,16 +127,12 @@ def _frame_to_image_content(frame: np.ndarray, format: str = "jpg") -> dict[str,
         else:
             bgr_frame = frame
 
-        # Encode frame to specified format
-        if format.lower() in ["jpg", "jpeg"]:
+        if format.lower() in _INLINE_JPEG_FORMATS:
             success, encoded_img = cv2.imencode(".jpg", bgr_frame)
             image_format = "jpeg"
-        elif format.lower() == "png":
+        else:
             success, encoded_img = cv2.imencode(".png", bgr_frame)
             image_format = "png"
-        else:
-            success, encoded_img = cv2.imencode(".jpg", bgr_frame)  # Default to JPEG
-            image_format = "jpeg"
 
         if not success:
             raise ValueError("Failed to encode frame")
@@ -537,7 +567,10 @@ def lerobot_camera(
             refused rather than silently read as "NO_ROTATION".
         format: Image format ("jpg", "png", "bmp"). Becomes the saved file's
             extension, so like filename it is resolved inside save_path and
-            refused if it names a location outside it.
+            refused if it names a location outside it. The image returned
+            alongside the file is encoded as JPEG only for a JPEG request; any
+            other format is carried back losslessly as PNG, so the inline copy
+            has the frame's own pixels.
         capture_duration: Duration for video recording (positive seconds)
         preview_duration: Duration for preview display (positive seconds)
         async_mode: Use async reading for better performance. A boolean; it

--- a/tests/tools/test_lerobot_camera.py
+++ b/tests/tools/test_lerobot_camera.py
@@ -92,16 +92,62 @@ def test_actions_requiring_camera_id_error_without_it(action: str) -> None:
 # --- _frame_to_image_content (pure helper) --------------------------------
 
 
-@pytest.mark.parametrize(
-    "fmt,expected",
-    [("jpg", "jpeg"), ("jpeg", "jpeg"), ("png", "png"), ("bmp", "jpeg")],
-)
+# The inline copy's encoding, per requested format. JPEG is the answer to a JPEG
+# request and to nothing else: every other spelling names a container the caller
+# chose to keep the frame in, and the encoding used to be a lossy default for all
+# of them - ``"bmp"`` is one of the three the tool's docstring lists. ``"PNG"``
+# covers the case-insensitive comparison, ``"tiff"``/``"webp"``/``"gif"`` the
+# spellings OpenCV writes to disk but the Converse API cannot carry.
+INLINE_ENCODINGS = [
+    ("jpg", "jpeg"),
+    ("jpeg", "jpeg"),
+    ("JPG", "jpeg"),
+    ("png", "png"),
+    ("PNG", "png"),
+    ("bmp", "png"),
+    ("tiff", "png"),
+    ("webp", "png"),
+    ("gif", "png"),
+]
+
+
+@pytest.mark.parametrize("fmt,expected", INLINE_ENCODINGS)
 def test_frame_to_image_content_formats(fmt: str, expected: str) -> None:
     frame = np.zeros((4, 4, 3), dtype=np.uint8)
     content = cam_mod._frame_to_image_content(frame, fmt)
     assert content["image"]["format"] == expected
     assert isinstance(content["image"]["source"]["bytes"], bytes)
     assert content["image"]["source"]["bytes"]
+
+
+@pytest.mark.parametrize("fmt,expected", INLINE_ENCODINGS)
+def test_only_a_jpeg_request_is_answered_with_lossy_pixels(fmt: str, expected: str) -> None:
+    """The bytes handed back must be the frame's own pixels unless JPEG was asked for.
+
+    The declared format above says what the copy claims to be; this says what it
+    carries. A frame with a gradient and one odd pixel is the discriminator: PNG
+    round-trips it exactly, and JPEG's block transform does not, so the assertion
+    is on the decoded pixels rather than on the codec's name.
+    """
+    frame = np.zeros((8, 8, 3), dtype=np.uint8)
+    frame[:, :4] = (255, 0, 0)
+    frame[:, 4:] = (0, 0, 255)
+    frame[0, 0] = (17, 200, 99)
+
+    content = cam_mod._frame_to_image_content(frame, fmt)
+    decoded = cam_mod.cv2.imdecode(
+        np.frombuffer(content["image"]["source"]["bytes"], dtype=np.uint8), cam_mod.cv2.IMREAD_COLOR
+    )
+    assert decoded is not None, f"format={fmt!r} produced bytes no decoder accepts"
+    round_tripped = cam_mod.cv2.cvtColor(decoded, cam_mod.cv2.COLOR_BGR2RGB)
+
+    if expected == "jpeg":
+        assert not np.array_equal(round_tripped, frame), "a JPEG request is the one lossy answer"
+    else:
+        assert np.array_equal(round_tripped, frame), (
+            f"format={fmt!r} lost pixels: max difference "
+            f"{int(np.abs(round_tripped.astype(int) - frame.astype(int)).max())} of 255"
+        )
 
 
 def test_frame_to_image_content_handles_encode_failure(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -497,14 +543,6 @@ def test_create_camera_realsense_uses_real_config_dataclass_field() -> None:
 
 
 # --- frame encoding failure -------------------------------------------------
-
-
-def test_frame_to_image_content_unknown_format_defaults_to_jpeg() -> None:
-    """An unrecognised format string falls back to JPEG encoding rather than
-    erroring."""
-    frame = np.zeros((4, 4, 3), dtype=np.uint8)
-    content = cam_mod._frame_to_image_content(frame, "tiff")
-    assert content["image"]["format"] == "jpeg"
 
 
 def test_create_camera_opencv_maps_color_mode_and_rotation(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/tools/test_lerobot_camera_vocabulary_options.py
+++ b/tests/tools/test_lerobot_camera_vocabulary_options.py
@@ -272,6 +272,12 @@ class TestOnlyTheOptionsAnActionReadsAreValidated:
         replaced - it becomes the saved file's extension and OpenCV writes it if it
         can - so narrowing it to the three names the docstring lists would refuse
         working requests. Its failure mode is loud, not silent.
+
+        The inline copy is the other half of that result and is not a vocabulary
+        question: the Converse API carries a fixed set of encodings, so a format
+        it cannot carry is re-encoded rather than refused. What that re-encode may
+        not do is discard pixels - see
+        ``test_only_a_jpeg_request_is_answered_with_lossy_pixels``.
         """
         result = _call(action="capture", camera_id=0, save_path=str(tmp_path), format="tiff")
 


### PR DESCRIPTION
![inline copy fidelity](https://raw.githubusercontent.com/cagataycali/robots/assets/camera-inline-image-pixels/inline_image_pixels.png)

**What** A `lerobot_camera` capture result carries the saved file *and* an inline copy of the frame for the model to look at. That copy was encoded as JPEG for every `format` the encoder's branch did not name.

**Why** `format="bmp"` - one of the three the tool documents - wrote a real BMP to disk and returned a JPEG that altered 76,159 of 76,800 pixels by up to 131 of 255, under `status="success"`. `tiff`, `webp` and `gif` reached the same fallback. JPEG now answers a JPEG request and nothing else; every other spelling is carried as PNG, which is lossless and which the Converse API accepts. `jpg` and `png` are byte-identical, and the file on disk is unchanged, so nothing that worked before is refused.

**Tests** 18 table-driven cells over declared encoding and decoded pixels; 8 fail pre-fix. Full suite 51,554 passed / 316 skipped / 0 failed, coverage 96.05%; ruff and mypy clean. +115/-20 across 4 files - the encoder itself loses a branch.