### PR TITLE
fix(drivers/dynamixel): a sync-write's data_length is held to the register it addresses

### DIFF
--- a/changelog.d/3547-dynamixel-sync-write-width-matches-the-register.md
+++ b/changelog.d/3547-dynamixel-sync-write-width-matches-the-register.md
@@ -1,0 +1,37 @@
+### Fixed: a sync-write's data_length is held to the register it addresses
+
+`sync_write_packet`'s own documentation stated the requirement and named the
+consequence of breaking it - `data_length` "must match the register's width in
+`CONTROL_TABLE`", because "a 4-byte write to a 2-byte register is accepted by
+the servo but writes into the next register" - but nothing enforced it. The
+function checked that `data_length` was a positive 16-bit count and that every
+entry's data was exactly `data_length` bytes, and never consulted the table it
+cited.
+
+So a 4-byte write to `GOAL_CURRENT`, a 2-byte register at address 102, framed:
+
+    sync_write_packet(102, 4, [(1, (500).to_bytes(4, "little"))])
+    -> fffffd00fe0c00836600040001f40100002059
+
+`GOAL_VELOCITY` is the 4-byte register at address 104. The servo carves the
+payload by address, so the top two bytes of that current command land in it: a
+caller asking for 500 mA also commanded a velocity of zero on a joint that was
+moving. The opposite mistake is as quiet - a 2-byte write to the 4-byte
+`GOAL_POSITION` leaves half the target unwritten, so the joint goes to a
+position nobody asked for. A SYNC_WRITE is a broadcast that no servo answers,
+which is what makes both silent: neither can come back as an error, only as a
+joint in the wrong place.
+
+The width is now checked before the packet is framed, and the refusal says where
+the bytes would have gone:
+
+    GOAL_CURRENT at register_address=102 is 2 bytes wide, got data_length=4;
+    the servo accepts the longer write and runs the extra 2 byte(s) on into
+    GOAL_VELOCITY
+
+Only an address `CONTROL_TABLE` names is graded. The table is a curated subset of
+the servo's registers rather than an allowlist, so a write to a register it does
+not list - `PROFILE_VELOCITY` at 112, say - carries whatever `data_length` the
+caller asks for, and every register it does list still frames at its own
+declared width. The widths are read from `CONTROL_TABLE` itself rather than
+restated, so the check cannot drift from the table it grades against.

--- a/strands_robots/drivers/dynamixel/protocol.py
+++ b/strands_robots/drivers/dynamixel/protocol.py
@@ -124,6 +124,15 @@ CONTROL_TABLE: Final[dict[str, tuple[int, int, str]]] = {
     "PRESENT_INPUT_VOLTAGE": (144, 2, "0.1V units."),
 }
 
+# Address -> (name, width), derived from CONTROL_TABLE rather than written out
+# again, so the widths a write is graded against cannot drift from the widths the
+# table publishes. Addresses are unique in the table; the assert states that
+# rather than letting a future duplicate silently drop the earlier entry.
+_REGISTER_AT: Final[dict[int, tuple[str, int]]] = {
+    address: (name, width) for name, (address, width, _) in CONTROL_TABLE.items()
+}
+assert len(_REGISTER_AT) == len(CONTROL_TABLE), "CONTROL_TABLE has two names at one address"
+
 
 def checksum(frame: bytes) -> int:
     """Return the Protocol 2.0 CRC over ``frame``.
@@ -314,10 +323,20 @@ def sync_write_packet(register_address: int, data_length: int, entries: list[tup
     carries N (id, data) tuples and the servos self-select on ID.
 
     Args:
-        register_address: The register to write.
+        register_address: The register to write. An address
+            :data:`CONTROL_TABLE` names is graded against that register's
+            declared width; an address it does not name carries whatever
+            ``data_length`` the caller asks for, because the table is a
+            curated subset of the servo's registers and not an allowlist.
         data_length: Bytes per servo. Must match the register's width in
-            :data:`CONTROL_TABLE` - a 4-byte write to a 2-byte register is
-            accepted by the servo but writes into the next register.
+            :data:`CONTROL_TABLE`, and is refused when it does not: a 4-byte
+            write to a 2-byte register is accepted by the servo but runs on
+            into the next register, and a 2-byte write to a 4-byte register
+            leaves the rest of it unwritten. The servo answers a sync-write
+            with nothing at all, so neither mistake can come back as an
+            error - it comes back as a joint somewhere the caller did not
+            ask for, which is why the width is checked before the packet is
+            framed.
         entries: List of ``(servo_id, data)`` pairs. Each ``data`` must be
             exactly ``data_length`` bytes; a data of the wrong length is
             :class:`ValueError`, not a silent truncation, because the servo
@@ -327,14 +346,35 @@ def sync_write_packet(register_address: int, data_length: int, entries: list[tup
         The full framed packet, targeting :data:`BROADCAST_ID`.
 
     Raises:
-        ValueError: If any entry's data is not ``data_length`` bytes, or if
-            an entry's ID is outside ``0..0xFC``, or if the parameter block
-            would overflow the 16-bit length field.
+        ValueError: If ``data_length`` disagrees with the width
+            :data:`CONTROL_TABLE` declares for ``register_address``, if any
+            entry's data is not ``data_length`` bytes, or if an entry's ID is
+            outside ``0..0xFC``, or if the parameter block would overflow the
+            16-bit length field.
     """
     if data_length <= 0 or data_length > 0xFFFF:
         raise ValueError(f"sync_write_packet: data_length must be > 0 and <= 0xFFFF; got {data_length}")
     if not 0 <= register_address <= 0xFFFF:
         raise ValueError(f"sync_write_packet: register_address must be 0..0xFFFF; got {register_address}")
+    # Graded here, with the other register-level checks, rather than in the entry
+    # loop below: a data_length that does not fit the register is wrong about the
+    # register, and reporting it first tells a caller the width to ask for
+    # instead of the width their entries failed to match.
+    listed = _REGISTER_AT.get(register_address)
+    if listed is not None and data_length != listed[1]:
+        name, width = listed
+        if data_length > width:
+            spill = _REGISTER_AT.get(register_address + width)
+            lands = f"into {spill[0]}" if spill is not None else "into the register above it"
+            consequence = (
+                f"the servo accepts the longer write and runs the extra {data_length - width} byte(s) on {lands}"
+            )
+        else:
+            consequence = f"the servo leaves the remaining {width - data_length} byte(s) of it unwritten"
+        raise ValueError(
+            f"sync_write_packet: {name} at register_address={register_address} is {width} bytes wide, "
+            f"got data_length={data_length}; {consequence}"
+        )
     params = bytearray(
         [
             register_address & 0xFF,

--- a/tests/drivers/test_dynamixel_driver.py
+++ b/tests/drivers/test_dynamixel_driver.py
@@ -184,6 +184,86 @@ class TestProtocol:
         with pytest.raises(ValueError, match="data_length"):
             sync_write_packet(register_address=116, data_length=0, entries=[])
 
+    # ------------------- sync width against the register --------------------
+    #
+    # A servo answers a SYNC_WRITE with nothing, so a data_length that does not
+    # fit the register it addresses cannot come back as an error - it comes back
+    # as a joint somewhere nobody asked for. The widths below are read from
+    # CONTROL_TABLE rather than retyped, so a table edit moves these cases with
+    # it instead of leaving them pinning a stale width.
+
+    _MISMATCHED_WIDTHS = [
+        # A 4-byte current command runs its top half into GOAL_VELOCITY, so
+        # asking for 500 mA also commands a velocity of 0 on a moving joint.
+        pytest.param("GOAL_CURRENT", 4, "runs the extra 2 byte(s) on into GOAL_VELOCITY", id="current-into-velocity"),
+        pytest.param("TORQUE_ENABLE", 4, "runs the extra 3 byte(s) on into LED", id="torque-into-led"),
+        # The register above GOAL_VELOCITY is one the table does not name, so the
+        # refusal says where the bytes go without inventing a name for it.
+        pytest.param("GOAL_VELOCITY", 8, "on into the register above it", id="velocity-into-unlisted"),
+        pytest.param("GOAL_POSITION", 2, "leaves the remaining 2 byte(s) of it unwritten", id="position-short"),
+        pytest.param("GOAL_CURRENT", 1, "leaves the remaining 1 byte(s) of it unwritten", id="current-short"),
+    ]
+
+    @pytest.mark.parametrize(("register", "data_length", "consequence"), _MISMATCHED_WIDTHS)
+    def test_sync_write_refuses_a_data_length_the_register_is_not(
+        self, register: str, data_length: int, consequence: str
+    ) -> None:
+        """The refusal names the register, its width, and where the bytes land.
+
+        Naming the consequence is the point: a caller who picked the wrong width
+        picked it from a register map, and "GOAL_CURRENT is 2 bytes wide" sends
+        them back to the map, while "runs on into GOAL_VELOCITY" tells them what
+        the servo would have done with the packet.
+        """
+        address, width, _ = CONTROL_TABLE[register]
+        assert data_length != width
+        with pytest.raises(ValueError) as excinfo:
+            sync_write_packet(address, data_length, [(1, bytes(data_length))])
+        message = str(excinfo.value)
+        assert f"{register} at register_address={address} is {width} bytes wide" in message
+        assert consequence in message
+
+    def test_sync_write_accepts_every_listed_register_at_its_own_width(self) -> None:
+        """The gate narrows nothing a correct caller does.
+
+        Every register the table names, framed at the width the table declares
+        for it, still produces a broadcast packet - so the refusal above cannot
+        be passing merely because the width check refuses everything.
+        """
+        for name, (address, width, _) in CONTROL_TABLE.items():
+            packet = sync_write_packet(address, width, [(1, bytes(width))])
+            assert packet[4] == BROADCAST_ID, name
+
+    def test_sync_write_leaves_an_address_the_table_does_not_name_ungraded(self) -> None:
+        """CONTROL_TABLE is a curated subset of the servo's registers, not an
+        allowlist. PROFILE_VELOCITY (112) is a real 4-byte register it omits;
+        grading unlisted addresses would refuse writes to every register the
+        table has not got round to naming.
+        """
+        assert 112 not in {address for address, _, _ in CONTROL_TABLE.values()}
+        packet = sync_write_packet(112, 4, [(1, bytes(4))])
+        assert packet[4] == BROADCAST_ID
+
+    def test_a_zero_data_length_is_still_reported_as_a_count(self) -> None:
+        """The width gate reads a data_length that is already a positive count,
+        so the domain check keeps its place in front of it: a 0 is diagnosed as
+        a 0 rather than as a width GOAL_POSITION happens not to be.
+        """
+        with pytest.raises(ValueError, match=r"data_length must be > 0"):
+            sync_write_packet(register_address=116, data_length=0, entries=[])
+
+    def test_the_register_width_is_reported_before_the_entry_length(self) -> None:
+        """A caller who picks the wrong width sizes their entries to it, so both
+        checks have something to say. The register is the fault that explains the
+        other one, and a caller told only "expected 2" would re-send entries at a
+        width GOAL_POSITION still will not take.
+        """
+        with pytest.raises(ValueError) as excinfo:
+            sync_write_packet(register_address=116, data_length=2, entries=[(1, b"\x00")])
+        message = str(excinfo.value)
+        assert "GOAL_POSITION at register_address=116 is 4 bytes wide" in message
+        assert "expected 2" not in message
+
     # -------------------------------- parse --------------------------------
 
     def _make_status(self, servo_id: int, err: int, params: bytes) -> bytes:
@@ -267,6 +347,12 @@ class TestProtocol:
 
     def test_torque_enable_width_is_one_byte(self) -> None:
         assert CONTROL_TABLE["TORQUE_ENABLE"][:2] == (64, 1)
+
+    def test_no_two_registers_share_an_address(self) -> None:
+        """A sync-write's width is looked up by address, so two names at one
+        address would silently grade one of them by the other's width."""
+        addresses = [address for address, _, _ in CONTROL_TABLE.values()]
+        assert len(addresses) == len(set(addresses))
 
     def test_max_unicast_id_below_the_broadcast(self) -> None:
         """A codec-level invariant. The values are the manual's; a change here


### PR DESCRIPTION
`sync_write_packet` documented the requirement and named the consequence of breaking it - `data_length` "must match the register's width in `CONTROL_TABLE`", because "a 4-byte write to a 2-byte register is accepted by the servo but writes into the next register" - but nothing enforced it. It graded `data_length` as a positive 16-bit count and each entry against `data_length`, and never consulted the table it cited.

![register width](https://raw.githubusercontent.com/cagataycali/robots/df9d9c66ec0d742056e6dffbb323e615953dfe4e/sync_write_width.png)

A servo carves a sync-write payload by address, and a SYNC_WRITE is a broadcast none of them answer - so neither mistake can come back as an error, only as a joint in the wrong place.

**What**: the width is checked before the packet is framed, and the refusal names where the bytes would have gone. Only an address `CONTROL_TABLE` names is graded: it is a curated subset of the servo's registers, not an allowlist, so all 18 listed registers still frame at their declared width and an unlisted one (`PROFILE_VELOCITY`, 112) still carries any `data_length`. Widths are read from the table rather than restated, so the check cannot drift from it.

**Tests**: 5 mismatch cells (over-wide into a named register, into an unlisted one, and short), plus 3 that pin the gate narrows nothing, plus ordering (a `0` is still a count; the register is reported before the entry length) and a table-integrity pin that no two registers share an address. 6 failed / 72 passed before, all pass after.

+169/-6 across 3 files.