### PR TITLE
fix(mesh/iot): a shadow-topic segment must be a single MQTT topic level

### DIFF
--- a/changelog.d/3557-shadow-topic-segment-is-one-mqtt-level.md
+++ b/changelog.d/3557-shadow-topic-segment-is-one-mqtt-level.md
@@ -1,0 +1,17 @@
+### Fixed: a shadow-topic segment that is not a single MQTT topic level is refused
+
+`init_mesh` refuses `/`, `+` and `#` in a `peer_id` because "these break MQTT
+topic structure and AWS Thing-name rules", but the Device Shadow mirror - the
+one surface that puts that identifier on a topic - interpolated it and
+`shadow_name` raw into the reserved 7-level
+`$aws/things/{thing}/shadow/name/{shadow}/update`. A slash smuggled an extra
+level, so the topic named a different Thing and no longer matched the reserved
+pattern the broker accepts; `+` and `#` are wildcards a publish topic may not
+carry; an empty name left an empty level. None of it surfaced, because
+`ShadowMirror.update` is best-effort and swallows what the transport says - so
+the named shadow that late-joining operators read for fleet state was simply
+never written, and every call reported nothing wrong. `shadow_update_topic`,
+`shadow_get_topic` and `ShadowMirror` now hold both names to the shared
+mesh-identifier domain under their own names. That domain is a superset of what
+`init_mesh` admits, so no identifier a live mesh accepted - a dotted `peer_id`
+included - is refused here.

--- a/strands_robots/mesh/iot/shadow.py
+++ b/strands_robots/mesh/iot/shadow.py
@@ -35,19 +35,88 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from strands_robots.mesh.security import validate_mesh_identifier
+
 logger = logging.getLogger(__name__)
+
+
+def _validate_topic_segments(context: str, thing_name: Any, shadow_name: Any) -> None:
+    """Refuse a shadow-topic segment that is not a single MQTT topic level.
+
+    Both values are interpolated into a reserved ``$aws/things/...`` topic, so
+    each must be ONE topic level. They are graded on the shared mesh-identifier
+    domain (:func:`~strands_robots.mesh.security.validate_mesh_identifier`) -
+    the same charset :func:`~strands_robots.mesh.core.init_mesh` already
+    requires of a ``peer_id``, and for the same stated reason: ``/``, ``+`` and
+    ``#`` break MQTT topic structure. A ``/`` smuggles an extra level, so the
+    topic names a different Thing than the caller asked for and no longer
+    matches the 7-level reserved pattern the broker accepts; ``+`` and ``#``
+    are wildcards, which a publish topic may not carry at all; and an empty
+    segment leaves an empty level.
+
+    None of those reach the shadow as an error the caller can see, because
+    :meth:`ShadowMirror.update` is best-effort and swallows what the transport
+    says (see its ``logger.debug``). The named shadow an operator reads for
+    fleet state is then simply never written, which is why the refusal belongs
+    at the surface that builds the topic rather than at the publish.
+
+    The domain is the SUPERSET of what ``init_mesh`` accepts, so every
+    ``peer_id`` that reached a live mesh - including a dotted one - is accepted
+    here; this cannot refuse an identifier the mesh already admitted. It is
+    deliberately NOT the stricter Thing-name rule the provisioning path applies
+    (which additionally rejects ``.`` for filesystem-path safety, because it
+    also names a certificate file): a topic segment is not a path component,
+    and refusing ``rover.01`` here would refuse a peer the mesh admitted.
+
+    Args:
+        context: The surface that received the values, used verbatim as the
+            message prefix - the function name, or the class name for a
+            constructor parameter.
+        thing_name: Candidate AWS IoT Thing name (topic level 2).
+        shadow_name: Candidate named-shadow name (topic level 5).
+
+    Raises:
+        ValidationError: Either value is not a single usable topic level.
+    """
+    validate_mesh_identifier(thing_name, f"{context}.thing_name")
+    validate_mesh_identifier(shadow_name, f"{context}.shadow_name")
 
 
 def shadow_update_topic(thing_name: str, shadow_name: str = "presence") -> str:
     """The MQTT topic that triggers an IoT named-shadow update.
 
     AWS IoT uses ``$aws/things/{thing}/shadow/name/{shadow}/update``.
+
+    Args:
+        thing_name: The AWS IoT Thing name. Must be a single topic level
+            (:func:`~strands_robots.mesh.security.validate_mesh_identifier`).
+        shadow_name: The named shadow to update. Must be a single topic level.
+
+    Returns:
+        The reserved update topic for that Thing and shadow.
+
+    Raises:
+        ValidationError: Either name is not a single usable topic level.
     """
+    _validate_topic_segments("shadow_update_topic", thing_name, shadow_name)
     return f"$aws/things/{thing_name}/shadow/name/{shadow_name}/update"
 
 
 def shadow_get_topic(thing_name: str, shadow_name: str = "presence") -> str:
-    """The topic that triggers an IoT named-shadow GET reply."""
+    """The topic that triggers an IoT named-shadow GET reply.
+
+    Args:
+        thing_name: The AWS IoT Thing name. Must be a single topic level
+            (:func:`~strands_robots.mesh.security.validate_mesh_identifier`).
+        shadow_name: The named shadow to read. Must be a single topic level.
+
+    Returns:
+        The reserved get topic for that Thing and shadow.
+
+    Raises:
+        ValidationError: Either name is not a single usable topic level.
+    """
+    _validate_topic_segments("shadow_get_topic", thing_name, shadow_name)
     return f"$aws/things/{thing_name}/shadow/name/{shadow_name}/get"
 
 
@@ -68,6 +137,24 @@ class ShadowMirror:
     """
 
     def __init__(self, thing_name: str, shadow_name: str = "presence") -> None:
+        """Bind a mirror to one Thing's named shadow.
+
+        Args:
+            thing_name: The AWS IoT Thing name - normally the mesh
+                ``peer_id``. Must be a single topic level
+                (:func:`~strands_robots.mesh.security.validate_mesh_identifier`).
+            shadow_name: The named shadow to mirror into. Must be a single
+                topic level.
+
+        Raises:
+            ValidationError: Either name is not a single usable topic level.
+        """
+        # Named here rather than left to `shadow_update_topic` below so the
+        # refusal names the call the caller actually made. The refusal precedes
+        # the assignments: a mirror that cannot address a shadow must not exist
+        # holding a topic `update` would publish and then swallow the rejection
+        # of.
+        _validate_topic_segments(type(self).__name__, thing_name, shadow_name)
         self.thing_name = thing_name
         self.shadow_name = shadow_name
         self._update_topic = shadow_update_topic(thing_name, shadow_name)

--- a/strands_robots/mesh/security.py
+++ b/strands_robots/mesh/security.py
@@ -1050,6 +1050,14 @@ def validate_mesh_identifier(value: Any, param: str) -> str:
     :class:`~strands_robots.mesh.core.Mesh` interpolates into
     ``strands/{sender_id}/response/{responder}/{turn_id}`` to answer it.
 
+    The same contract covers a segment interpolated into an AWS IoT reserved
+    MQTT topic - the ``thing_name`` and ``shadow_name`` of
+    :func:`~strands_robots.mesh.iot.shadow.shadow_update_topic`. MQTT spells
+    its wildcards ``+`` and ``#`` rather than ``*``, and reserves ``/`` as the
+    level separator, so the charset below excludes all three for the reason
+    :func:`~strands_robots.mesh.core.init_mesh` already gives when it refuses
+    them in a ``peer_id``: they break MQTT topic structure.
+
     Zenoh treats ``*`` and ``**`` as key-expression wildcards, so an
     unvalidated segment silently widens a point-to-point subscription into a
     match-any one: a receiver built with ``source_peer_id="**"`` subscribes to

--- a/tests/mesh/test_shadow_topic_segments_are_single_mqtt_levels.py
+++ b/tests/mesh/test_shadow_topic_segments_are_single_mqtt_levels.py
@@ -1,0 +1,135 @@
+"""A shadow-topic segment that is not a single MQTT topic level is refused.
+
+``$aws/things/{thing}/shadow/name/{shadow}/update`` is a reserved 7-level AWS
+IoT topic, so each interpolated name must be exactly ONE level.
+:func:`~strands_robots.mesh.core.init_mesh` already refuses ``/``, ``+`` and
+``#`` in a ``peer_id`` and says why - "these break MQTT topic structure and AWS
+Thing-name rules" - but the shadow mirror, the one surface that actually puts
+that identifier on a topic, interpolated it and ``shadow_name`` raw.
+
+Nothing downstream reports the mistake: :meth:`ShadowMirror.update` is
+best-effort and swallows whatever the transport says, so a malformed topic is
+published, rejected by the broker, and logged at debug. The named shadow that
+late-joining operators read for fleet state is then never written and every
+call reports nothing wrong - which is why the refusal belongs where the topic is
+built.
+
+The domain is the shared mesh-identifier one, a SUPERSET of what ``init_mesh``
+admits, so this cannot refuse an identifier the mesh already accepted.
+"""
+
+from __future__ import annotations
+
+import string
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from strands_robots.mesh.iot.shadow import (
+    ShadowMirror,
+    shadow_get_topic,
+    shadow_update_topic,
+)
+from strands_robots.mesh.security import MAX_PEER_ID_LEN, ValidationError
+
+#: Every character class ``init_mesh``'s own refusal names as allowed in a
+#: ``peer_id`` ("[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}"). A peer_id it admitted
+#: reaches :func:`ShadowMirror` as ``thing_name``, so each must address a shadow.
+INIT_MESH_ALLOWED_CHARS = string.ascii_letters + string.digits + "._-"
+
+#: The three surfaces that turn a pair of names into a reserved topic. Each is
+#: called with ``(thing_name, shadow_name)`` and must refuse the same domain
+#: under its own name, so a refusal identifies the call the caller made.
+SURFACES: tuple[tuple[str, Any], ...] = (
+    ("shadow_update_topic", shadow_update_topic),
+    ("shadow_get_topic", shadow_get_topic),
+    ("ShadowMirror", ShadowMirror),
+)
+
+#: Segments that cannot be honored as written, with what each would have done.
+BAD_SEGMENTS: tuple[tuple[str, str], ...] = (
+    ("fleet/rover-01", "a slash smuggles a level: the topic names Thing 'fleet'"),
+    ("+", "the MQTT single-level wildcard, illegal in a publish topic"),
+    ("#", "the MQTT multi-level wildcard, illegal in a publish topic"),
+    ("", "an empty segment leaves an empty topic level"),
+    ("rover 01", "whitespace"),
+    ("rover\x0001", "a NUL"),
+    ("*", "a Zenoh wildcard, which the bridge backend also routes by intersection"),
+    ("a" * (MAX_PEER_ID_LEN + 1), "longer than one addressable segment"),
+)
+
+
+class TestASegmentThatIsNotOneTopicLevelIsRefused:
+    @pytest.mark.parametrize("surface,build", SURFACES, ids=[s for s, _ in SURFACES])
+    @pytest.mark.parametrize("segment,why", BAD_SEGMENTS, ids=[s[:12] or "empty" for s, _ in BAD_SEGMENTS])
+    def test_thing_name_is_refused(self, surface: str, build: Any, segment: str, why: str) -> None:
+        with pytest.raises(ValidationError) as excinfo:
+            build(segment, "presence")
+        assert f"{surface}.thing_name" in str(excinfo.value), why
+
+    @pytest.mark.parametrize("surface,build", SURFACES, ids=[s for s, _ in SURFACES])
+    @pytest.mark.parametrize("segment,why", BAD_SEGMENTS, ids=[s[:12] or "empty" for s, _ in BAD_SEGMENTS])
+    def test_shadow_name_is_refused(self, surface: str, build: Any, segment: str, why: str) -> None:
+        with pytest.raises(ValidationError) as excinfo:
+            build("rover-01", segment)
+        assert f"{surface}.shadow_name" in str(excinfo.value), why
+
+    @pytest.mark.parametrize("surface,build", SURFACES, ids=[s for s, _ in SURFACES])
+    def test_a_non_string_is_refused_before_it_is_formatted_into_a_topic(self, surface: str, build: Any) -> None:
+        """``None`` interpolated raw addresses a Thing literally named 'None'."""
+        with pytest.raises(ValidationError, match=f"{surface}.thing_name must be a string"):
+            build(None, "presence")
+
+
+class TestTheShippedTopicsAreUnchanged:
+    """The refusal is the only new behaviour: every honorable pair still builds."""
+
+    def test_update_and_get_topics(self) -> None:
+        assert shadow_update_topic("rover-01") == "$aws/things/rover-01/shadow/name/presence/update"
+        assert shadow_update_topic("rover-01", "task") == "$aws/things/rover-01/shadow/name/task/update"
+        assert shadow_get_topic("rover-01") == "$aws/things/rover-01/shadow/name/presence/get"
+        transport = MagicMock()
+        transport.is_alive = MagicMock(return_value=True)
+        ShadowMirror("rover-01", "health").update(transport, {"connected": True})
+        assert transport.put.call_args.args[0] == "$aws/things/rover-01/shadow/name/health/update"
+
+    def test_a_valid_mirror_still_publishes_and_still_swallows_a_transport_error(self) -> None:
+        """``update`` stays best-effort for a topic that IS addressable."""
+        transport = MagicMock()
+        transport.is_alive = MagicMock(return_value=True)
+        transport.put.side_effect = RuntimeError("network")
+        ShadowMirror("rover-01").update(transport, {"connected": True})
+        assert transport.put.call_count == 1
+
+
+class TestNoIdentifierTheMeshAdmittedIsRefused:
+    """The new domain is a superset of ``init_mesh``'s, so it cannot over-refuse."""
+
+    @pytest.mark.parametrize("char", list(INIT_MESH_ALLOWED_CHARS), ids=lambda c: f"char-{ord(c)}")
+    def test_every_character_init_mesh_allows_in_a_peer_id_addresses_a_shadow(self, char: str) -> None:
+        thing = f"r{char}"
+        assert shadow_update_topic(thing) == f"$aws/things/{thing}/shadow/name/presence/update"
+
+    def test_a_dotted_peer_id_is_accepted_though_the_thing_name_rule_would_refuse_it(self) -> None:
+        """The provisioning Thing-name rule rejects ``.`` for filesystem-path
+        safety because it also names a certificate file. A topic segment is not
+        a path component, and ``init_mesh`` admits a dotted ``peer_id``, so
+        borrowing that stricter rule here would refuse a live peer.
+        """
+        assert ShadowMirror("rover.01").thing_name == "rover.01"
+
+    def test_the_longest_peer_id_init_mesh_accepts_is_accepted(self) -> None:
+        assert shadow_update_topic("a" * MAX_PEER_ID_LEN).count("/") == 6
+
+
+class TestARefusedMirrorNeverExistsToPublishWith:
+    def test_construction_refuses_before_any_topic_is_held(self) -> None:
+        """A mirror holding an unaddressable topic would publish it once per
+        heartbeat and swallow every rejection, so it must not be constructible.
+        """
+        transport = MagicMock()
+        transport.is_alive = MagicMock(return_value=True)
+        with pytest.raises(ValidationError):
+            ShadowMirror("fleet/rover-01").update(transport, {"connected": True})
+        transport.put.assert_not_called()


### PR DESCRIPTION
![shadow topic levels](https://raw.githubusercontent.com/cagataycali/robots/71c5641f2f1a4f9a4fa4ba18e94ff7ceb62a3dfc/shadow_topic.png)

## What
`shadow_update_topic`, `shadow_get_topic` and `ShadowMirror` now hold `thing_name` and `shadow_name` to the shared mesh-identifier domain, each under its own name.

## Why
`init_mesh` already refuses `/`, `+` and `#` in a `peer_id` because "these break MQTT topic structure and AWS Thing-name rules" - but the shadow mirror, the one surface that puts that identifier on a topic, interpolated it and `shadow_name` raw into the reserved 7-level `$aws/things/{thing}/shadow/name/{shadow}/update`. A slash smuggles a level, so the topic names Thing `fleet` rather than `fleet/rover-01`; `+`/`#` are wildcards a publish topic may not carry; an empty name leaves an empty level. `ShadowMirror.update` is best-effort and swallows what the transport says, so all 9 measured cases published and the caller saw nothing - the named shadow operators read for fleet state simply never written.

The domain is a superset of what `init_mesh` admits, so no identifier a live mesh accepted (a dotted `peer_id` included) is refused; deliberately not the stricter provisioning Thing-name rule, which rejects `.` for certificate-path safety.

## Tests
`tests/mesh/test_shadow_topic_segments_are_single_mqtt_levels.py`: 52 failed / 69 passed pre-fix, 121 passed after. Covers both parameters across all three surfaces, plus the no-over-refusal property (every character `init_mesh` allows still addresses a shadow) and the unchanged best-effort publish. `tests/mesh/` 5129 passed, ruff + mypy clean.

LOC: +248 / -1 (135 test, 89 source, 17 changelog, 8 docstring).