### PR TITLE
docs(AGENTS): py/mixed-returns does not model a pytest outcome's NoReturn, and the boundary is graded

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2606,6 +2606,59 @@ Corrections from code review that apply to all future contributions:
   runtime, the one shape where this exemption would suppress a true finding and
   the one direction `ruff` and `mypy` cannot report, since the cast string
   resolves either way.
+- **`py/mixed-returns` does not read a `NoReturn` it did not model, so a
+  test helper that returns a value on one path and ends in `pytest.fail(...)`
+  on the other is reported as falling through.** `pytest.fail`, `pytest.skip`,
+  `pytest.exit` and `pytest.xfail` are each declared `-> NoReturn` in
+  `_pytest/outcomes.py` - as the `__call__` of an outcome class, which is why
+  the analysis does not follow it - so the only way past that line is an
+  exception and the implicit `None` the alert describes cannot be produced.
+  The shape is the idiomatic one for a helper that searches and refuses:
+
+  ```python
+  def _self_calls(module: str, method: str) -> set[str]:
+      for node in ast.walk(tree):
+          if isinstance(node, ast.FunctionDef) and node.name == method:
+              return {...}
+      pytest.fail(f"{method} not found in {module}")
+  ```
+
+  Do not answer the alert by rewriting the helper. Run the counterfactual,
+  because the two cases need opposite actions and only one of them is a false
+  positive:
+
+  | `mypy` after replacing the outcome with a call that can return | meaning | action |
+  |---|---|---|
+  | `Missing return statement [return]` at the `def` | the fall-through exists only if the terminal call returns, and it cannot | dismiss as `false positive` |
+  | clean | the helper is `-> Any` or unannotated, so `mypy` is not reading its body at all | read the terminal call yourself |
+
+  Measured with the three helpers' own annotations: `-> dict[str, str]` and
+  `-> set[str]` report `[return]` on the counterfactual and are clean as
+  written, and `-> Any` reports nothing either way - `mypy` does not grade a
+  missing return against `Any`, and `[tool.mypy]` relaxes
+  `disallow_untyped_defs` for `tests.*` and `tests_integ.*`, so an unannotated
+  helper's body is not read there. `hatch run lint` runs `mypy` over both test
+  trees, so the first row is already inside `call-test-lint / Test and Lint`;
+  the second row is the hole. Do not reach for the query filter: the rule
+  carries live signal, since a helper ending in `print(...)` or a cleanup
+  call is exactly the defect it names, and `tests/test_codeql_query_filters.py`
+  pins the filter at two ids.
+
+  Three instances, one class, none adjudicated until the third held a merge:
+
+  | alert | site | terminal call | cost before it was adjudicated |
+  |---|---|---|---|
+  | 823 | `tests/simulation/test_recording_rate_matches_control_frequency.py` | `pytest.fail` | open on `main` for 45 days |
+  | 1140 | `tests/drivers/ur/test_ur_sim_joint_order_matches_the_wire.py` | `pytest.skip`, closing a `try` handler | open on `main` for 12 days, and `-> Any`, so in the second row |
+  | 1206 | `tests/mesh/test_mesh_guide_opening_block_starts_the_mesh.py` | `pytest.fail` | a review thread gated #3551 under `required_review_thread_resolution`; merged 8 seconds after the resolve |
+
+  `tests/test_mixed_return_helpers_end_in_a_pytest_outcome.py` grades the
+  boundary at every site whatever the annotation: it derives from the test
+  trees every function that returns a value and can fall off its end through a
+  bare call - the terminal statement, or the last statement of an `if`, `try`
+  or `with` branch it ends in - and refuses one whose call is not a declared
+  `NoReturn`. That is the one shape where this exemption would suppress a true
+  finding and the one `mypy` cannot report in a test.
 - **Dependency Review hard-fails on high/critical CVEs in new deps.** If a PR
   needs a dep with a known critical CVE, the conversation is "do we need this
   dep" not "let's bypass the check."

--- a/changelog.d/3556-mixed-returns-terminal-outcome-is-no-return.md
+++ b/changelog.d/3556-mixed-returns-terminal-outcome-is-no-return.md
@@ -1,0 +1,11 @@
+### Docs: a `py/mixed-returns` alert on a helper ending in a pytest outcome is a false positive, and the boundary is graded
+
+`pytest.fail`, `pytest.skip`, `pytest.exit` and `pytest.xfail` are declared
+`-> NoReturn`, so a test helper that returns a value on one path and ends in
+one of them on the other has no implicit return; CodeQL does not model the
+outcome and reported the shape three times, the third holding a merge.
+`AGENTS.md` records the counterfactual (`mypy` reports a missing return on an
+annotated helper once the outcome is replaced, and nothing for `-> Any` or an
+unannotated one), and
+`tests/test_mixed_return_helpers_end_in_a_pytest_outcome.py` refuses a helper
+whose terminal call can return, whatever its annotation.

--- a/tests/test_mixed_return_helpers_end_in_a_pytest_outcome.py
+++ b/tests/test_mixed_return_helpers_end_in_a_pytest_outcome.py
@@ -1,0 +1,291 @@
+"""A helper that mixes ``return <value>`` with a terminal ``pytest.fail(...)`` has no implicit return.
+
+CodeQL's ``py/mixed-returns`` reports a function that returns a value on some
+paths and falls off the end on another, because the fall-through returns
+``None``. Test helpers here end in a pytest *outcome* by design::
+
+    def _self_calls(module: str, method: str) -> set[str]:
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == method:
+                return {...}
+        pytest.fail(f"{method} not found in {module}")
+
+``pytest.fail``, ``pytest.skip``, ``pytest.exit`` and ``pytest.xfail`` are each
+declared ``-> NoReturn`` (``_pytest/outcomes.py``), as the ``__call__`` of an
+outcome class - which is why CodeQL's Python analysis does not model them. The
+only way past that line is an exception, so the ``None`` the alert describes
+cannot be produced. It has been reported three times - alerts 823
+(``tests/simulation/test_recording_rate_matches_control_frequency.py``,
+2026-07-29), 1140 (``tests/drivers/ur/test_ur_sim_joint_order_matches_the_wire.py``,
+2026-08-31) and 1206 (``tests/mesh/test_mesh_guide_opening_block_starts_the_mesh.py``,
+2026-09-12, whose review thread gated #3551 under
+``required_review_thread_resolution``) - and all three are false positives.
+``AGENTS.md`` records that adjudication so a fourth instance is read rather than
+re-derived.
+
+What this module grades is the precondition the adjudication rests on. ``mypy``
+grades the counterfactual for an annotated helper: replace the ``pytest.fail``
+with any call that can return and it reports ``Missing return statement
+[return]``. But that grader has two holes in the test trees, and one of the three
+adjudicated sites sits in one of them. A helper declared ``-> Any`` is not
+checked for a missing return at all, which is alert 1140's shape; and
+``[tool.mypy]`` relaxes ``disallow_untyped_defs`` for ``tests.*`` and
+``tests_integ.*``, so an unannotated helper's body is never read. In either
+shape a helper whose terminal call *can* return - ``print``, ``logger.warning``,
+a cleanup - is exactly the defect the query names, with nothing else to report
+it. So the exemption is not "a mixed-return helper in a test is fine" - it holds
+while the terminal call is one that cannot return, and that is the property
+asserted below, at every site and whatever the annotation.
+
+The population is derived from the tree rather than written down, so a helper
+added by a later change is graded on arrival and one that stops qualifying
+leaves without an edit here.
+"""
+
+from __future__ import annotations
+
+import ast
+import tomllib
+from pathlib import Path
+from typing import NamedTuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# The trees a pytest outcome can legitimately terminate a helper in. The
+# package is out of scope: it does not import pytest, and every function there
+# is annotated with a concrete return type, so ``mypy`` grades it without a hole.
+_TREES = ("tests", "tests_integ")
+
+# Callables declared ``-> NoReturn`` by their own module. The pytest four are
+# ``_pytest/outcomes.py``; ``sys.exit`` and ``os._exit`` are the interpreter's
+# and are the two CodeQL itself models.
+_NO_RETURN_CALLEES = frozenset(
+    {
+        ("pytest", "fail"),
+        ("pytest", "skip"),
+        ("pytest", "exit"),
+        ("pytest", "xfail"),
+        ("sys", "exit"),
+        ("os", "_exit"),
+    }
+)
+
+
+class _MixedReturnHelper(NamedTuple):
+    """One function that returns a value somewhere and ends in a bare call."""
+
+    path: str
+    name: str
+    line: int
+    terminal_call: str
+
+
+def _imported_callees(tree: ast.Module) -> dict[str, tuple[str, str]]:
+    """Map each module-level import alias to the ``(module, name)`` it binds.
+
+    ``import pytest`` binds ``pytest`` to the module; ``from pytest import fail``
+    and ``from pytest import fail as bail`` bind a callable directly, and both
+    spellings have to resolve to the same ``("pytest", "fail")`` key.
+    """
+    aliases: dict[str, tuple[str, str]] = {}
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                aliases[alias.asname or alias.name] = (alias.name, "")
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            for alias in node.names:
+                aliases[alias.asname or alias.name] = (node.module, alias.name)
+    return aliases
+
+
+def _callee_key(call: ast.Call, aliases: dict[str, tuple[str, str]]) -> tuple[str, str] | None:
+    """Resolve ``pytest.fail(...)`` and ``fail(...)`` to ``("pytest", "fail")``; ``None`` for anything else."""
+    func = call.func
+    if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+        module, name = aliases.get(func.value.id, (func.value.id, ""))
+        return (module, func.attr) if not name else None
+    if isinstance(func, ast.Name):
+        module, name = aliases.get(func.id, ("", ""))
+        return (module, name) if name else None
+    return None
+
+
+def _returns_a_value(function: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """Whether ``function``'s own body - not a nested def or lambda - has a ``return <expr>``."""
+    stack: list[ast.AST] = list(function.body)
+    while stack:
+        node = stack.pop()
+        if isinstance(node, ast.Return):
+            if node.value is not None:
+                return True
+            continue
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)):
+            continue
+        stack.extend(ast.iter_child_nodes(node))
+    return False
+
+
+def _call_tails(body: list[ast.stmt]) -> list[ast.Call]:
+    """The bare calls control can fall off the end of ``body`` through.
+
+    Walks the last statement only, because that is the one a fall-through
+    leaves by: a call there is a tail; a ``return`` or ``raise`` is not; an
+    ``if``, ``try`` or ``with`` is entered and its own last statements read the
+    same way. Alert 1140's shape is the ``try`` case - ``return`` inside the
+    body, ``pytest.skip(...)`` closing the handler. A branch that ends in
+    anything else (an assignment, a loop, an empty ``else``) is a *silent*
+    fall-through, which is a mixed return too but not one this exemption
+    covers, so it is left to the query rather than counted here.
+    """
+    if not body:
+        return []
+    last = body[-1]
+    if isinstance(last, ast.Expr) and isinstance(last.value, ast.Call):
+        return [last.value]
+    if isinstance(last, ast.If):
+        return _call_tails(last.body) + _call_tails(last.orelse)
+    if isinstance(last, ast.Try):
+        tails = _call_tails(last.orelse or last.body)
+        for handler in last.handlers:
+            tails += _call_tails(handler.body)
+        return tails
+    if isinstance(last, (ast.With, ast.AsyncWith)):
+        return _call_tails(last.body)
+    return []
+
+
+def _mixed_return_helpers(path: Path) -> list[tuple[_MixedReturnHelper, tuple[str, str] | None]]:
+    """Every function in ``path`` that returns a value and can fall off its end through a bare call.
+
+    That is the one shape of ``py/mixed-returns`` the adjudication exempts - a
+    fall-through whose last act is a call - so it is the one shape graded here,
+    one entry per such call.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    aliases = _imported_callees(tree)
+    found: list[tuple[_MixedReturnHelper, tuple[str, str] | None]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        tails = _call_tails(node.body)
+        if not tails or not _returns_a_value(node):
+            continue
+        for call in tails:
+            helper = _MixedReturnHelper(
+                path=str(path.relative_to(REPO_ROOT)),
+                name=node.name,
+                line=call.lineno,
+                terminal_call=ast.unparse(call.func),
+            )
+            found.append((helper, _callee_key(call, aliases)))
+    return found
+
+
+def _population() -> list[tuple[_MixedReturnHelper, tuple[str, str] | None]]:
+    """Every mixed-return helper ending in a call, across the trees pytest outcomes live in."""
+    return [
+        entry
+        for tree in _TREES
+        for path in sorted((REPO_ROOT / tree).rglob("*.py"))
+        for entry in _mixed_return_helpers(path)
+    ]
+
+
+class TestAMixedReturnHelperEndsInACallThatCannotReturn:
+    """The exemption's premise, asserted at every site regardless of annotation."""
+
+    def test_every_terminal_call_is_a_declared_no_return(self) -> None:
+        """A terminal call that can return is the implicit ``None`` the query names, and nothing else reports it."""
+        offenders = [
+            f"{helper.path}:{helper.line} {helper.name}() ends in {helper.terminal_call}(...)"
+            for helper, key in _population()
+            if key not in _NO_RETURN_CALLEES
+        ]
+        assert offenders == [], (
+            "a helper that returns a value elsewhere ends in a call that can return, "
+            "so the fall-through returns None; either return after it, raise, or end in a "
+            "pytest outcome (fail / skip / exit / xfail):\n  " + "\n  ".join(offenders)
+        )
+
+
+class TestTheClassifierReadsTheShapeItGrades:
+    """Controls on the AST read, so the sweep above cannot pass by finding nothing."""
+
+    @staticmethod
+    def _classify(source: str) -> list[tuple[str, tuple[str, str] | None]]:
+        tree = ast.parse(source)
+        aliases = _imported_callees(tree)
+        out: list[tuple[str, tuple[str, str] | None]] = []
+        for node in tree.body:
+            if isinstance(node, ast.FunctionDef) and _returns_a_value(node):
+                out.extend((node.name, _callee_key(call, aliases)) for call in _call_tails(node.body))
+        return out
+
+    def test_a_terminal_call_that_can_return_is_an_offender(self) -> None:
+        """``print`` is the query's finding, and the annotation does not excuse it - ``-> Any`` and none are the mypy holes."""
+        source = (
+            "from typing import Any\n"
+            "def typed(xs: list[str]) -> str:\n    for x in xs:\n        if x:\n            return x\n    print('none')\n"
+            "def any_typed(xs: list[str]) -> Any:\n    for x in xs:\n        if x:\n            return x\n    print('none')\n"
+            "def untyped(xs):\n    for x in xs:\n        if x:\n            return x\n    print('none')\n"
+        )
+        classified = self._classify(source)
+        assert [name for name, _ in classified] == ["typed", "any_typed", "untyped"]
+        assert all(key not in _NO_RETURN_CALLEES for _, key in classified)
+
+    def test_every_spelling_of_a_pytest_outcome_is_accepted(self) -> None:
+        """Attribute form, bare import and aliased import all resolve to the same declared ``NoReturn``."""
+        source = (
+            "import pytest\nimport sys\nfrom pytest import skip\nfrom pytest import fail as bail\n"
+            "def a(xs: list[str]) -> str:\n    for x in xs:\n        return x\n    pytest.fail('none')\n"
+            "def b(xs: list[str]) -> str:\n    for x in xs:\n        return x\n    skip('none')\n"
+            "def c(xs: list[str]) -> str:\n    for x in xs:\n        return x\n    bail('none')\n"
+            "def d(xs: list[str]) -> str:\n    for x in xs:\n        return x\n    sys.exit(1)\n"
+        )
+        keys = [key for _, key in self._classify(source)]
+        assert keys == [("pytest", "fail"), ("pytest", "skip"), ("pytest", "fail"), ("sys", "exit")]
+        assert all(key in _NO_RETURN_CALLEES for key in keys)
+
+    def test_a_handler_closing_in_an_outcome_is_the_try_shape(self) -> None:
+        """``return`` in the ``try`` body and ``pytest.skip`` closing the handler is alert 1140's shape; a ``print`` there is the defect."""
+        source = (
+            "import pytest\n"
+            "def skips(robot: str):\n    try:\n        return build(robot)\n"
+            "    except OSError as exc:\n        pytest.skip(str(exc))\n"
+            "def leaks(robot: str):\n    try:\n        return build(robot)\n"
+            "    except OSError as exc:\n        print(exc)\n"
+        )
+        assert self._classify(source) == [("skips", ("pytest", "skip")), ("leaks", None)]
+
+    def test_a_bare_return_or_a_nested_def_is_not_a_value_return(self) -> None:
+        """``return`` with no value is not mixed with a fall-through, and a nested function's return is its own."""
+        source = (
+            "def bare(xs: list[str]) -> None:\n    for x in xs:\n        return\n    print('none')\n"
+            "def nested(xs: list[str]) -> None:\n    def inner() -> int:\n        return 1\n    print(inner())\n"
+        )
+        assert self._classify(source) == []
+
+
+class TestThePopulationIsDerivedFromTheTree:
+    """The sweep reads the trees it names, and finds the idiom it grades."""
+
+    def test_every_named_tree_ships_python(self) -> None:
+        """A tree that stops shipping Python is a stale name here, not a silently empty walk."""
+        for tree in _TREES:
+            assert any((REPO_ROOT / tree).rglob("*.py")), f"{tree}/ ships no Python; drop it from _TREES"
+
+    def test_the_sweep_finds_the_idiom_it_grades(self) -> None:
+        """At least one helper in the tree ends in a pytest outcome - three did when this was written."""
+        accepted = [helper for helper, key in _population() if key in _NO_RETURN_CALLEES]
+        assert accepted, "no mixed-return helper ends in a pytest outcome; the sweep is reading the wrong shape"
+
+    def test_mypy_grades_the_annotated_half_inside_the_required_check(self) -> None:
+        """The counterfactual the adjudication cites is run by ``hatch run lint`` over both test trees."""
+        with (REPO_ROOT / "pyproject.toml").open("rb") as handle:
+            config = tomllib.load(handle)
+        lint = config["tool"]["hatch"]["envs"]["default"]["scripts"]["lint"]
+        mypy_steps = [step for step in lint if step.split()[0] == "mypy"]
+        assert mypy_steps, "lint no longer runs mypy, so nothing grades the counterfactual"
+        for tree in _TREES:
+            assert any(tree in step.split() for step in mypy_steps), f"mypy is not run over {tree}/"
+        assert config["tool"]["mypy"].get("warn_no_return", True) is True


### PR DESCRIPTION
**What**

An `AGENTS.md` entry under CI Security Baseline, beside the `py/unused-import` / `cast("X", ...)` one, recording how a `py/mixed-returns` alert on a test helper is adjudicated - and a grader, `tests/test_mixed_return_helpers_end_in_a_pytest_outcome.py`, that pins the boundary the adjudication rests on.

**Why**

A helper that returns a value on one path and ends in `pytest.fail(...)` on the other has no implicit return: `pytest.fail`, `pytest.skip`, `pytest.exit` and `pytest.xfail` are declared `-> NoReturn` in `_pytest/outcomes.py`, as the `__call__` of an outcome class, which is what the CodeQL Python analysis does not follow. The query has reported that shape three times and none was adjudicated until the third held a merge:

| alert | site | terminal call | cost |
|---|---|---|---|
| 823 | `tests/simulation/test_recording_rate_matches_control_frequency.py` | `pytest.fail` | open on `main` for 45 days |
| 1140 | `tests/drivers/ur/test_ur_sim_joint_order_matches_the_wire.py` | `pytest.skip`, closing a `try` handler | open on `main` for 12 days |
| 1206 | `tests/mesh/test_mesh_guide_opening_block_starts_the_mesh.py` | `pytest.fail` | review thread gated #3551 under `required_review_thread_resolution`; merged 8 s after the resolve |

The entry records the counterfactual rather than the query: replace the outcome with a call that can return and `mypy` reports `Missing return statement [return]` on an annotated helper, which is already inside `call-test-lint`. Measured, that grader has two holes in the test trees: `-> Any` (alert 1140's shape) is not graded for a missing return, and `[tool.mypy]` relaxes `disallow_untyped_defs` for `tests.*` / `tests_integ.*`, so an unannotated helper's body is not read. A helper ending in `print(...)` or a cleanup call in either shape is exactly the defect the query names, with nothing else to report it.

**The grader**

Derives from `tests/` and `tests_integ/` every function that returns a value and can fall off its end through a bare call - the terminal statement, or the last statement of an `if` / `try` / `with` branch it ends in - and refuses one whose call is not a declared `NoReturn` (the pytest four, `sys.exit`, `os._exit`). Whatever the annotation. Controls pin the classifier on synthetic sources: a `print` tail is an offender under a concrete, `Any` and absent annotation alike; every spelling of an outcome (`pytest.fail`, bare `skip`, aliased `fail as bail`, `sys.exit`) is accepted; the `try`-handler shape is read; a bare `return` or a nested def's return is not a value return. Non-vacuity asserts the sweep finds the idiom, and one cell pins that `hatch run lint` still runs `mypy` over both test trees, which is the first row of the counterfactual table.

Population on this tree: 5 sites, all five ending in a pytest outcome, 0 offenders - the three alerts above plus `tests/simulation/mujoco/test_concurrency.py::_read_first_frame_or_skip` and `tests_integ/groot/test_groot_integration.py::_find_server_script`. `scripts/check_whole_tree_graders.py` derives the new grader into its roster (139) without an edit.

**Verification**

- new grader: 8 passed
- `ruff check` / `ruff format --check` / `mypy` (pyproject config) on the new file: clean
- graders that read `AGENTS.md` or the test tree: `test_codeql_query_filters`, `test_cast_string_imports_are_the_names_only_binding`, `test_changelog_fragments`, `test_test_case_names_describe_behaviour`, `test_no_host_paths`, `test_on_disk_text_io_states_utf8`, `test_docstring_xref_roles_resolve`, `test_except_tuples_state_their_real_scope`, `test_sys_modules_removal_leaves_no_orphan`: 172 passed
- intake: `check_merge_base_overlap.py --paths` reports no behaviour-bearing overlap; `AGENTS.md` shared as prose with #3343 only

Alerts 823 and 1140 are dismissed as `false positive` with a pointer at this entry; 1206 was dismissed the same way on #3551.

No behaviour change. Docs and a test only.