### PR TITLE
fix(mesh/ackermann): a yaw asked for at rest is refused, not sent as a halt

### DIFF
--- a/changelog.d/3541-ackermann-rest-command-refused.md
+++ b/changelog.d/3541-ackermann-rest-command-refused.md
@@ -1,0 +1,21 @@
+### Fixed: an Ackermann car refuses a yaw it cannot execute instead of sending a halt
+
+`AckermannRosRobot.drive` converts `(linear, angular)` through a bicycle model
+that maps every `abs(linear)` below the rest threshold (`1e-3` m/s) onto the zero
+servo pair. That conversion is right - a stock Ackermann platform steers its
+front wheels and cannot yaw about its own axis, and `atan2` near `v = 0` would
+amplify noise into hard steering - but the zero pair is exactly what `stop()`
+publishes. A `drive(linear=0.0, angular=1.0)` therefore left on the wire as
+`{"angle": 0.0, "throttle": 0.0}`, byte-identical to a halt, under
+`status="success"`: a rotate-in-place request and a stop were indistinguishable
+to the vehicle and to the caller, who went on to plan from a heading the car
+never reached. The drive tool's own description already stated that the car
+"cannot turn in place"; the call accepted it anyway.
+
+`drive()` now refuses such a pair by name, quoting the threshold and what to send
+instead, ordered with the other domain refusals and ahead of the `init_services`
+handshake so an unexecutable request cannot be what switches the car into manual
+mode. The threshold is read from the constant the conversion uses, so the door
+and the conversion cannot come to disagree about what rest is. `drive(0, 0)`
+still means rest, because that is what it asked for, and any yaw carrying a
+linear speed still converts as before.

--- a/docs/ros2-integration.md
+++ b/docs/ros2-integration.md
@@ -272,7 +272,13 @@ are clamped to `max_speed`; holds longer
 than `max_duration` are rejected loudly rather than silently truncated. The
 `linear`/`angular`/`duration`/`count` values themselves are checked against the
 same shared domains the differential-drive bridges use, so an unusable value is
-refused with identical text on every transport. The
+refused with identical text on every transport. A pair the steering geometry
+cannot execute is refused for the same reason: below the rest threshold
+(1e-3 m/s) the bicycle model maps any command to the zero servo pair, so
+`drive(linear=0.0, angular=1.0)` - a rotate in place, which this platform cannot
+do - would otherwise leave as byte-identical to `stop()` and report success for a
+heading change that never happened. Give a turn a linear speed to travel at, or
+call `stop()`; `drive(0, 0)` still means rest, because that is what it asked for. The
 stock platform publishes no odometry, so there is deliberately no
 `get_pose`.
 

--- a/strands_robots/mesh/ackermann_robot.py
+++ b/strands_robots/mesh/ackermann_robot.py
@@ -114,6 +114,59 @@ def _twist_to_servo(
     return (delta / max_steering_rad, throttle)
 
 
+def _rest_command_error(linear: float, angular: float, context: str) -> str | None:
+    """Report why a command maps to rest although it did not ask for rest, or ``None``.
+
+    :func:`_twist_to_servo` maps every ``abs(linear) < _REST_VELOCITY_EPS`` onto
+    ``(0.0, 0.0)``, which is the right conversion - a stock Ackermann platform
+    steers its front wheels and cannot yaw about its own axis, and ``atan2``
+    near ``v = 0`` would amplify noise into hard steering. What it cannot decide
+    is whether the caller meant that. A ``drive(linear=0.0, angular=1.0)`` leaves
+    on the wire as the same zero servo pair a stop uses, so a rotate-in-place
+    request and a halt are indistinguishable to the vehicle and to the caller,
+    who is told ``success`` for a heading change that never happened and plans
+    the next leg from a pose the car is not in.
+
+    The threshold is read from :data:`_REST_VELOCITY_EPS` rather than restated,
+    so the door and the conversion cannot come to disagree about what rest is.
+    This is :func:`~strands_robots.drivers.earthrover.drive_axis_error`'s
+    disposition - a velocity has no endpoint to land on, so it is refused by name
+    rather than substituted - applied at the other end of the range, and the rule
+    :meth:`~strands_robots.mesh._mobile_base.MobileBaseRobot.drive` already states
+    for ``count=0``: a request that commands nothing must not report success.
+
+    Args:
+        linear: The requested body-frame linear velocity in m/s, already known
+            finite.
+        angular: The requested body-frame yaw rate in rad/s, already known
+            finite.
+        context: Calling surface to quote in the reason.
+
+    Returns:
+        A reason naming the threshold and what to send instead, or ``None`` when
+        the command is executable - including the all-zero command, which is a
+        halt and means exactly what it maps to.
+    """
+    if abs(float(linear)) >= _REST_VELOCITY_EPS:
+        return None
+    if float(angular):
+        return (
+            f"{context}: angular={float(angular)} rad/s asks the car to yaw, but linear="
+            f"{float(linear)} m/s is below the rest threshold {_REST_VELOCITY_EPS} m/s - an "
+            "Ackermann platform steers its front wheels and cannot turn in place, so this "
+            "would go on the wire as the same zero servo pair a stop uses. Give the turn a "
+            "linear speed to travel at, or call stop() to hold the car still."
+        )
+    if float(linear):
+        return (
+            f"{context}: linear={float(linear)} m/s is below the rest threshold "
+            f"{_REST_VELOCITY_EPS} m/s, so it maps to the same zero servo pair a stop uses "
+            "and the car would not move. Command at least that speed, or call stop() to hold "
+            "the car still."
+        )
+    return None
+
+
 class AckermannRosRobot:
     """An Ackermann-steering ROS 2 car exposed as a strands-controllable robot.
 
@@ -274,8 +327,11 @@ class AckermannRosRobot:
         ``round(duration * publish_rate)`` messages, takes precedence over
         ``count``). Validation runs before any side effect, in order: inputs
         must be finite, ``duration`` (when given) must be a positive finite
-        number within ``max_duration``, and only then does the vehicle's
-        ``init_services`` handshake run (automatically, before the first
+        number within ``max_duration``, the pair must name a motion the steering
+        geometry can execute - a yaw asked for at rest is refused, because this
+        platform cannot turn in place and the conversion would otherwise publish
+        it as the same zero servo pair a stop uses - and only then does the
+        vehicle's ``init_services`` handshake run (automatically, before the first
         command; a failed handshake aborts the drive). Every timed or
         multi-message non-zero command is followed by a single zero servo
         message - even if the main publish failed - so it can never leave the
@@ -314,6 +370,11 @@ class AckermannRosRobot:
                 f"drive: duration {duration}s exceeds max_duration {self.max_duration}s "
                 "- issue shorter commands instead of one long hold"
             )
+        # Ordered with the other refusals, ahead of the handshake: a command the
+        # kinematics cannot execute must not be what switches the car into a
+        # commandable state, and it must not be published as a halt either.
+        if rest_err := _rest_command_error(linear, angular, "drive"):
+            return self._error(rest_err)
         if not self._enabled and self.init_services:
             enabled = self.enable(tool_context=tool_context)
             if enabled.get("status") != "success":

--- a/tests/mesh/test_ackermann_robot.py
+++ b/tests/mesh/test_ackermann_robot.py
@@ -390,6 +390,57 @@ def test_drive_short_duration_still_gets_trailing_zero(rec: _Recorder) -> None:
     assert rec.calls[1]["fields"] == {"angle": 0.0, "throttle": 0.0}
 
 
+#: ``(drive kwargs, the phrase the refusal must carry)`` for every command the
+#: rest mapping replaces. Each of these previously reached the servo topic as
+#: ``{"angle": 0.0, "throttle": 0.0}`` - byte for byte the stop message - under
+#: ``status="success"``. The rotate-in-place rows are what an agent actually
+#: writes, since the drive tool's own description states the car "cannot turn in
+#: place" while the call accepted it anyway; the sub-epsilon rows are the same
+#: substitution reached from the other side, a speed under the platform's floor.
+_REST_SUBSTITUTIONS: list[tuple[dict[str, Any], str]] = [
+    ({"linear": 0.0, "angular": 1.0}, "cannot turn in place"),
+    ({"linear": 0.0, "angular": -2.5, "duration": 1.0}, "cannot turn in place"),
+    ({"linear": 5e-4, "angular": 1.0}, "cannot turn in place"),
+    ({"linear": 5e-4, "angular": 0.0}, "below the rest threshold"),
+    ({"linear": -5e-4}, "below the rest threshold"),
+]
+
+
+@pytest.mark.parametrize(("kwargs", "expected"), _REST_SUBSTITUTIONS)
+def test_drive_refuses_a_command_the_rest_mapping_would_replace(
+    rec: _Recorder, kwargs: dict[str, Any], expected: str
+) -> None:
+    """A command that maps to rest is refused, not published as a halt.
+
+    ``_twist_to_servo`` sends every sub-epsilon speed to ``(0.0, 0.0)``, which is
+    the correct conversion - the platform cannot yaw at rest. It is not a correct
+    *answer*: the zero pair is what ``stop()`` publishes, so a rotate-in-place
+    request and a halt left byte-identical, and the caller was told ``success``
+    for a heading change that never happened.
+    """
+    car = _car(init_services=_HANDSHAKE)
+    result = car.drive(**kwargs)
+    assert result["status"] == "error"
+    assert expected in result["content"][0]["text"]
+    # Refused ahead of the handshake, like every other domain refusal here: an
+    # unexecutable request must not be what switches the car into manual mode.
+    assert rec.calls == []
+
+
+def test_drive_still_accepts_the_commands_the_geometry_can_execute(rec: _Recorder) -> None:
+    """The refusal narrows nothing: rest itself, and any yaw with speed, still go out.
+
+    ``drive(0, 0)`` maps to the zero pair because it *asked* for rest, and an arc
+    is a yaw the bicycle model can convert, so both keep reaching the wire.
+    """
+    car = _car()
+    assert car.drive(linear=0.0, angular=0.0)["status"] == "success"
+    assert car.drive(linear=1.0, angular=1.0)["status"] == "success"
+    assert [call["fields"] for call in rec.calls][0] == {"angle": 0.0, "throttle": 0.0}
+    turn = rec.calls[1]["fields"]
+    assert turn["throttle"] > 0 and turn["angle"] > 0
+
+
 def test_drive_overlong_duration_rejected_before_enable(rec: _Recorder) -> None:
     # Validation precedes side effects: an invalid request must not switch the
     # car into manual mode.


### PR DESCRIPTION
![before/after](https://raw.githubusercontent.com/cagataycali/robots/7dc2af2d76f4183c5e25b9dc169bd2f76e1579e6/ackermann_rest_refusal.png)

## What
`AckermannRosRobot.drive` refuses a `(linear, angular)` pair the steering geometry cannot execute, ordered with the other domain refusals and ahead of the `init_services` handshake. `drive(0, 0)` still means rest; any yaw with speed still converts.

## Why
The bicycle model maps every `abs(linear) < 1e-3` onto `(0.0, 0.0)` - correct, since the platform cannot yaw about its own axis and `atan2` near `v = 0` amplifies noise into hard steering. It is not a correct *answer*: that zero pair is exactly what `stop()` publishes, so `drive(linear=0.0, angular=1.0)` left byte-identical to a halt under `status="success"`, and the caller plans the next leg from a heading the car never reached. The drive tool's own description already states the car "cannot turn in place".

This is `drive_axis_error`'s disposition (a velocity has no endpoint to land on, so refuse rather than substitute) applied at the other end of the range, and the rule `MobileBaseRobot.drive` already states for `count=0`: a request that commands nothing must not report success. The threshold is read from the same constant the conversion uses, so door and conversion cannot drift.

## Tests
`tests/mesh/test_ackermann_robot.py`: 5 parametrized rows for the substituted commands plus a control that the refusal narrows nothing. **5 failed / 44 passed pre-fix, 49 passed after.** LOC delta +121/-3 across 3 files.