### PR TITLE
fix(drivers/crazyflie): an action naming a key no setpoint carries is refused

### DIFF
--- a/changelog.d/0000-crazyflie-action-refuses-a-dropped-flight-key.md
+++ b/changelog.d/0000-crazyflie-action-refuses-a-dropped-flight-key.md
@@ -1,0 +1,25 @@
+### Fixed: a Crazyflie action naming a key no setpoint carries is refused, not flown without it
+
+`action_to_setpoint` reads every flight component with a zero default, so a key
+the driver does not command was dropped before any check saw it and the
+component it named rested at zero. The gate above it - refusing an action that
+names *none* of `ACTION_KEYS` - exists because an all-zero setpoint "would latch
+the aircraft into a hover the caller never asked for and report success for it",
+and that outcome was reachable straight through the gate, since one known key
+satisfies it:
+
+    action_to_setpoint({"vx": 0.0, "height": 1.5})
+    -> ("send_velocity_world_setpoint", (0.0, 0.0, 0.0, 0.0))
+
+`height` is this module's own internal spelling of the hover key `z`, so the
+request most likely to be spelled that way is the one that reaches the resting
+setpoint. `{"vx": 0.5, "vyaw": 2.0}` translated without the yaw, and
+`{"z": 1.0, "vX": 0.6}` hovered without the velocity - each reported as success.
+
+A key outside `ACTION_KEYS` is now refused by name, the shape `earthrover`'s
+`send_action` already uses for its drive channels and `ur`'s
+`targets_from_action` for its joints. It is checked after the all-unknown gate
+rather than before it, so each refusal diagnoses one fault: an action with no
+known key is told what to send, and an action that mostly parsed is told which
+component was dropped. Both refusals name the accepted keys and their units
+from one constant, so the two cannot drift apart.

--- a/strands_robots/drivers/crazyflie.py
+++ b/strands_robots/drivers/crazyflie.py
@@ -207,9 +207,13 @@ LOG_VARIABLES: tuple[tuple[str, str], ...] = (
 _LOG_NAME = "strands_state"
 _LOG_PERIOD_MS = 100
 
-#: Action keys :func:`action_to_setpoint` understands, for the refusal message
-#: when an action names none of them.
+#: Action keys :func:`action_to_setpoint` understands. The allowlist an action
+#: is checked against, and the set both of its refusals name.
 ACTION_KEYS: tuple[str, ...] = ("vx", "vy", "vz", "wz", "z")
+
+#: The unit gloss both :func:`action_to_setpoint` refusals carry, named once so
+#: the two cannot drift apart.
+_ACTION_KEY_UNITS = "vx/vy/vz in m/s, wz in rad/s, z the hover height in m"
 
 #: ``cflib`` ``Commander`` method names this driver calls. Named constants
 #: because :func:`action_to_setpoint` returns one of them and the tests assert
@@ -368,6 +372,14 @@ def action_to_setpoint(action: Mapping[str, Any]) -> tuple[str, tuple[float, flo
     all-zero setpoint - would latch the aircraft into a hover the caller never
     asked for and report success for it.
 
+    A key *outside* :data:`ACTION_KEYS` is refused for that same reason, even
+    with a known key beside it. Absent means resting, but unknown means the
+    caller named a component the aircraft never receives, and the two are not
+    distinguishable downstream: ``{"vx": 0.0, "height": 1.5}`` - ``height``
+    being this module's own internal spelling of the hover key ``z`` - reaches
+    precisely the all-zero setpoint the gate above exists to refuse, and
+    reports success for it.
+
     Args:
         action: Joint targets keyed as this driver names them; see
             :data:`ACTION_KEYS`.
@@ -379,7 +391,15 @@ def action_to_setpoint(action: Mapping[str, Any]) -> tuple[str, tuple[float, flo
     if not any(key in action for key in ACTION_KEYS):
         return (
             f"send_action: no flight command in {sorted(action)}; expected at least one of "
-            f"{list(ACTION_KEYS)} (vx/vy/vz in m/s, wz in rad/s, z the hover height in m)"
+            f"{list(ACTION_KEYS)} ({_ACTION_KEY_UNITS})"
+        )
+    # Checked after the gate above rather than before it, so each refusal
+    # diagnoses one fault: an action with no known key is told what to send,
+    # and an action that mostly parsed is told which component was dropped.
+    unknown = sorted(set(action) - set(ACTION_KEYS))
+    if unknown:
+        return (
+            f"send_action: {unknown} name no flight command; expected any of {list(ACTION_KEYS)} ({_ACTION_KEY_UNITS})"
         )
     height = action.get("z")
     if (

--- a/tests/drivers/crazyflie/test_crazyflie_envelope_refuses_an_unflyable_command.py
+++ b/tests/drivers/crazyflie/test_crazyflie_envelope_refuses_an_unflyable_command.py
@@ -11,6 +11,11 @@ The rows cover the two ways a number is unusable - outside the envelope, and not
 a number at all - because they fail differently: an over-speed is a valid float
 the firmware would honour, while ``nan`` serialises into a CRTP packet as a
 perfectly well-formed float64 that poisons the controller's state.
+
+A key the driver does not command is the third way, and the quietest of the
+three. An unusable *value* is at least read before it is judged; an unusable
+*key* is dropped before any check sees it, and the component it named then rests
+at zero - indistinguishable, downstream, from a caller who never asked for it.
 """
 
 from __future__ import annotations
@@ -20,6 +25,7 @@ from typing import Any
 import pytest
 
 from strands_robots.drivers.crazyflie import (
+    ACTION_KEYS,
     MAX_HEIGHT,
     MAX_HORIZONTAL_SPEED,
     MAX_VERTICAL_SPEED,
@@ -138,3 +144,53 @@ class TestNothingIsClamped:
         reason = action_to_setpoint({"vx": 5.0, "wz": 99.0})
         assert isinstance(reason, str)
         assert "vx" in reason
+
+
+class TestAKeyTheDriverCannotCarryIsRefusedByName:
+    """The key half of the same rule: a named component is flown, or refused.
+
+    Every flight component is read with a zero default, so a key this driver
+    does not know is dropped in silence. The gate for an action naming *no*
+    known key exists precisely because an all-zero setpoint "would latch the
+    aircraft into a hover the caller never asked for" - and that outcome is
+    reachable straight through the gate, because a single known key satisfies
+    it. ``{"vx": 0.0, "height": 1.5}`` asks to hover at 1.5 m using this
+    module's own internal spelling of ``z``, and produces the resting setpoint.
+    """
+
+    @pytest.mark.parametrize(
+        ("action", "dropped"),
+        [
+            ({"vx": 0.0, "height": 1.5}, "height"),  # this module's own name for z
+            ({"wz": 0.0, "altitude": 1.5}, "altitude"),
+            ({"vx": 0.5, "vyaw": 2.0}, "vyaw"),  # the yaw spelling robotd uses
+            ({"z": 1.0, "vX": 0.6}, "vX"),  # a capitalisation nothing downstream reads
+            ({"vx": 0.2, "z": 0.5, "gripper": 1.0}, "gripper"),
+        ],
+    )
+    def test_a_dropped_component_is_refused_not_rested(self, action: dict[str, Any], dropped: str) -> None:
+        reason = action_to_setpoint(action)
+        assert isinstance(reason, str), (
+            f"{action} names {dropped!r}, which no setpoint carries; returning a setpoint here "
+            "flies a command the caller never gave and reports success for it"
+        )
+        assert dropped in reason, "the refusal must name the key that would have been dropped"
+        for key in ACTION_KEYS:
+            assert key in reason, f"the refusal must name {key!r} as an accepted alternative"
+
+    def test_nothing_reaches_the_commander(self, connected, recorder) -> None:  # type: ignore[no-untyped-def]
+        """The envelope door refuses too, so no partial command is latched.
+
+        The flyable keys here are flyable, so a driver that refused only the
+        whole action would still have to decide what to do with them; it must
+        send nothing and keep no repeater alive.
+        """
+        driver, _fake, connect_reason = connected()
+        assert connect_reason is None, connect_reason
+
+        envelope = driver.send_action({"vx": 0.2, "z": 0.5, "height": 1.5})
+
+        assert envelope["status"] == "error", envelope
+        assert "height" in str(envelope)
+        assert recorder.count("commander.send_hover_setpoint") == 0
+        assert recorder.count("commander.send_velocity_world_setpoint") == 0


### PR DESCRIPTION
![before and after](https://raw.githubusercontent.com/cagataycali/robots/assets/crazyflie-dropped-flight-key/crazyflie_dropped_key.png)

**What.** `action_to_setpoint` reads every flight component with a zero default, so a key the driver does not command was dropped before any check saw it. The gate above it refuses an action naming *none* of `ACTION_KEYS`, because an all-zero setpoint "would latch the aircraft into a hover the caller never asked for and report success for it" - and one known key satisfies that gate, so the outcome was reachable straight through it. `height` is this module's own internal spelling of the hover key `z`, so the request most likely spelled that way is the one that reached the resting setpoint.

**Why.** A key outside `ACTION_KEYS` is now refused by name - the shape `earthrover.send_action` already uses for its drive channels and `ur.targets_from_action` for its joints. Checked after the all-unknown gate, so each refusal diagnoses one fault; both name the accepted keys and their units from one constant.

**Tests.** 6 new cells fail on `main`, 33 pass after. Full suite 51,552 passed / 316 skipped, coverage 96.05%; `ruff` + `mypy` clean on 1,977 files. LOC +104/-3 (source +23 net).