### PR TITLE
fix(drivers/reachy): an action naming a key no axis answers is refused

### DIFF
--- a/changelog.d/0000-reachy-action-refuses-a-dropped-axis.md
+++ b/changelog.d/0000-reachy-action-refuses-a-dropped-axis.md
@@ -1,0 +1,34 @@
+### Fixed: a Reachy Mini action naming a key no axis answers is refused, not moved without it
+
+`ReachyDriver.send_action` builds the daemon's head pose from six keys read with
+a zero default, so a key the driver has no actuator for was dropped before any
+check saw it. The gate above it - refusing an action that names *none* of the
+nine axes - exists so an action that moved nothing is not reported as a success,
+and that outcome was reachable straight through the gate, since one known key
+satisfies it.
+
+For the head it is worse than a no-op. The daemon's head command is a whole
+pose, not a delta, so a dropped head axis is not left alone but commanded to
+zero:
+
+    send_action({"head_pitch": 20.0, "head_rol": 15.0})
+    -> head_pose for pitch 20, roll 0        status="success"
+
+The axis names most likely to be spelled that way are this package's own: the
+`reachy_look` tool takes `pitch`/`roll`/`yaw`, `reachy_antennas` takes
+`left`/`right` and `reachy_body_turn` takes `yaw`, while the driver's action keys
+spell the same axes `head_pitch`, `antenna_left` and `body_yaw`. So
+`{"head_pitch": 20.0, "roll": 15.0}` levelled the head it was asked to tilt,
+`{"head_yaw": 20.0, "left": 30.0}` never moved an antenna, and
+`{"body_yaw": 10.0, "yaw": 30.0}` left the head where it was - each under a
+success envelope naming the groups it did send.
+
+A key outside the accepted set is now refused by name, the shape
+`earthrover.send_action` already uses for its drive channels, `ur`'s
+`targets_from_action` for its joints, `franka`'s for its joint keys and
+`crazyflie`'s `action_to_setpoint` for its flight components. It is checked after
+the all-unknown gate rather than before it, so each refusal diagnoses one fault:
+an action naming no axis at all is told what to send, and an action that mostly
+parsed is told which key was dropped. The reason names the substitution as well
+as the key, because "ignored" and "commanded to zero" are different outcomes for
+whoever plans the next gesture.

--- a/strands_robots/drivers/reachy.py
+++ b/strands_robots/drivers/reachy.py
@@ -697,9 +697,11 @@ class ReachyDriver:
            the head pose and turns the body no further than the limit, so a
            lone body yaw beyond it would report success and stop short. The
            limit is skipped, not guessed, while that target is unknown.
-        3. The action names at least one thing this driver can send. An action
-           dict of unknown keys is refused rather than reported as a successful
-           no-op.
+        3. Every key names something this driver can send. An action naming no
+           axis at all is refused rather than reported as a successful no-op,
+           and so is one that names a real axis alongside a key this driver has
+           no actuator for: a dropped head axis is not left alone but commanded
+           to zero, because the daemon's head command is a whole pose.
 
         Degrees in, radians and pose matrices out. The caller-facing unit is
         degrees because the envelope is expressed in degrees and because the
@@ -743,6 +745,15 @@ class ReachyDriver:
             return _refuse(
                 f"send_action: nothing to send - none of {sorted(action)} names a Reachy Mini axis; "
                 f"expected any of {sorted(_ACTION_KEYS)}"
+            )
+        # Checked after the gate above rather than before it, so each refusal
+        # diagnoses one fault: an action naming no axis at all is told what to
+        # send, and an action that mostly parsed is told which key was dropped.
+        if unknown := sorted(set(action) - _ACTION_KEYS):
+            return _refuse(
+                f"send_action: {unknown} names no Reachy Mini axis; expected any of {sorted(_ACTION_KEYS)}. "
+                "A dropped head axis is commanded to zero rather than left alone, because the daemon's "
+                "head command is a whole pose"
             )
 
         for command in commands:

--- a/tests/drivers/test_reachy_driver.py
+++ b/tests/drivers/test_reachy_driver.py
@@ -635,6 +635,93 @@ class TestActionsReachTheWireInTheDaemonsUnits:
         assert "socket closed" in _text(result)
 
 
+#: Misspellings drawn from this module's own public vocabulary, each paired with
+#: the axis it was meant to name. ``reachy_look`` takes ``pitch``/``roll``/``yaw``,
+#: ``reachy_antennas`` takes ``left``/``right`` and ``reachy_body_turn`` takes
+#: ``yaw``, while the driver's action keys spell the same axes ``head_pitch``,
+#: ``antenna_left`` and ``body_yaw`` - so a caller who read one of those
+#: signatures and drove the driver directly writes exactly these actions.
+_DROPPED_AXIS = [
+    ("a typo on a head axis", {"head_pitch": 20.0, "head_rol": 15.0}, "head_rol"),
+    ("the reachy_look spelling of a head axis", {"head_pitch": 20.0, "roll": 15.0}, "roll"),
+    ("the reachy_antennas spelling of an antenna", {"head_yaw": 20.0, "left": 30.0}, "left"),
+    ("the reachy_body_turn spelling of the body", {"body_yaw": 10.0, "yaw": 30.0}, "yaw"),
+]
+
+
+class TestAnActionCarryingAKeyNoAxisAnswersIsRefused:
+    """One unknown key beside a real one is refused, not quietly dropped.
+
+    The whole-pose rule that makes :func:`_head_yaw_of` knowable also makes a
+    dropped head axis worse than a no-op: the daemon's head command carries all
+    six axes, so a misspelled ``head_roll`` does not leave the roll alone - it
+    commands it to zero. An operator who asked for 15 degrees of roll and got
+    zero, under a success envelope, plans the next gesture around a pose the
+    robot never held. The four in-house precedents for the same guard are
+    ``ur.targets_from_action``, ``earthrover.send_action``,
+    ``franka`` joint commands and ``crazyflie.action_to_setpoint``.
+    """
+
+    @pytest.mark.parametrize(
+        ("label", "action", "dropped"),
+        _DROPPED_AXIS,
+        ids=[case[0] for case in _DROPPED_AXIS],
+    )
+    def test_the_refusal_names_the_dropped_key_and_nothing_reaches_the_wire(
+        self, monkeypatch: pytest.MonkeyPatch, label: str, action: dict[str, float], dropped: str
+    ) -> None:
+        del label
+        driver, _, link = _connected(monkeypatch)
+        result = driver.send_action(dict(action))
+        assert result["status"] == "error"
+        reason = _text(result)
+        assert dropped in reason, reason
+        # The accepted set is named, so a caller is not left to read the source
+        # for the spelling that would have worked.
+        assert "head_roll" in reason and "antenna_left" in reason and "body_yaw" in reason, reason
+        assert link.commands == []
+
+    def test_the_reason_says_a_dropped_head_axis_would_have_been_zeroed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The substitution, not merely the unknown name, is what the caller
+        # needs told: "ignored" and "commanded to zero" are different outcomes.
+        driver, _, _ = _connected(monkeypatch)
+        reason = _text(driver.send_action({"head_pitch": 20.0, "head_rol": 15.0}))
+        assert "whole pose" in reason and "zero" in reason, reason
+
+    def test_an_action_of_only_unknown_keys_still_gets_the_nothing_to_send_reason(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The two refusals partition: an action naming no axis at all is told
+        # what to send, and one that mostly parsed is told what was dropped.
+        driver, _, _ = _connected(monkeypatch)
+        nothing = _text(driver.send_action({"pitch": 20.0, "roll": 15.0}))
+        partial = _text(driver.send_action({"head_pitch": 20.0, "roll": 15.0}))
+        assert "nothing to send" in nothing, nothing
+        assert "nothing to send" not in partial, partial
+
+    def test_an_action_whose_every_key_is_an_axis_still_reaches_the_wire(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The guard must not narrow the accepted vocabulary: every documented
+        # key, in one action, is still carried.
+        driver, _, link = _connected(monkeypatch)
+        action = {
+            "head_pitch": 5.0,
+            "head_roll": 5.0,
+            "head_yaw": 5.0,
+            "head_x": 1.0,
+            "head_y": 1.0,
+            "head_z": 1.0,
+            "body_yaw": 5.0,
+            "antenna_left": 5.0,
+            "antenna_right": 5.0,
+        }
+        assert driver.send_action(action)["status"] == "success"
+        assert [sorted(c) for c in link.commands] == [
+            ["head_pose"],
+            ["body_yaw"],
+            ["antennas_joint_positions"],
+        ]
+
+
 class TestTheStopPathReachesTheDaemon:
     """A Mini has a real stop: a recorded move can be halted mid-play."""
 


### PR DESCRIPTION
![before/after](https://raw.githubusercontent.com/cagataycali/robots/assets/reachy-dropped-axis/reachy-dropped-axis.png)

## What
`send_action` built the daemon's head pose from six keys read with a zero default, so a key the driver has no actuator for was dropped before any check saw it. The gate above it - refusing an action naming *none* of the nine axes - was satisfied by one known key, so its own outcome was reachable through it.

For the head it is worse than a no-op: the head command is a whole pose, not a delta, so a dropped axis is commanded to **zero**, not left alone. `{"head_pitch": 20, "head_rol": 15}` sent a pose 15.0 deg off the one asked for (max 4x4 element differs by 0.2588) under `status="success"`.

## Why these spellings
They are this package's own: `reachy_look` takes `pitch`/`roll`/`yaw`, `reachy_antennas` takes `left`/`right`, `reachy_body_turn` takes `yaw` - while the driver's keys spell those axes `head_pitch`, `antenna_left`, `body_yaw`.

A key outside the accepted set is now refused by name - the shape `earthrover`, `ur`, `franka` and `crazyflie` already use. Checked *after* the all-unknown gate, so each refusal diagnoses one fault and the existing "nothing to send" reason is unchanged.

## Tests
7 cells in the existing wire-contract file: **5 fail pre-fix**, all pass after. Full suite 51,572 passed / 316 skipped, coverage 96.05%; ruff + mypy (1,977 files) clean.

LOC: +135 / -3 (source +14/-3, tests +87, changelog +34).