### PR TITLE
fix(simulation): add_camera holds each segment of a name to the bare-token rule

### DIFF
--- a/changelog.d/3562-add-camera-name-segments-are-tokens.md
+++ b/changelog.d/3562-add-camera-name-segments-are-tokens.md
@@ -1,0 +1,20 @@
+### Fixed: a scene camera's name is held to the bare-token rule in every segment
+
+`add_camera` on the MuJoCo, Newton and Isaac backends refused only a name that
+cannot be a registry key at all, so `'..'`, `'sub/../etc'`, `'a b'`, `'cam#1'`
+and `'**'` each registered under `status="success"` and reached the consumers
+the hardware door was hardened against: the mesh published a frame on
+`strands/rover01/camera/**` - a Zenoh wildcard on a `put`, routed by
+intersection to every peer subscribed to any camera - and
+`CameraOffloader.s3_key_for` joined `'../../etc/passwd'` into
+`'frames/rover01/../../etc/passwd/123.jpg'`.
+
+The hardware rule is not applied verbatim, because the simulation itself writes
+a `/` into a camera's name: a robot's cameras register under
+`<namespace>/<cam>` (`arm0/wrist`), `render_all` resolves a short name against
+that form, and the dataset column collapses the separator to `__`. The scene
+rule, `utils.camera_segments_error`, holds every `/`-separated segment to the
+one alphabet both doors read - letters, digits, `_` and `-`, opening on a letter
+or a digit - and refuses an empty segment. Every documented name, namespaced or
+not, is unaffected; all three backends read the rule through
+`camera_name_error`, so one refusal sentence covers them.

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -2943,10 +2943,11 @@ def camera_name_error(method: str, param_name: str, name: Any, *, routes_free_ca
 
     The whole name rule for a camera creation site, in one place and in one
     order: :func:`entity_name_error` first (a value that cannot be a registry
-    key at all), then :func:`reserved_camera_name_error` (a ``str`` this
-    backend's own render entry points resolve past). Every ``add_camera``
-    reads it, so the order is a property of the rule rather than of whichever
-    body a caller reached.
+    key at all), then :func:`camera_segments_error` (a ``str`` some consumer of
+    the camera's frames would read as structure), then
+    :func:`reserved_camera_name_error` (a ``str`` this backend's own render
+    entry points resolve past). Every ``add_camera`` reads it, so the order is a
+    property of the rule rather than of whichever body a caller reached.
 
     That order was the defect this composition removes. The two guards had been
     applied separately at each site, and the sites disagreed about where the
@@ -2990,9 +2991,73 @@ def camera_name_error(method: str, param_name: str, name: Any, *, routes_free_ca
     """
     if (err := entity_name_error(method, param_name, name)) is not None:
         return err
+    if (err := camera_segments_error(method, param_name, name)) is not None:
+        return err
     if routes_free_camera_tokens:
         return reserved_camera_name_error(method, param_name, name)
     return None
+
+
+def camera_segments_error(method: str, param_name: str, name: str) -> str | None:
+    """Return an error message if a scene camera's name is not bare tokens joined by ``/``.
+
+    The simulation counterpart to :func:`camera_token_error`, and the reason it
+    is a separate rule rather than that one: a scene camera's name may carry a
+    ``/``, because the simulation itself writes one. A robot's cameras are
+    registered under ``<namespace>/<cam>`` (``arm0/wrist``), ``render_all``
+    resolves a short name against that form, and :func:`camera_schema_key`
+    collapses the separator to ``__`` for the dataset column - so refusing the
+    character outright would refuse a shape three documented surfaces produce
+    and read. What those surfaces never produce is a segment that is not a bare
+    token, and that is what this rule holds each segment to
+    (:data:`_CAMERA_TOKEN`), so the alphabet has one owner across both doors and
+    only the separator differs.
+
+    The consumers are the ones :func:`camera_token_error` names, reached from
+    the scene rather than from a ``cameras`` mapping. Measured on this tree, one
+    ``create_world`` then ``add_camera`` per name, before this rule existed:
+
+    * ``'a/b'``, ``'..'``, ``'sub/../etc'``, ``'a b'``, ``'cam#1'`` and ``'**'``
+      each registered under ``status="success"``; only ``''`` was refused.
+    * :meth:`~strands_robots.mesh.core.Mesh._publish_sim_cameras` strips the
+      robot's namespace and publishes the rest on
+      ``strands/<peer_id>/camera/<name>``, so ``'**'`` went out on
+      ``strands/rover01/camera/**`` - a Zenoh wildcard on a ``put``, which is
+      routed by intersection to every peer subscribed to any camera.
+    * :meth:`~strands_robots.mesh.iot.camera_offload.CameraOffloader.s3_key_for`
+      joined ``'../../etc/passwd'`` into ``'frames/rover01/../../etc/passwd/123.jpg'``.
+    * The MuJoCo backend renders the name into MJCF and the Isaac backend into a
+      USD prim path (``<stage>/Cameras/<name>``), where whitespace and ``#`` are
+      not a name either.
+
+    An empty segment is refused too (``'/wrist'``, ``'arm0/'``, ``'a//b'``):
+    each is a topic level with nothing in it, and the namespace strip above would
+    publish the second on the bare camera root.
+
+    Args:
+        method: The calling method, for the message prefix (e.g. ``"add_camera"``).
+        param_name: The parameter being validated, for the message.
+        name: The claimed camera name. Already a non-empty ``str`` with no NUL:
+            :func:`entity_name_error` runs first at every call site, which is
+            what lets this one read the value as text.
+
+    Returns:
+        An error message naming the value and the alphabet, or ``None`` when
+        every ``/``-separated segment of *name* is a bare token.
+    """
+    if all(_CAMERA_TOKEN.match(segment) is not None for segment in name.split("/")):
+        return None
+    rendered = refusal_repr(name)
+    return (
+        f"{method}: {param_name}={rendered} is not bare tokens joined by '/'. A scene camera's "
+        "name is the identity every consumer keys its frames by, and each reserves punctuation "
+        "of its own: the mesh publishes them on 'strands/<peer_id>/camera/<name>', where '*' is "
+        "a wildcard a put is routed by; the S3 offload joins it into the object key, where '..' "
+        "walks out of the peer's prefix; a recording writes it as the "
+        "'observation.images.<name>' dataset feature key; and the backend renders it into the "
+        "scene description. Use letters, digits, '_' or '-' in each segment, with '/' only as "
+        "the namespace separator the simulation itself writes ('arm0/wrist')."
+    )
 
 
 #: What a camera's name in a ``cameras`` mapping may be: a bare token of

--- a/tests/simulation/test_add_camera_name_segments_are_bare_tokens.py
+++ b/tests/simulation/test_add_camera_name_segments_are_bare_tokens.py
@@ -1,0 +1,304 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests: ``add_camera`` holds each segment of a name to the bare-token rule.
+
+A scene camera's name reaches the same consumers a hardware camera's does - the
+mesh publishes its frames on ``strands/<peer_id>/camera/<name>``, the IoT offload
+joins it into the S3 object key, a recording writes it as the
+``observation.images.<name>`` dataset feature key - and
+:func:`~strands_robots.utils.camera_token_error` hardened the hardware door
+against a name those consumers read as structure. Every backend's ``add_camera``
+stayed on the older rule, which refuses only a name that cannot be a registry key
+at all. Measured on MuJoCo, one ``create_world`` then one ``add_camera`` per name:
+``'a/b'``, ``'..'``, ``'sub/../etc'``, ``'a b'``, ``'cam#1'`` and ``'**'`` each
+registered under ``status="success"``, and only ``''`` was refused.
+
+The hardware rule cannot be applied verbatim, because the simulation itself writes
+a ``/`` into a camera's name: a robot's cameras are registered under
+``<namespace>/<cam>`` (``arm0/wrist``), ``render_all`` resolves a short name
+against that form, and :func:`~strands_robots.utils.camera_schema_key` collapses
+the separator for the dataset column. So the scene rule is
+:func:`~strands_robots.utils.camera_segments_error`: every ``/``-separated segment
+is a bare token, on the one alphabet :data:`~strands_robots.utils._CAMERA_TOKEN`
+both doors read. Refusing ``/`` outright would refuse a shape three documented
+surfaces produce, which is why these tests pin the namespaced form as accepted
+beside the refusals.
+
+Every backend is graded here, and each half runs where the optional solver is
+absent: MuJoCo compiles the spec and renders nothing, and the Newton and Isaac
+guards run before the method touches a solver or a stage, so an unbound call with
+a small stand-in for ``self`` reaches them (the pattern
+``tests/simulation/test_reserved_camera_name_at_creation.py`` uses).
+"""
+
+from __future__ import annotations
+
+import threading
+import types
+from typing import Any, cast
+
+import pytest
+
+from strands_robots.simulation.newton.simulation import NewtonSimEngine
+from strands_robots.utils import camera_name_error, camera_segments_error
+
+#: One row per reserved character, with the consumer that reads it as structure.
+UNUSABLE = [
+    pytest.param("..", id="parent-of-the-s3-prefix"),
+    pytest.param("sub/../etc", id="traversal-inside-a-namespace"),
+    pytest.param("**", id="zenoh-multi-wildcard"),
+    pytest.param("*", id="zenoh-wildcard"),
+    pytest.param("a b", id="whitespace"),
+    pytest.param("cam#1", id="mjcf-and-usd-punctuation"),
+    pytest.param("wrist.rgb", id="dataset-feature-key-separator"),
+    pytest.param("/wrist", id="empty-leading-segment"),
+    pytest.param("arm0/", id="empty-trailing-segment"),
+    pytest.param("a//b", id="empty-middle-segment"),
+    pytest.param("front\nwrist", id="newline"),
+]
+
+#: Names every consumer can carry, including the namespaced form the simulation
+#: writes and the two shapes ``docs/simulation/world-building.md`` documents.
+USABLE = ["wrist", "cam-1", "front_cam", "0", "arm0/wrist", "arm2/wrist", "so101/wrist_cam"]
+
+
+class TestTheDomain:
+    """The rule, read directly and through the composed camera name rule."""
+
+    @pytest.mark.parametrize("name", UNUSABLE)
+    def test_a_segment_that_is_not_a_bare_token_is_refused(self, name: str) -> None:
+        err = camera_segments_error("add_camera", "name", name)
+        assert err is not None, name
+        assert err.startswith("add_camera: name=")
+        assert "bare tokens joined by '/'" in err
+
+    @pytest.mark.parametrize("name", USABLE)
+    def test_bare_tokens_joined_by_a_slash_are_accepted(self, name: str) -> None:
+        assert camera_segments_error("add_camera", "name", name) is None
+
+    @pytest.mark.parametrize("routes", [True, False])
+    @pytest.mark.parametrize("name", UNUSABLE)
+    def test_the_composed_rule_refuses_it_on_every_backend_posture(self, name: str, routes: bool) -> None:
+        """Both ``routes_free_camera_tokens`` postures reach this rule - it is not gated on one."""
+        err = camera_name_error("add_camera", "name", name, routes_free_camera_tokens=routes)
+        assert err is not None and "bare tokens" in err
+
+    @pytest.mark.parametrize("routes", [True, False])
+    @pytest.mark.parametrize("name", USABLE)
+    def test_the_composed_rule_still_accepts_a_usable_name(self, name: str, routes: bool) -> None:
+        assert camera_name_error("add_camera", "name", name, routes_free_camera_tokens=routes) is None
+
+    def test_the_addressability_refusal_still_comes_first(self) -> None:
+        """A value that is not a ``str`` is refused by ``entity_name_error``, so this rule never reads it."""
+        err = camera_name_error("add_camera", "name", 7, routes_free_camera_tokens=True)
+        assert err is not None and "bare tokens" not in err
+
+    def test_the_reserved_refusal_is_still_reached_for_a_token(self) -> None:
+        """A routing token is a bare token, so the reserved rule stays the one that refuses it."""
+        err = camera_name_error("add_camera", "name", "default", routes_free_camera_tokens=True)
+        assert err is not None and "reserved" in err
+
+    def test_the_message_is_ascii(self) -> None:
+        """Project rule: the rule's own text is plain ASCII; the ``repr`` of the refused value is the caller's."""
+        for name in ("a b", "**", "..", "cam#1"):
+            err = camera_segments_error("add_camera", "name", name)
+            assert err is not None
+            err.encode("ascii")
+
+
+# --------------------------------------------------------------------------- #
+# What a refused name would have done downstream                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_the_topic_a_refused_name_would_publish_on_is_a_wildcard() -> None:
+    """Why the rule: the publisher joins the raw name into the topic, so ``**`` is a Zenoh wildcard.
+
+    A ``put`` on a wildcard key is routed by intersection, so the frame reaches
+    every peer subscribed to any camera rather than the one asking for this one.
+    The sim publisher strips a robot's namespace and hands the rest to the same
+    encoder the hardware path uses, which is the seam graded here.
+    """
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    import numpy as np
+
+    from strands_robots.mesh import Mesh
+
+    name = "**"
+    inner = SimpleNamespace(is_connected=True, name="rover", config=SimpleNamespace(cameras={name: {}}))
+    mesh = Mesh(SimpleNamespace(tool_name_str="rover", robot=inner), peer_id="rover01")
+    frame = np.full((48, 64, 3), 128, dtype=np.uint8)
+
+    with patch("strands_robots.mesh.core.put") as mock_put:
+        mesh._encode_and_publish_frames({name: frame}, [name])
+
+    topic, _payload = mock_put.call_args[0]
+    assert topic == "strands/rover01/camera/**"
+    # The door is what keeps that name out of the scene in the first place.
+    assert camera_segments_error("add_camera", "name", name) is not None
+
+
+def test_the_s3_key_a_refused_name_would_write_leaves_the_peer_prefix() -> None:
+    """Why the rule: the offload joins the name into the object key unchanged."""
+    from strands_robots.mesh.iot.camera_offload import CameraOffloader
+
+    offloader = CameraOffloader(bucket="fleet-frames", prefix="frames")
+    assert offloader.s3_key_for("rover01", "arm0/wrist", 123) == "frames/rover01/arm0/wrist/123.jpg"
+    assert offloader.s3_key_for("rover01", "../../etc/passwd", 123) == "frames/rover01/../../etc/passwd/123.jpg"
+    assert camera_segments_error("add_camera", "name", "../../etc/passwd") is not None
+
+
+# --------------------------------------------------------------------------- #
+# MuJoCo                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def sim():
+    pytest.importorskip("mujoco")
+    from strands_robots.simulation import Simulation
+
+    s = Simulation()
+    s.create_world()
+    yield s
+    s.destroy()
+
+
+class TestMujocoAddCamera:
+    @pytest.mark.parametrize("name", UNUSABLE)
+    def test_an_unusable_name_is_refused(self, sim, name: str) -> None:
+        result = sim.add_camera(name, position=[1.0, 1.0, 1.0], target=[0.0, 0.0, 0.0])
+        assert result["status"] == "error", (name, result)
+        assert "bare tokens" in result["content"][0]["text"]
+
+    @pytest.mark.parametrize("name", UNUSABLE)
+    def test_the_refusal_registers_nothing(self, sim, name: str) -> None:
+        before = dict(sim._world.cameras)
+        sim.add_camera(name, position=[1.0, 1.0, 1.0], target=[0.0, 0.0, 0.0])
+        assert sim._world.cameras == before
+
+    @pytest.mark.parametrize("name", USABLE)
+    def test_a_usable_name_still_registers(self, sim, name: str) -> None:
+        result = sim.add_camera(name, position=[1.0, 1.0, 1.0], target=[0.0, 0.0, 0.0])
+        assert result["status"] == "success", (name, result)
+        assert name in sim._world.cameras
+
+    def test_a_namespaced_camera_compiles_under_the_name_it_was_given(self, sim) -> None:
+        """The reason ``/`` stays admitted: the namespaced form is a first-class scene camera.
+
+        ``tests/simulation/mujoco/test_render_all_multicamera.py`` pins that
+        ``render_all`` resolves the short name onto it; this pins the half that
+        belongs to the door - the name is accepted and the compiled model
+        carries it, so the camera is reachable through the API that created it.
+        """
+        import mujoco
+
+        assert (
+            sim.add_camera(name="arm0/wrist", position=[0.4, 0.0, 0.5], target=[0.0, 0.0, 0.2])["status"] == "success"
+        )
+        assert mujoco.mj_name2id(sim._world._model, mujoco.mjtObj.mjOBJ_CAMERA, "arm0/wrist") >= 0
+
+
+# --------------------------------------------------------------------------- #
+# Newton                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def _newton_stub() -> types.SimpleNamespace:
+    """A stand-in for ``self`` carrying only what ``add_camera`` reads before the solver."""
+    return types.SimpleNamespace(
+        _world=types.SimpleNamespace(cameras={}),
+        _model=types.SimpleNamespace(body_label=("ground", "ball")),
+        _lock=threading.RLock(),
+    )
+
+
+def _newton_add_camera(stub: types.SimpleNamespace, name: Any) -> dict[str, Any]:
+    return NewtonSimEngine.add_camera(
+        cast(NewtonSimEngine, stub), name, position=[1.0, 1.0, 1.0], target=[0.0, 0.0, 0.0]
+    )
+
+
+class TestNewtonAddCamera:
+    @pytest.mark.parametrize("name", UNUSABLE)
+    def test_an_unusable_name_is_refused_before_the_solver(self, name: str) -> None:
+        stub = _newton_stub()
+        result = _newton_add_camera(stub, name)
+        assert result["status"] == "error", (name, result)
+        assert "bare tokens" in result["content"][0]["text"]
+        assert stub._world.cameras == {}
+
+    @pytest.mark.parametrize("name", UNUSABLE)
+    def test_the_refusal_is_the_same_sentence_as_mujocos(self, name: str) -> None:
+        """One owner, one message: a caller moving between backends reads one rule."""
+        result = _newton_add_camera(_newton_stub(), name)
+        assert result["content"][0]["text"] == camera_name_error(
+            "add_camera", "name", name, routes_free_camera_tokens=True
+        )
+
+    @pytest.mark.parametrize("name", USABLE)
+    def test_a_usable_name_gets_past_the_guard(self, name: str) -> None:
+        """Not a blanket refusal: a usable name reaches the solver path, which is what fails on the stub."""
+        result = _newton_add_camera(_newton_stub(), name)
+        text = result["content"][0]["text"]
+        assert "bare tokens" not in text, (name, result)
+
+
+# --------------------------------------------------------------------------- #
+# Isaac                                                                       #
+# --------------------------------------------------------------------------- #
+
+
+class _FakeCameraHandle:
+    """Stand-in for the Isaac ``Camera`` sensor handle."""
+
+
+def _isaac_engine():
+    from strands_robots.simulation.isaac.simulation import IsaacConfig, IsaacSimulation
+
+    engine = IsaacSimulation.__new__(IsaacSimulation)
+    engine._config = IsaacConfig()
+    engine._lock = threading.RLock()
+    engine._world = None
+    engine._world_created = True
+    engine._robots = {}
+    engine._objects = {}
+    engine._cameras = {}
+    engine._prim_registry = []
+    engine._cam_out_size = {}
+    engine._camera_warmup_steps = 0
+    engine._sim_time = 0.0
+    engine._step_count = 0
+    engine._main_tid = threading.get_ident()
+
+    def _create_camera_prim(**kwargs: Any) -> tuple[Any, float]:
+        return _FakeCameraHandle(), 24.0
+
+    engine._create_camera_prim = _create_camera_prim  # type: ignore[method-assign]
+    return engine
+
+
+class TestIsaacAddCamera:
+    """Isaac does not route the free-camera tokens, and this rule is not gated on that posture."""
+
+    @pytest.mark.parametrize("name", UNUSABLE)
+    def test_an_unusable_name_is_refused_before_the_stage(self, name: str) -> None:
+        engine = _isaac_engine()
+        result = engine.add_camera(name, position=[1.0, 1.0, 1.0], target=[0.0, 0.0, 0.0])
+        assert result["status"] == "error", (name, result)
+        assert "bare tokens" in result["content"][0]["text"]
+        assert engine._cameras == {}
+
+    @pytest.mark.parametrize("name", USABLE)
+    def test_a_usable_name_still_registers(self, name: str) -> None:
+        engine = _isaac_engine()
+        result = engine.add_camera(name, position=[1.0, 1.0, 1.0], target=[0.0, 0.0, 0.0])
+        assert result["status"] == "success", (name, result)
+        assert name in engine._cameras
+
+    def test_the_documented_signature_default_still_works(self) -> None:
+        engine = _isaac_engine()
+        assert engine.add_camera(position=[1.0, 1.0, 1.0], target=[0.0, 0.0, 0.0])["status"] == "success"
+        assert "default" in engine._cameras


### PR DESCRIPTION
## What

`add_camera` on the MuJoCo, Newton and Isaac backends refused only a name that cannot be a registry key at all (`entity_name_error`), so a scene camera named `'..'`, `'sub/../etc'`, `'a b'`, `'cam#1'` or `'**'` registered under `status="success"` and reached the consumers #3559 hardened the hardware door against.

Measured on `main` (`4165f79`), one `create_world` then one `add_camera` per name: all five above accepted, only `''` refused. `Mesh._publish_sim_cameras` then published on `strands/rover01/camera/**` - a Zenoh wildcard on a `put`, routed by intersection to every peer subscribed to any camera - and `CameraOffloader.s3_key_for('rover01', '../../etc/passwd', 123)` returned `frames/rover01/../../etc/passwd/123.jpg`.

## Why not the fix as filed

#3562 proposed reading `camera_token_error` (the hardware rule) inside `camera_name_error`. That refuses `/` outright, and the simulation itself writes one: a robot's cameras register under `<namespace>/<cam>` (`arm0/wrist`), `render_all` resolves a short name against that form (`TestRenderAllNamespacedCameraResolution`), and `camera_schema_key` collapses the separator to `__` for the dataset column (`test_recording_camera_scoping.py`). Applying the hardware rule verbatim would have broken three pinned, documented surfaces.

## Fix

`utils.camera_segments_error`: every `/`-separated segment is a bare token on the one alphabet both doors already read (`_CAMERA_TOKEN`), and an empty segment is refused (`'/wrist'`, `'arm0/'`, `'a//b'` - the namespace strip would publish the second on the bare camera root). `camera_name_error` reads it between the addressability rule and the reserved-name rule, so all three backends inherit it through the call they already make and one refusal sentence covers them. Not gated on `routes_free_camera_tokens` - Isaac's posture is about routing, not about what a name may carry.

`strands_robots/utils.py` +76 / -4; no backend file changes.

## Tests

`tests/simulation/test_add_camera_name_segments_are_bare_tokens.py` - GL-free on all three backends (MuJoCo compiles the spec; Newton and Isaac reach the guard through the unbound-method stand-in the sibling `test_reserved_camera_name_at_creation.py` uses).

| cell | pins |
|---|---|
| 11 unusable names x 3 backends | refused with the shared sentence; registry untouched |
| 7 usable names x 3 backends, incl. `arm0/wrist`, `so101/wrist_cam` | still register |
| composed rule, both `routes_free_camera_tokens` postures | refusal not gated on the posture |
| order | non-`str` still refused by `entity_name_error`; `default` still refused as reserved |
| namespaced form compiles | `mj_name2id` resolves `arm0/wrist` - the reason `/` stays admitted |
| the wire | `Mesh._encode_and_publish_frames` puts `**` on `strands/rover01/camera/**`; `s3_key_for` traverses on `../../etc/passwd` |
| Isaac | documented signature default `name="default"` still works |

The module errors at import against pre-fix `utils.py` (no `camera_segments_error`), so the pin cannot pass on `main`.

## Gate

- `ruff check` / `ruff format --check` clean; `mypy` success on both files.
- Sim camera/name selection over `tests/simulation` (`-k "camera or Camera or name"`): 3949 passed, 2 failed - both `start_recording` needing `lerobot`, absent on this runner.
- Whole-tree graders (`scripts/check_whole_tree_graders.py` roster, 138 of 140; the two skipped are the `@tool` docstring graders, which import `lerobot` and grade a surface this diff does not touch): 5058 passed, 24 failed. The same 24 fail on `main`'s `utils.py` in this environment - every one names an absent optional module (`lerobot`, `awsiot`, `torch`, `device_connect_edge`). Delta: 0.
- Neighbouring owners re-run green: `test_reserved_camera_name_at_creation.py`, `test_entity_name_domain_at_creation.py`, `test_camera_schema_key_collision.py`, `test_render_all_multicamera.py`, `test_camera_name_list_contract.py`.

## Intake

`check_duplicate_claim.py --issue 3562` -> `unique-claim`; `check_merge_base_overlap.py --paths` -> no open PR edits either path; re-read at open time: #3562 still `OPEN`, no PR links it; #3563 (opened meanwhile) touches `tests/drivers/` only.

Closes #3562

## Round changelog

- r0: opened.