### PR TITLE
fix(hardware_robot): a camera's name is a bare token at every door that accepts one

### DIFF
--- a/changelog.d/3559-camera-name-bare-token.md
+++ b/changelog.d/3559-camera-name-bare-token.md
@@ -1,0 +1,19 @@
+### Fixed: a camera's name is held to one alphabet at every door that accepts one
+
+`Robot(cameras={...})` validated every option of a camera entry and never the
+name it was keyed under, while `lerobot_teleoperate` refused a `robot_cameras`
+name that is not a bare token. The name is what every consumer keys the camera's
+frames by, so the ten names measured as accepted by the factory each land as
+structure somewhere downstream: `Mesh` publishes frames on
+`strands/<peer_id>/camera/<name>`, where `/` adds a topic level and `*` is a
+Zenoh wildcard a `put` is routed by; `CameraOffloader.s3_key_for` joins the name
+into the object key, where `..` walks out of the peer's prefix; and a recording
+writes it as the `observation.images.<name>` dataset feature key. A camera named
+`wrist/ref` published its 274054-byte inline frame on
+`strands/rover-01/camera/wrist/ref` - the shape of the small S3 pointer the IoT
+transport exempts from its camera-frame drop - so the whole frame reached the
+broker that drop exists to spare.
+
+The rule now has one owner, `utils.camera_token_error`, which both doors read:
+letters, digits, `_` and `-`, opening on a letter or a digit. A name every
+consumer can carry is unaffected.

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -62,6 +62,7 @@ from strands_robots.teleop_mixin import TeleopMixin, _stop_reported_stopped
 from strands_robots.tools._command_gate import gate_motion
 from strands_robots.utils import (
     boolean_flag_error,
+    camera_token_error,
     dds_domain_id_error,
     positive_count_error,
     positive_finite_number_error,
@@ -357,14 +358,22 @@ def _build_camera_config(camera_name: str, config: Any) -> Any:
         names, ready for ``lerobot.cameras.make_cameras_from_configs``.
 
     Raises:
-        ValueError: If ``config`` is not a mapping, names a camera ``type``
-            lerobot does not register, carries a key that is not a declared
-            field of the resolved class, omits a field that has no default, or
-            holds a value lerobot's own config validation refuses. An unknown
-            key is refused rather than dropped per AGENTS.md > Review Learnings
-            (#86): a silently discarded option reports success while the camera
-            streams at the default.
+        ValueError: If ``camera_name`` is not a bare token
+            (:func:`~strands_robots.utils.camera_token_error`), or if ``config``
+            is not a mapping, names a camera ``type`` lerobot does not register,
+            carries a key that is not a declared field of the resolved class,
+            omits a field that has no default, or holds a value lerobot's own
+            config validation refuses. An unknown key is refused rather than
+            dropped per AGENTS.md > Review Learnings (#86): a silently discarded
+            option reports success while the camera streams at the default.
     """
+    # The name is graded before the options because it is what every consumer
+    # keys this camera's frames by -- a mesh topic level, an S3 object key, a
+    # dataset feature key -- so no option is worth checking under a name none of
+    # them can carry. ``lerobot_teleoperate`` holds its ``robot_cameras`` to the
+    # same rule at the same point, through the same owner.
+    if (name_err := camera_token_error("Robot(cameras=...)", "camera name", camera_name)) is not None:
+        raise ValueError(name_err)
     if not isinstance(config, Mapping):
         raise ValueError(
             f"Camera {camera_name!r} config must be a mapping of option name to value, "
@@ -642,6 +651,14 @@ class Robot(TeleopMixin, AgentTool):
             robot: LeRobot Robot instance, RobotConfig, or robot type string
             cameras: Camera configuration dict:
                 {"wrist": {"type": "opencv", "index_or_path": "/dev/video0", "fps": 30}}
+                Each key names one camera and must be a bare token of letters,
+                digits, ``_`` or ``-``: it is the identity every consumer keys
+                that camera's frames by - a level of the mesh topic they are
+                published on, a segment of the S3 key they are offloaded to, and
+                the ``observation.images.<name>`` feature key a recording writes
+                them under - so a name carrying punctuation any of those reserves
+                is refused here
+                (:func:`~strands_robots.utils.camera_token_error`).
             action_horizon: Actions consumed from each inferred policy chunk
                 before re-querying. Must be a positive integer - it is a lower
                 bound on the chunk slice the task loop applies

--- a/strands_robots/mesh/transport/iot_transport.py
+++ b/strands_robots/mesh/transport/iot_transport.py
@@ -268,9 +268,11 @@ def _is_camera_ref(topic: str) -> bool:
 
     The exemption is granted on the topic's SHAPE, not on substrings of it: the
     family segment must itself be ``camera``, and a camera name must sit between
-    it and the ``ref`` tail. A camera name is a free string taken from the
-    robot's own ``config.cameras`` keys, so a substring test hands the exemption
-    to topics that carry a frame rather than a pointer -- a camera named ``ref``
+    it and the ``ref`` tail. A camera name is taken from the robot's own
+    ``config.cameras`` keys - a bare token at the doors that accept one
+    (:func:`~strands_robots.utils.camera_token_error`), and whatever a config
+    built by other means carries - so a substring test hands the exemption to
+    topics that carry a frame rather than a pointer -- a camera named ``ref``
     publishes its inline base64 JPEG on ``strands/<peer>/camera/ref``, and a
     ``ref`` tail under any other family (``input/camera/ref``) reads as a
     pointer too. Both are the WAN payload the drop rule exists to refuse, and

--- a/strands_robots/tools/lerobot_teleoperate.py
+++ b/strands_robots/tools/lerobot_teleoperate.py
@@ -12,7 +12,6 @@ This tool integrates teleoperation and recording functionality from lerobot, all
 import importlib.util
 import logging
 import os
-import re
 import signal
 import subprocess
 import time
@@ -41,7 +40,7 @@ from strands_robots.tools._process_stop import (
 )
 from strands_robots.utils import (
     boolean_flag_error,
-    entity_name_error,
+    camera_token_error,
     non_negative_whole_number_error,
     positive_finite_number_error,
     positive_whole_number_error,
@@ -294,8 +293,11 @@ def _execution_flag_error(supplied: dict[str, Any]) -> str | None:
 # returned, and an episode is recorded from a camera nobody asked for. The last
 # three are the failure this module's numeric table already exists to prevent -
 # argv the detached subprocess cannot parse, reported minutes later in its log.
-# A name is a key in that dict and must be a bare token; a value is quoted at
-# the render (``_yaml_scalar``) so it is read back as the string it was.
+# A name is a key in that dict and must be a bare token, which is not this
+# module's rule to state either: ``utils.camera_token_error`` owns it, because
+# the ``Robot`` factory's ``cameras`` mapping is a second door onto the same
+# name and the two must accept one alphabet. A value is quoted at the render
+# (``_yaml_scalar``) so it is read back as the string it was.
 #
 # Which ``type`` values exist, and which options each admits, is not this
 # module's to list: ``type`` selects a class from lerobot's ``CameraConfig``
@@ -326,34 +328,6 @@ _CAMERA_GEOMETRY_DOMAINS: tuple[tuple[str, Callable[[Any, str, str], str | None]
     ("height", positive_whole_number_error),
     ("fps", positive_whole_number_error),
 )
-
-# A bare token: what a camera name may be without becoming punctuation in the
-# rendered dict, where it is a key. The name is additionally the dataset's
-# ``observation.images.<name>`` feature key, which is the same alphabet.
-_CAMERA_TOKEN = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9_-]*\Z")
-
-
-def _bare_token_error(where: str, param: str, value: Any) -> str | None:
-    """Refuse a camera name that would be punctuation in the argv.
-
-    Args:
-        where: The message prefix naming the surface and the map entry.
-        param: The name of the value being checked, for the message.
-        value: The claimed token, as supplied.
-
-    Returns:
-        An error message naming the value and the alphabet, or ``None``.
-    """
-    if error := entity_name_error(where, param, value):
-        return error
-    if _CAMERA_TOKEN.match(value) is None:
-        return (
-            f"{where}: {param}={refusal_repr(value)} is not a bare token. lerobot parses "
-            "--robot.cameras as a nested dict, where ',', ':', '{', '}', '=' and whitespace "
-            "are structure, so a value carrying one changes the shape of that dict rather "
-            "than the value in it. Use letters, digits, '_' or '-'."
-        )
-    return None
 
 
 def _camera_entry_error(context: str, name: str, entry: Any) -> str | None:
@@ -428,7 +402,7 @@ def _camera_map_error(robot_cameras: Any) -> str | None:
             f"mapping, got {refusal_repr(robot_cameras)}."
         )
     for name, entry in robot_cameras.items():
-        if error := _bare_token_error(context, "robot_cameras camera name", name):
+        if error := camera_token_error(context, "robot_cameras camera name", name):
             return error
         if error := _camera_entry_error(context, name, entry):
             return error

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -5,6 +5,7 @@ import logging
 import math
 import numbers
 import os
+import re
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any, Final
@@ -2992,6 +2993,86 @@ def camera_name_error(method: str, param_name: str, name: Any, *, routes_free_ca
     if routes_free_camera_tokens:
         return reserved_camera_name_error(method, param_name, name)
     return None
+
+
+#: What a camera's name in a ``cameras`` mapping may be: a bare token of
+#: letters, digits, ``_`` and ``-``, opening on a letter or a digit. Every
+#: consumer keys the camera's frames by this name, and each of them reserves
+#: punctuation of its own - see :func:`camera_token_error`.
+_CAMERA_TOKEN: Final = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9_-]*\Z")
+
+
+def camera_token_error(method: str, param_name: str, name: Any) -> str | None:
+    """Return an error message if ``name`` cannot key the camera it names.
+
+    A camera's name in a ``cameras`` mapping is not just a label: it is the
+    identity every downstream consumer keys that camera's frames by, and each of
+    them reserves punctuation of its own. So the name has to be a bare token
+    (:data:`_CAMERA_TOKEN`) at every door that accepts one - the
+    :class:`~strands_robots.hardware_robot.Robot` factory's ``cameras`` mapping
+    and the ``robot_cameras`` of
+    :func:`~strands_robots.tools.lerobot_teleoperate.lerobot_teleoperate` - and
+    the rule lives here, beside :func:`entity_name_error`, for the same reason
+    that one does: two doors onto one name must not accept different alphabets.
+
+    Three consumers, each of which reads a character it reserves as structure
+    rather than as part of the name:
+
+    * **The mesh topic.**
+      :meth:`~strands_robots.mesh.core.Mesh._encode_and_publish_frames`
+      publishes each frame on ``strands/<peer_id>/camera/<name>``. A ``/`` in
+      the name adds a topic level, so the frame lands under a key no
+      ``strands/*/camera/*`` subscription matches, and ``*`` / ``**`` are Zenoh
+      wildcards, which a ``put`` is routed by intersection - the frame is
+      delivered to every peer that subscribes to any camera rather than to the
+      one asking for this camera. Measured on this tree, a camera named
+      ``'wrist/ref'`` published its 274054-byte inline frame on
+      ``strands/rover-01/camera/wrist/ref``, which is the shape of the small S3
+      *pointer* the IoT transport exempts from its camera-frame drop
+      (:func:`~strands_robots.mesh.transport.iot_transport._is_camera_ref`), so
+      the whole frame was forwarded to the broker the drop exists to spare.
+    * **The S3 key.**
+      :meth:`~strands_robots.mesh.iot.camera_offload.CameraOffloader.s3_key_for`
+      joins the name into ``<prefix>/<peer_id>/<name>/<ts>.jpg``, so ``..``
+      walks out of the peer's own prefix.
+    * **The argv.** ``lerobot_teleoperate`` renders the entry into the nested
+      ``--robot.cameras`` dict lerobot's draccus CLI parses, where ``,``, ``:``,
+      ``{``, ``}``, ``=`` and whitespace are structure - a name carrying one
+      changes the shape of that dict rather than the value in it, and is
+      reported minutes later in a detached subprocess's log.
+
+    The name is additionally the dataset feature key a recording writes it under
+    (``observation.images.<name>``, see
+    :meth:`~strands_robots.dataset_recorder.DatasetRecorder.add_frame`), whose
+    ``.`` separator is the same kind of structure.
+
+    Args:
+        method: The surface being called, for the message prefix (e.g.
+            ``"Robot(cameras=...)"``).
+        param_name: What is being named, for the message (e.g.
+            ``"camera name"``).
+        name: The claimed camera name. Anything at all; a value that cannot be a
+            key of any kind is refused first by :func:`entity_name_error`.
+
+    Returns:
+        An error message naming the value and the alphabet, or ``None`` when
+        *name* is a bare token.
+    """
+    if (err := entity_name_error(method, param_name, name)) is not None:
+        return err
+    if _CAMERA_TOKEN.match(name) is not None:
+        return None
+    rendered = refusal_repr(name)
+    return (
+        f"{method}: {param_name}={rendered} is not a bare token. A camera's name is the "
+        "identity every consumer keys its frames by, and each reserves punctuation of its "
+        "own: the mesh publishes them on 'strands/<peer_id>/camera/<name>', where '/' adds a "
+        "topic level and '*' is a wildcard a put is routed by; the S3 offload joins it into "
+        "the object key, where '..' walks out of the peer's prefix; a recording writes it as "
+        "the 'observation.images.<name>' dataset feature key; and lerobot parses "
+        "--robot.cameras as a nested dict, where ',', ':', '{', '}', '=' and whitespace are "
+        "structure. Use letters, digits, '_' or '-'."
+    )
 
 
 def published_string_error(value: Any, param: str, context: str) -> str | None:

--- a/tests/test_camera_name_is_a_bare_token_at_every_door.py
+++ b/tests/test_camera_name_is_a_bare_token_at_every_door.py
@@ -1,0 +1,103 @@
+"""A camera's name is held to one alphabet at every door that accepts one.
+
+A camera's name in a ``cameras`` mapping is the identity every downstream
+consumer keys that camera's frames by, and each of them reserves punctuation of
+its own: the mesh publishes the frames on ``strands/<peer_id>/camera/<name>``,
+the IoT offload joins the name into the S3 object key, and a recording writes it
+as the ``observation.images.<name>`` dataset feature key. ``lerobot_teleoperate``
+already refused a name that is not a bare token, because it renders one into the
+nested ``--robot.cameras`` argv; the ``Robot`` factory accepted any name at all
+and the two doors disagreed. These tests pin that they now share one rule
+(:func:`~strands_robots.utils.camera_token_error`), and the wire outcome that
+makes the rule worth having.
+"""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from strands_robots.hardware_robot import _build_camera_config
+from strands_robots.utils import camera_token_error
+
+_teleop = importlib.import_module("strands_robots.tools.lerobot_teleoperate")
+_iot = importlib.import_module("strands_robots.mesh.transport.iot_transport")
+_offload = importlib.import_module("strands_robots.mesh.iot.camera_offload")
+
+# Each name, and the phrase both doors must answer it with. A name is refused
+# for what it would do downstream, so the table is one row per reserved
+# character rather than one file per spelling.
+UNUSABLE = [
+    pytest.param("wrist/ref", "bare token", id="topic-level-that-spells-the-pointer-tail"),
+    pytest.param("front/left", "bare token", id="topic-level"),
+    pytest.param("*", "bare token", id="zenoh-wildcard"),
+    pytest.param("**", "bare token", id="zenoh-multi-wildcard"),
+    pytest.param("..", "bare token", id="parent-of-the-s3-prefix"),
+    pytest.param("wrist.rgb", "bare token", id="dataset-feature-key-separator"),
+    pytest.param("front,wrist", "bare token", id="argv-dict-separator"),
+    pytest.param("front wrist", "bare token", id="whitespace"),
+    pytest.param("front\n--robot.port=/dev/x", "bare token", id="newline"),
+    pytest.param("", "non-empty string", id="empty"),
+    pytest.param(7, "non-empty string", id="not-a-str"),
+]
+
+USABLE = ["wrist", "front_cam", "top", "cam-2", "0"]
+
+
+@pytest.mark.parametrize(("name", "phrase"), UNUSABLE)
+def test_both_doors_refuse_a_name_no_consumer_could_carry(name, phrase):
+    """The factory and the teleop tool refuse the same name for the same reason."""
+    with pytest.raises(ValueError, match=phrase):
+        _build_camera_config(name, {"index_or_path": 0})
+
+    tool_error = _teleop._camera_map_error({name: {"index_or_path": 0}})
+    assert tool_error is not None and phrase in tool_error
+
+
+@pytest.mark.parametrize("name", USABLE)
+def test_both_doors_accept_a_bare_token(name):
+    """A name every consumer can carry still reaches a built camera config."""
+    assert camera_token_error("Robot(cameras=...)", "camera name", name) is None
+    built = _build_camera_config(name, {"index_or_path": 0})
+    assert (built.width, built.height) == (640, 480)
+    assert _teleop._camera_map_error({name: {"index_or_path": 0}}) is None
+
+
+def test_the_frame_topic_a_refused_name_would_publish_on_reads_as_a_pointer():
+    """Why the rule: a name spelling an extra level turns a frame into a 'pointer'.
+
+    The IoT transport drops camera frames rather than paying WAN for a base64
+    JPEG, and exempts the small S3 pointer published on
+    ``strands/<peer>/camera/<name>/ref``. It grants that exemption on the
+    topic's shape, so a camera named ``wrist/ref`` publishes its *inline* frame
+    on exactly the pointer's shape and the drop lets the whole frame through.
+    """
+    from strands_robots.mesh import Mesh
+
+    name = "wrist/ref"
+    inner = SimpleNamespace(is_connected=True, name="so101", config=SimpleNamespace(cameras={name: {}}))
+    mesh = Mesh(SimpleNamespace(tool_name_str="so101", robot=inner), peer_id="rover-01")
+    frame = np.full((480, 640, 3), 128, dtype=np.uint8)
+
+    with patch("strands_robots.mesh.core.put") as mock_put:
+        mesh._encode_and_publish_frames({name: frame}, [name])
+
+    topic, payload = mock_put.call_args[0]
+    assert topic == "strands/rover-01/camera/wrist/ref"
+    assert len(payload["data"]) > 1000  # an inline frame, not a few-hundred-byte pointer
+    assert _iot._is_camera_ref(topic) is True
+    assert _iot._should_drop(topic) is False
+    # The door is what keeps that name off the wire in the first place.
+    assert camera_token_error("Robot(cameras=...)", "camera name", name) is not None
+
+
+def test_the_s3_key_a_refused_name_would_write_leaves_the_peer_prefix():
+    """Why the rule: the offload joins the name into the object key unchanged."""
+    offloader = _offload.CameraOffloader(bucket="fleet-frames", prefix="frames")
+    assert offloader.s3_key_for("rover-01", "wrist", 123) == "frames/rover-01/wrist/123.jpg"
+    assert offloader.s3_key_for("rover-01", "../..", 123) == "frames/rover-01/../../123.jpg"
+    assert camera_token_error("Robot(cameras=...)", "camera name", "../..") is not None


### PR DESCRIPTION
![door parity](https://raw.githubusercontent.com/cagataycali/robots/954a36f0f07d6ef5a7b389b2506da6c656783b6e/camera_name_doors.png)

## What

`Robot(cameras={...})` validated every *option* of a camera entry and never the *name* it was keyed under, while `lerobot_teleoperate` refused a `robot_cameras` name that is not a bare token. Ten names measured as accepted by the factory (panel A).

## Why

The name is the identity every consumer keys the camera's frames by, and each reserves punctuation of its own: `Mesh` publishes on `strands/<peer_id>/camera/<name>` (`/` adds a topic level, `*` is a Zenoh wildcard a `put` is routed by), `CameraOffloader.s3_key_for` joins it into the object key (`..` walks out of the peer's prefix), and a recording writes it as `observation.images.<name>`.

Panel B: camera `wrist/ref` published its **274,054-byte inline frame** on `strands/rover-01/camera/wrist/ref` - the shape of the small S3 pointer the IoT transport exempts from its camera-frame drop - so `_should_drop` returned `False` and the whole frame reached the broker that drop exists to spare.

The rule now has one owner, `utils.camera_token_error`, read by both doors; `lerobot_teleoperate`'s private copy of it is deleted.

## Tests

`tests/test_camera_name_is_a_bare_token_at_every_door.py`, 18 cells: the 11-name table asserted at both doors (fails pre-fix at the factory), 5 usable names still building a config at both, plus the two why-cells that measure the frame topic and the S3 key. Full `tests/`: 52,260 passed / 316 skipped, coverage 96.06%; ruff + `mypy strands_robots tests tests_integ` clean.

LOC +239 / -43.