### PR TITLE
fix(mesh/transport): only a pointer topic gets the camera-frame drop exemption

### DIFF
--- a/changelog.d/3558-camera-ref-exemption-matches-the-topic-shape.md
+++ b/changelog.d/3558-camera-ref-exemption-matches-the-topic-shape.md
@@ -1,0 +1,17 @@
+### Fixed: only a pointer topic gets the camera-frame drop exemption
+
+The IoT transport drops `camera/` topics because a base64 JPEG frame does not
+belong on MQTT, and exempts the small `camera/<cam>/ref` pointer that tells a
+cloud subscriber the S3 key. The exemption was decided by sniffing substrings -
+`topic.endswith("/ref") and "/camera/" in topic` - and a camera name is a free
+string from the robot's own `config.cameras`, so a camera named `ref` published
+its inline frame on `strands/<peer>/camera/ref`, which reads as a pointer: an
+81 KB envelope reached the MQTT client past both the drop rule and MQTT's
+128 KB cap, and the bridge republished it to the WAN. A `ref` tail under any
+other family (`input/camera/ref`, `hand/camera/ref` - the 50 Hz LAN-only
+topics) was exempted the same way. The exemption is now granted on the topic's
+shape: the family segment must be `camera` and a camera name must sit between
+it and the `ref` tail. A multi-segment camera name (`camera/front/left/ref`)
+keeps its exemption, so no real pointer is refused. The bridge leg calls the
+transport's own predicate instead of keeping a second copy of the rule, so the
+two legs cannot drift on which topics are pointers.

--- a/strands_robots/mesh/transport/bridge_transport.py
+++ b/strands_robots/mesh/transport/bridge_transport.py
@@ -51,6 +51,8 @@ import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+from strands_robots.mesh.transport.iot_transport import _is_camera_ref
+
 if TYPE_CHECKING:
     from strands_robots.mesh.transport.iot_transport import IotMqttTransport
     from strands_robots.mesh.transport.zenoh_transport import ZenohTransport
@@ -214,8 +216,11 @@ def _should_bridge(
     # Camera S3-reference metadata (``camera/<cam>/ref``) is a small pointer to
     # an offloaded frame, not the frame itself. It must reach cloud subscribers
     # so they learn the S3 key, so it bridges regardless of the suffix filter
-    # (raw ``camera/<cam>`` frame topics still stay LAN-only).
-    if suffix.startswith("camera/") and suffix.endswith("/ref"):
+    # (raw ``camera/<cam>`` frame topics still stay LAN-only). The shape test is
+    # the transport's own, so the two legs cannot drift on which topics are
+    # pointers -- an exemption granted here but not there (or the reverse) is a
+    # frame on the WAN or a pointer that never arrives.
+    if _is_camera_ref(topic):
         return True
 
     # Exact match -- fast path.

--- a/strands_robots/mesh/transport/iot_transport.py
+++ b/strands_robots/mesh/transport/iot_transport.py
@@ -265,8 +265,24 @@ def _is_camera_ref(topic: str) -> bool:
     hundred bytes. It is exactly the pointer a cloud subscriber needs to fetch
     the offloaded frame, so it MUST traverse MQTT even though its topic sits
     under the otherwise-dropped ``camera/`` prefix.
+
+    The exemption is granted on the topic's SHAPE, not on substrings of it: the
+    family segment must itself be ``camera``, and a camera name must sit between
+    it and the ``ref`` tail. A camera name is a free string taken from the
+    robot's own ``config.cameras`` keys, so a substring test hands the exemption
+    to topics that carry a frame rather than a pointer -- a camera named ``ref``
+    publishes its inline base64 JPEG on ``strands/<peer>/camera/ref``, and a
+    ``ref`` tail under any other family (``input/camera/ref``) reads as a
+    pointer too. Both are the WAN payload the drop rule exists to refuse, and
+    letting one through inflates broker billing exactly the way the tail-append
+    match in :func:`~strands_robots.mesh.transport.bridge_transport._should_bridge`
+    already refuses to.
+
+    A multi-segment camera name keeps its exemption: the tail is matched, not
+    the segment count, so ``camera/front/left/ref`` is still a pointer.
     """
-    return topic.startswith("strands/") and topic.endswith("/ref") and "/camera/" in topic
+    parts = topic.split("/")
+    return len(parts) >= 5 and parts[0] == "strands" and parts[2] == "camera" and parts[-1] == "ref"
 
 
 def _should_drop(topic: str) -> bool:

--- a/tests/mesh/test_iot_camera_ref_delivery.py
+++ b/tests/mesh/test_iot_camera_ref_delivery.py
@@ -10,10 +10,18 @@ offload cost was paid with nothing on the receiving end.
 These tests pin the exact split: raw ``camera/<cam>`` frames stay off MQTT, while
 ``camera/<cam>/ref`` pointers are delivered on both the pure-iot and bridge
 backends.
+
+The split is decided from the topic's SHAPE, and both legs decide it the same
+way. A camera name is a free string from the robot's ``config.cameras``, so a
+substring test for the exemption reads a frame topic as a pointer whenever the
+name collides with the tail: a camera named ``ref`` published its whole inline
+base64 JPEG on ``strands/<peer>/camera/ref``, straight past the drop rule that
+exists to keep that payload off the WAN.
 """
 
 from __future__ import annotations
 
+import base64
 import json
 from typing import Any
 
@@ -29,6 +37,9 @@ from strands_robots.mesh.transport.iot_transport import (
 
 REF_TOPIC = "strands/thor-arm/camera/wrist/ref"
 FRAME_TOPIC = "strands/thor-arm/camera/wrist"
+# The frame topic of a camera named ``ref``: an inline base64 JPEG on a topic
+# whose tail is the pointer marker, with no camera name in front of it.
+COLLIDING_FRAME_TOPIC = "strands/thor-arm/camera/ref"
 
 
 class TestCameraRefRoutingHelpers:
@@ -84,6 +95,66 @@ class TestCameraRefReachesTheWire:
         t = self._connected_transport()
         t.put(FRAME_TOPIC, {"blob": "x" * 1000})
         assert t._client.published == []
+
+    def test_a_camera_named_ref_publishes_nothing(self):
+        """A frame is a frame whatever the camera is called."""
+        t = self._connected_transport()
+        # The envelope Mesh._encode_and_publish_frames builds: a base64 JPEG,
+        # well past MQTT's 128 KB cap once the transport wraps it.
+        frame = {
+            "peer_id": "thor-arm",
+            "cam": "ref",
+            "shape": [480, 640, 3],
+            "encoding": "jpeg",
+            "data": base64.b64encode(b"\xff\xd8\xff" + b"\x00" * 61_000).decode("ascii"),
+        }
+        assert len(json.dumps(frame).encode()) > 80_000  # this is a frame, not a pointer
+        t.put(COLLIDING_FRAME_TOPIC, frame)
+        assert t._client.published == []
+
+
+class TestOnlyAPointerGetsThePointerExemption:
+    """The exemption follows the topic shape, not a substring of it.
+
+    ``camera/<cam>/ref`` is a pointer; a ``ref`` tail reached any other way is
+    a payload the drop rule refuses. Delivering one is the cloud-pollution
+    shape ``_should_bridge`` already refuses for tail-appended topics.
+    """
+
+    @pytest.mark.parametrize(
+        "topic, why",
+        [
+            (COLLIDING_FRAME_TOPIC, "a camera named 'ref' - the frame itself, not a pointer"),
+            ("strands/thor-arm/input/camera/ref", "teleop input, LAN-only at 50 Hz"),
+            ("strands/thor-arm/hand/camera/ref", "hand control, LAN-only at 50 Hz"),
+            ("strands/thor-arm/state/camera/ref", "a state topic that merely names a camera"),
+        ],
+    )
+    def test_a_ref_tail_outside_the_camera_family_is_not_a_pointer(self, topic, why):
+        assert _is_camera_ref(topic) is False, why
+
+    @pytest.mark.parametrize(
+        "topic",
+        [
+            REF_TOPIC,
+            "strands/thor-arm/camera/front/left/ref",  # multi-segment camera name
+        ],
+    )
+    def test_a_real_pointer_keeps_its_exemption(self, topic):
+        assert _is_camera_ref(topic) is True
+        assert _should_drop(topic) is False
+        assert _qos_and_retain_for(topic)[0] >= 0
+
+    def test_the_colliding_frame_topic_is_dropped_by_both_gates(self):
+        assert _should_drop(COLLIDING_FRAME_TOPIC) is True
+        assert _qos_and_retain_for(COLLIDING_FRAME_TOPIC)[0] < 0
+
+    @pytest.mark.parametrize("topic", [REF_TOPIC, FRAME_TOPIC, COLLIDING_FRAME_TOPIC])
+    def test_the_bridge_leg_and_the_mqtt_leg_agree_on_what_a_pointer_is(self, topic):
+        # A filter that excludes camera entirely, so bridging can only come
+        # from the pointer exemption.
+        suffixes = frozenset({"presence"})
+        assert _should_bridge(topic, suffixes) is _is_camera_ref(topic)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
![camera-ref routing, measured before/after](https://raw.githubusercontent.com/cagataycali/robots/35e352ea48cb75cd9b798933292174992259c66f/camref_routing.png)

## What

The IoT transport drops `camera/` topics because a base64 JPEG frame does not belong on MQTT, and exempts the small `camera/<cam>/ref` pointer carrying the S3 key. The exemption sniffed substrings: `topic.endswith("/ref") and "/camera/" in topic`.

A camera name is a free string from the robot's own `config.cameras`. A camera named `ref` publishes its inline frame on `strands/<peer>/camera/ref`, which reads as a pointer, so **81,461 bytes reached the MQTT client** past the drop rule and the bridge republished it. A `ref` tail under the 50 Hz LAN-only `input/` and `hand/` families was exempted the same way.

## Why

That is the cloud-pollution shape `_should_bridge` already refuses for tail-appended topics. The exemption is now granted on the topic's shape: the family segment must be `camera`, with a camera name between it and the `ref` tail. A multi-segment camera name (`camera/front/left/ref`) keeps its exemption, so no real pointer is refused. The bridge leg calls the transport's own predicate instead of keeping a second copy of the rule.

## Tests

`tests/mesh/test_iot_camera_ref_delivery.py` gains the shape table, a both-legs-agree pin, and a wire cell asserting an 81 KB frame on a colliding topic publishes nothing: **6 fail on `main`, 17 pass after**. Non-regression cells (a real pointer, a multi-segment camera name) pass either way. `tests/mesh/` 5,129 passed / 11 skipped; ruff + `mypy` clean on 1,989 files.

+112 / -3.