### PR TITLE
fix(policies/lerobot_local): camera_key_map routes cameras on the declarative embodiment path

### DIFF
--- a/changelog.d/3555-embodiment-honors-camera-key-map.md
+++ b/changelog.d/3555-embodiment-honors-camera-key-map.md
@@ -1,0 +1,15 @@
+### Fixed: `camera_key_map` routes cameras on the declarative `embodiment` path too
+
+The `lerobot_local` path taken when an `embodiment` is declared merged only
+`obs_rename_override` over the embodiment's `obs_rename`, so a scene whose
+cameras are named for the scene rather than for the embodiment (`cam_top` vs
+`front`) was refused by the pre-download check - which named
+`obs_rename_override` as the remedy for a caller who had already bound the
+cameras with `camera_key_map` - and, past that check, reached the model with no
+image input at all: the rename map still named the embodiment's absent sources,
+so the frames were neither renamed onto the model's image features nor
+recognized as camera frames (they stayed HWC `uint8`). `camera_key_map` is now
+routed over the embodiment's declared renames, replacing the source key for each
+image feature it claims, before `obs_rename_override` (which stays last because
+a falsy value there is the only way to DROP a rename). This matches the three
+other camera routers, which have always resolved `camera_key_map` first.

--- a/docs/policies/camera-naming.md
+++ b/docs/policies/camera-naming.md
@@ -133,7 +133,9 @@ The free view is ranked last, not removed: a scene whose only camera is the free
 view still fills the slot it filled before. Real cameras keep their relative
 order among themselves, so the ordering decides only which camera a *guess*
 picks - a name the policy declares still binds by name, and an explicit
-`camera_key_map` still outranks both. The fallback stays loud either way
+`camera_key_map` still outranks both (including on the declarative
+`embodiment` path, where it replaces the source key the embodiment declares
+for the image feature it claims). The fallback stays loud either way
 (`positional_fallback_used` and a per-camera WARN); `strict_keys=True` still
 turns it into an error.
 

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -236,17 +236,34 @@ inputs as `observation.images.*`. Each camera is routed by, in order:
 ### Embodiment `obs_rename` and the pre-flight check
 
 `embodiment="so101"` routes cameras from the embodiment's `obs_rename`
-(`{runtime_camera_name: "observation.images.*"}`), merged under any
-`obs_rename_override`. Before the model is built the policy checks that every
-declared image feature has a source in the runtime observation and refuses
-otherwise, naming both sides:
+(`{runtime_camera_name: "observation.images.*"}`), under `camera_key_map` and
+then `obs_rename_override`. A `camera_key_map` entry replaces the source key the
+embodiment declares for the feature it claims, so a scene whose cameras are
+named for the scene routes onto an embodiment without renaming them:
+
+```python
+# so101 declares front -> .../image and wrist -> .../wrist_image
+create_policy("lerobot_local", pretrained_name_or_path=..., embodiment="so101",
+              camera_key_map={"cam_top": "observation.images.image",
+                              "cam_wrist": "observation.images.wrist_image"})
+# routed obs_rename: {cam_top: .../image, cam_wrist: .../wrist_image}
+```
+
+`obs_rename_override` is applied last, because a falsy value there is the only
+way to DROP a declared rename (`{"wrist": None}` adapts a two-camera embodiment
+to a single-camera checkpoint). An entry in either map naming an image feature
+the model does not declare is refused by name.
+
+Before the model is built the policy checks that every declared image feature
+has a source in the runtime observation - after routing both maps, so a camera
+you bound explicitly satisfies it - and refuses otherwise, naming both sides:
 
 ```text
 Embodiment 'so101' cannot route cameras to the model's image feature(s)
 ['observation.images.image', 'observation.images.wrist_image']: none of the
 expected source key(s) ['front', 'wrist'] are in the runtime observation, which
 provides [...]. Either: (a) rename your sim cameras to one of ['front', 'wrist']
-..., or (b) pass policy_config={'obs_rename_override': {...}} ...
+..., or (b) pass policy_config={'camera_key_map': {...}} ...
 ```
 
 A single-camera checkpoint needs no embodiment: declare the joint names with

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -15,6 +15,7 @@ import logging
 import threading
 import time
 from collections import deque
+from collections.abc import Mapping
 from typing import Any
 
 import numpy as np
@@ -151,6 +152,45 @@ def _merge_obs_rename(base: dict[str, str], override: dict[str, str | None] | No
 # kinova_gen3 is joint_1..joint_7), which is why the run, not the prefix, is
 # what identifies a placeholder.
 _GENERIC_STATE_KEY_PREFIX = "joint_"
+
+
+def _route_camera_key_map(base: dict[str, str], camera_key_map: Mapping[str, str] | None) -> dict[str, str]:
+    """Route an explicit ``camera_key_map`` over an embodiment's ``obs_rename``.
+
+    ``camera_key_map`` is the first rung of camera routing for every other
+    router in this class (:meth:`LerobotLocalPolicy._resolve_camera_targets`,
+    :meth:`LerobotLocalPolicy._to_lerobot_observation` and
+    :meth:`LerobotLocalPolicy._synthesized_camera_renames` all resolve it before
+    any name match), so the declarative path has to honor it too: the only
+    difference between those routers and this one is whether the checkpoint
+    ships a preprocessor and whether an ``embodiment`` is declared, and a camera
+    binding may not depend on either.
+
+    The replacement is scoped by rename TARGET, not by source key. An
+    embodiment declares ``{"front": "observation.images.image"}``; a caller who
+    maps their own camera onto that same feature means *instead of* ``front``,
+    not *as well as* - two sources feeding one target would let whichever the
+    pipeline renamed last win. So every declared source whose target a
+    ``camera_key_map`` entry claims is dropped before the entries are added.
+
+    An entry naming an image feature the model does not declare is left in the
+    merged map so ``EmbodimentMap.validate`` refuses it by name, matching the
+    ``camera_key_map routes camera ... but the policy does not declare it``
+    refusal the other two routers raise.
+
+    Args:
+        base: The embodiment's declared ``obs_rename`` map.
+        camera_key_map: Caller mapping of runtime camera name -> image feature.
+
+    Returns:
+        The routed rename map; a copy of ``base`` when no map is given.
+    """
+    if not camera_key_map:
+        return dict(base)
+    claimed = set(camera_key_map.values())
+    merged = {src: dst for src, dst in base.items() if dst not in claimed}
+    merged.update(camera_key_map)
+    return merged
 
 
 def _undeclared_image_feature_error(
@@ -375,9 +415,14 @@ class LerobotLocalPolicy(Policy):
             default) adopts the model config value, else 10.0.
         camera_key_map: Optional explicit mapping of robot/sim camera name
             (e.g. "top") to the policy's declared image feature key
-            (e.g. "observation.images.top"). When omitted, cameras are
-            routed by exact short-name match and then by declared order
-            with a warning on mismatch.
+            (e.g. "observation.images.top"). It is the first rung of camera
+            routing on every path, including a declared ``embodiment``: an
+            entry claiming an image feature replaces the source key the
+            embodiment declares for that feature, so a scene whose cameras are
+            named for the scene routes without renaming them. When omitted,
+            cameras are routed by the embodiment's ``obs_rename``, then by
+            exact short-name match and then by declared order with a warning on
+            mismatch.
         strict_keys: When True, raise (instead of warning + a degraded
             binding) wherever a key cannot be bound by name. It governs BOTH
             halves of the key binding, not cameras alone:
@@ -1501,10 +1546,12 @@ class LerobotLocalPolicy(Policy):
 
         Resolution: the model needs every declared image feature populated, so
         for each image rename TARGET (``observation.images.*``) at least one of
-        its source keys must be present in ``observation_keys``. A caller-
-        supplied ``obs_rename_override`` is merged over the embodiment's
-        ``obs_rename`` first, so an explicit override that maps a present camera
-        onto the feature satisfies the check.
+        its source keys must be present in ``observation_keys``. The caller's own
+        camera bindings are routed over the embodiment's ``obs_rename`` first -
+        ``camera_key_map`` (routing rung 1, see :func:`_route_camera_key_map`)
+        and then ``obs_rename_override`` - so an explicit binding that maps a
+        present camera onto the feature satisfies the check rather than being
+        refused with a remedy it already used.
 
         The converse is also checked: an explicit ``image_keys=`` replaces the
         feature list that would be derived from those same rename targets (it is
@@ -1595,7 +1642,14 @@ class LerobotLocalPolicy(Policy):
         except Exception:  # noqa: BLE001 - unknown/odd spec; create_policy reports it
             return
 
-        obs_rename = _merge_obs_rename(embodiment.obs_rename, policy_config.get("obs_rename_override"))
+        # ``camera_key_map`` is routing rung 1 (see :func:`_route_camera_key_map`),
+        # so it is applied before the availability check below: a caller who
+        # bound their cameras with it has already answered the question this
+        # check asks, and refusing them would name a remedy they used.
+        obs_rename = _merge_obs_rename(
+            _route_camera_key_map(embodiment.obs_rename, policy_config.get("camera_key_map")),
+            policy_config.get("obs_rename_override"),
+        )
 
         # Group source keys by the image feature TARGET they feed. A target is
         # satisfied when ANY of its sources is present in the observation, so an
@@ -1628,9 +1682,10 @@ class LerobotLocalPolicy(Policy):
             f"are in the runtime observation, which provides {sorted(obs)}. Either:\n"
             f"  (a) rename your sim cameras to one of {expected} "
             f"(e.g. sim.add_camera(name={expected[0]!r}, ...)), or\n"
-            f"  (b) pass policy_config={{'obs_rename_override': "
-            f"{{'<your_camera_name>': '{missing_features[0]}'}}}} to map an existing "
-            f"camera onto the model's image feature without renaming it."
+            f"  (b) pass policy_config={{'camera_key_map': "
+            f"{{'<your_camera_name>': '{missing_features[0]}'}}}} (or the equivalent "
+            f"'obs_rename_override') to map an existing camera onto the model's image "
+            f"feature without renaming it."
         )
 
     def _synthesized_camera_renames(self) -> dict[str, str]:
@@ -1680,8 +1735,10 @@ class LerobotLocalPolicy(Policy):
 
         1. Resolves ``self._embodiment_spec`` (name / dict / EmbodimentMap), or
            synthesises a trivial map from ``robot_state_keys`` for back-compat.
-        2. Validates the map against the model's declared input/output features
-           (fail-fast on dim or key mismatch).
+        2. Routes ``camera_key_map`` and then ``obs_rename_override`` over the
+           map's declared ``obs_rename``, and validates the result against the
+           model's declared input/output features (fail-fast on dim or key
+           mismatch).
         3. Injects ``rename_map`` + a ``strands_pack_state`` step into the
            preprocessor pipeline via :meth:`ProcessorBridge.apply_embodiment`.
 
@@ -1714,13 +1771,21 @@ class LerobotLocalPolicy(Policy):
         except ValueError as exc:
             raise RuntimeError(f"Failed to load embodiment {spec!r}: {exc}") from exc
 
-        # Merge any caller-supplied obs_rename override OVER the embodiment's
-        # declared renames so custom sim camera names route onto the model's
-        # image features without renaming cameras. Override entries win.
-        if self._obs_rename_override:
+        # Route the caller's own camera bindings over the embodiment's declared
+        # renames so custom sim camera names reach the model's image features
+        # without renaming cameras. ``camera_key_map`` is applied first (routing
+        # rung 1, honored identically by the other routers - see
+        # :func:`_route_camera_key_map`), then ``obs_rename_override`` over that:
+        # the override is the last word because it is the only spelling that can
+        # DROP a declared rename (a falsy value), so a caller already relying on
+        # it keeps exactly the map they had.
+        if self.camera_key_map or self._obs_rename_override:
             from dataclasses import replace
 
-            merged = _merge_obs_rename(embodiment.obs_rename, self._obs_rename_override)
+            merged = _merge_obs_rename(
+                _route_camera_key_map(embodiment.obs_rename, self.camera_key_map),
+                self._obs_rename_override,
+            )
             embodiment = replace(embodiment, obs_rename=merged)
 
         # Fail-fast validation against the model's declared features.

--- a/tests/policies/lerobot_local/test_camera_key_map_routes_a_declared_embodiment.py
+++ b/tests/policies/lerobot_local/test_camera_key_map_routes_a_declared_embodiment.py
@@ -1,0 +1,215 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""An explicit ``camera_key_map`` routes cameras on the declarative path too.
+
+``camera_key_map`` is documented as the first rung of camera routing, and the
+other three routers honor it there: ``_resolve_camera_targets`` (torch-batch
+path), ``_to_lerobot_observation`` (preprocessor path with no embodiment) and
+``_synthesized_camera_renames`` (embodiment synthesized from
+``set_robot_state_keys``) all resolve the map before any name match. The path
+taken when an ``embodiment`` IS declared did not: it merged only
+``obs_rename_override`` over the embodiment's declared ``obs_rename``, so a
+scene whose cameras are named for the scene (``cam_top``, ``cam_wrist``) rather
+than for the embodiment (``front``, ``wrist``) was
+
+* refused by :meth:`LerobotLocalPolicy.preflight` before any download, naming
+  ``obs_rename_override`` as the remedy for a caller who had already bound the
+  cameras with ``camera_key_map``; and
+* if that check was bypassed, left unrouted at inference: the rename map still
+  named the embodiment's absent sources, so the frames were neither renamed onto
+  the model's image features nor recognized as camera frames by
+  ``_canonicalize_obs_images`` (they stayed HWC ``uint8``), and the model
+  received no image input at all.
+
+These tests pin the routing, the target-scoped replacement it performs, and the
+bindings it must not change (no map at all, and an ``obs_rename_override`` that
+still has the last word because it is the only spelling that can DROP a rename).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.lerobot_local.embodiment import load_embodiment
+from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy, _route_camera_key_map
+
+SO101_JOINTS = {"1", "2", "3", "4", "5", "6"}
+SCENE_CAMS = {"cam_top", "cam_wrist"}
+SCENE_MAP = {
+    "cam_top": "observation.images.image",
+    "cam_wrist": "observation.images.wrist_image",
+}
+
+
+def _visual(shape=(3, 48, 64)):
+    return SimpleNamespace(type=SimpleNamespace(name="VISUAL"), shape=shape)
+
+
+def _state(dim=6):
+    return SimpleNamespace(type=SimpleNamespace(name="STATE"), shape=(dim,))
+
+
+def _action(dim=6):
+    return SimpleNamespace(type=SimpleNamespace(name="ACTION"), shape=(dim,))
+
+
+def _so101_policy(camera_key_map=None, obs_rename_override=None):
+    """A loaded two-camera SO-101 policy declaring ``embodiment="so101"``.
+
+    ``so101`` renames ``front`` -> ``observation.images.image`` and ``wrist`` ->
+    ``observation.images.wrist_image``; the model declares both features plus a
+    6-dof state, so only the camera SOURCE keys are in question.
+    """
+    with patch.object(LerobotLocalPolicy, "_load_model"):
+        policy = LerobotLocalPolicy(
+            pretrained_name_or_path=None,
+            policy_type="act",
+            embodiment="so101",
+            camera_key_map=camera_key_map,
+            obs_rename_override=obs_rename_override,
+        )
+    policy._input_features = {
+        "observation.state": _state(6),
+        "observation.images.image": _visual(),
+        "observation.images.wrist_image": _visual(),
+    }
+    policy._output_features = {"action": _action(6)}
+    policy._loaded = True
+    return policy
+
+
+def _real_pipeline_bridge(policy):
+    """Attach a real (network-free) LeRobot rename+batch pipeline to ``policy``."""
+    pytest.importorskip("lerobot.processor.pipeline")
+    from lerobot.processor import AddBatchDimensionProcessorStep, RenameObservationsProcessorStep
+    from lerobot.processor.pipeline import DataProcessorPipeline
+
+    from strands_robots.policies.lerobot_local.processor import ProcessorBridge
+
+    pipe = DataProcessorPipeline(
+        steps=[RenameObservationsProcessorStep(rename_map={}), AddBatchDimensionProcessorStep()]
+    )
+    policy._processor_bridge = ProcessorBridge(preprocessor=pipe, device="cpu")
+    return policy._processor_bridge
+
+
+class TestRouteCameraKeyMapReplacesByTarget:
+    """The merge is scoped by rename TARGET, so one source feeds one feature."""
+
+    def test_an_entry_replaces_the_declared_source_for_its_feature(self):
+        base = {"front": "observation.images.image", "wrist": "observation.images.wrist_image"}
+        # 'front' and 'wrist' are dropped: two sources feeding one target would
+        # let whichever the pipeline renamed last win.
+        assert _route_camera_key_map(base, SCENE_MAP) == SCENE_MAP
+
+    def test_a_feature_no_entry_claims_keeps_its_declared_source(self):
+        base = {"front": "observation.images.image", "wrist": "observation.images.wrist_image"}
+        assert _route_camera_key_map(base, {"cam_top": "observation.images.image"}) == {
+            "wrist": "observation.images.wrist_image",
+            "cam_top": "observation.images.image",
+        }
+
+    def test_no_map_leaves_the_declared_renames_alone(self):
+        base = {"front": "observation.images.image"}
+        for empty in (None, {}):
+            assert _route_camera_key_map(base, empty) == base
+
+
+class TestPreflightHonorsCameraKeyMap:
+    """The pre-download check must not refuse a binding the caller supplied."""
+
+    def test_a_camera_key_map_satisfies_the_embodiment_image_features(self):
+        LerobotLocalPolicy.preflight(SCENE_CAMS | SO101_JOINTS, embodiment="so101", camera_key_map=SCENE_MAP)
+
+    def test_an_unbound_camera_is_still_refused(self):
+        # Over-reach control: routing rung 1 is honored, not assumed.
+        with pytest.raises(ValueError) as ei:
+            LerobotLocalPolicy.preflight(SCENE_CAMS | SO101_JOINTS, embodiment="so101")
+        assert "front" in str(ei.value) and "wrist" in str(ei.value)
+
+    def test_the_refusal_names_camera_key_map_as_a_remedy(self):
+        with pytest.raises(ValueError) as ei:
+            LerobotLocalPolicy.preflight(SCENE_CAMS | SO101_JOINTS, embodiment="so101")
+        msg = str(ei.value)
+        assert "camera_key_map" in msg
+        assert "obs_rename_override" in msg
+
+
+class TestConfiguredEmbodimentRoutesTheSceneCameras:
+    """The configured map, its canonicalization set, and the model's batch."""
+
+    def test_obs_rename_carries_the_caller_cameras(self):
+        policy = _so101_policy(camera_key_map=SCENE_MAP)
+        _real_pipeline_bridge(policy)
+        policy._configure_embodiment()
+        assert policy._embodiment.obs_rename == SCENE_MAP
+
+    def test_the_caller_cameras_are_canonicalized_as_frames(self):
+        # The rename runs INSIDE the pipeline, so canonicalization has to
+        # recognize the caller's bare source keys or the frames stay HWC uint8.
+        policy = _so101_policy(camera_key_map=SCENE_MAP)
+        _real_pipeline_bridge(policy)
+        policy._configure_embodiment()
+        assert policy._embodiment_image_source_keys() == SCENE_CAMS
+
+        obs = {"cam_top": np.full((48, 64, 3), 255, dtype=np.uint8)}
+        out = policy._canonicalize_obs_images(obs, image_source_keys=policy._embodiment_image_source_keys())
+        frame = out["cam_top"]
+        assert frame.dtype.is_floating_point  # was uint8
+        assert tuple(frame.shape) == (3, 48, 64)  # was HWC
+        assert float(frame.max()) <= 1.0
+
+    def test_a_real_pipeline_feeds_both_declared_image_features(self):
+        policy = _so101_policy(camera_key_map=SCENE_MAP)
+        bridge = _real_pipeline_bridge(policy)
+        policy._configure_embodiment()
+
+        obs = {name: float(i) for i, name in enumerate(load_embodiment("so101").state_keys)}
+        obs["cam_top"] = np.full((48, 64, 3), 255, dtype=np.uint8)
+        obs["cam_wrist"] = np.full((48, 64, 3), 128, dtype=np.uint8)
+        obs = policy._canonicalize_obs_images(obs, image_source_keys=policy._embodiment_image_source_keys())
+        batch = bridge.preprocess(obs, instruction="pick up the cube")
+
+        assert "observation.images.image" in batch
+        assert "observation.images.wrist_image" in batch
+        assert "cam_top" not in batch and "cam_wrist" not in batch
+        assert tuple(batch["observation.images.image"].shape) == (1, 3, 48, 64)
+        assert tuple(batch["observation.state"].shape) == (1, 6)
+
+    def test_an_undeclared_image_feature_is_refused_by_name(self):
+        # House convention for a bad map target: the other routers raise naming
+        # the feature, so validate must too rather than route it silently.
+        policy = _so101_policy(camera_key_map={"cam_top": "observation.images.nope"})
+        _real_pipeline_bridge(policy)
+        with pytest.raises((ValueError, RuntimeError), match="observation.images.nope"):
+            policy._configure_embodiment()
+
+
+class TestBindingsThatMustNotChange:
+    """Over-reach controls: what a caller had before still holds."""
+
+    def test_no_map_keeps_the_embodiment_declared_sources(self):
+        policy = _so101_policy()
+        _real_pipeline_bridge(policy)
+        policy._configure_embodiment()
+        assert policy._embodiment.obs_rename == {
+            "front": "observation.images.image",
+            "wrist": "observation.images.wrist_image",
+        }
+
+    def test_obs_rename_override_still_has_the_last_word(self):
+        # The override is applied after the map: it is the only spelling that
+        # can DROP a rename, so a caller relying on it keeps their exact map.
+        policy = _so101_policy(
+            camera_key_map=SCENE_MAP,
+            obs_rename_override={"cam_top": None, "front": "observation.images.image"},
+        )
+        _real_pipeline_bridge(policy)
+        policy._configure_embodiment()
+        assert policy._embodiment.obs_rename == {
+            "front": "observation.images.image",
+            "cam_wrist": "observation.images.wrist_image",
+        }


### PR DESCRIPTION
![routing](https://raw.githubusercontent.com/cagataycali/robots/db4c41db33874b38efbafbadef72eebb87dbf5c0/camera_key_map_embodiment.png)

## What
`camera_key_map` is routing rung 1 in the docs, and `_resolve_camera_targets`, `_to_lerobot_observation` and `_synthesized_camera_renames` all resolve it before any name match. The path taken when an `embodiment` **is** declared merged only `obs_rename_override`, so a scene whose cameras are named for the scene (`cam_top`) rather than for the embodiment (`front`) was refused by the pre-download check -- which named `obs_rename_override` as the remedy for a caller who had already bound the cameras -- and past that check reached the model with **no image input at all** (panel B).

## Why
The existing comment on the sibling router says the two routers "have to agree - the only difference between them is whether the checkpoint ships a preprocessor, which is not something a camera binding may depend on". Declaring an `embodiment` is not either.

`camera_key_map` now replaces the source key for each image feature it claims (by target, so one source feeds one feature), before `obs_rename_override` -- which stays last because a falsy value there is the only way to DROP a rename.

## Tests
New `test_camera_key_map_routes_a_declared_embodiment.py`: **9 failed / 3 passed on `main` -> 12 passed**, through a real network-free LeRobot rename+batch pipeline. The 3 pre-fix passes are over-reach controls (no map; an unbound camera still refused; declared sources kept). `ruff` + `mypy` clean (1987 files), `tests/policies` + graders 5768 passed, `mkdocs --strict` rc=0.