### PR TITLE
fix(simulation): a camera name may not carry structure its frames cannot travel under

### DIFF
--- a/changelog.d/3569-sim-camera-frame-key-structure.md
+++ b/changelog.d/3569-sim-camera-frame-key-structure.md
@@ -1,0 +1,22 @@
+### Fixed: a sim camera's name may not carry structure its own frames cannot travel under
+
+`add_camera` accepted any string as a camera name, but that name is the key the
+camera's frames travel under: the mesh publishes each frame on
+`strands/<peer_id>/camera/<name>` and the IoT offload joins the name into
+`<prefix>/<peer_id>/<name>/<ts>.jpg`. Measured on one `create_world` (zenoh
+1.10.1), `'**'`, `'*'`, `'a$b'`, `'cam#1'`, `'cam?1'`, `'a+b'`, `'a//b'`,
+`'/wrist'`, `'..'`, `'.'` and `'sub/../etc'` all reported `status="success"`,
+registered and compiled into the model - and then a wildcard name was routed by
+intersection, delivering one camera's frames to peers subscribed to a different
+camera; a name carrying a character Zenoh forbids made the topic unpublishable,
+which the publish loop logs at debug, so the camera rendered forever and never
+reached the mesh; and `s3_key_for('rover01', '..', 123)` resolved to
+`frames/123.jpg`, outside the peer's own prefix.
+
+The shared `camera_name_error` every backend's `add_camera` reads now also
+applies `camera_frame_key_error`, so the rule holds on MuJoCo, Newton and Isaac
+alike. It is deliberately narrower than the bare-token rule the hardware
+`cameras` mapping applies: a sim camera name carries the backend's own
+namespacing, so `arm0/wrist_cam` - the form recording documents - is still
+accepted, as are a name with a space or an inner dot. Only what no consumer can
+carry is refused.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -139,6 +139,14 @@ which swaps the compiled scene but leaves the camera registry untouched) is
 absent from the observation rather than filled in with the
 overview, so a column is never quietly populated from the wrong camera.
 
+A camera's name is also the key its frames travel under once the world is on
+the mesh: each frame is published on `strands/<peer_id>/camera/<name>` and, with
+the IoT offload enabled, written to `<prefix>/<peer_id>/<name>/<ts>.jpg`. So
+`add_camera` refuses a name carrying structure those consumers read instead of
+the name - `*`, `$`, `#`, `?` or `+` (Zenoh and MQTT wildcards, or characters
+they forbid outright), and an empty, `.` or `..` path segment. The namespaced
+form above is unaffected: `arm0/wrist_cam` is a name, `arm0/../wrist_cam` is not.
+
 That guarantee needs the scene's cameras to have distinct column names, and the
 `/` -> `__` collapse is not injective: `arm0/wrist` and `arm0__wrist` are two
 cameras and one column. `start_recording` refuses such a scene up front, naming

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -5318,6 +5318,12 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
             # prim would land at ``/World/Cameras/``, the container scope shared
             # by every camera on the stage.
             #
+            # The rule also refuses a name carrying structure the camera's own
+            # frames cannot travel under (a Zenoh or MQTT wildcard, a character
+            # either forbids, a relative or empty path segment). That half holds
+            # on every backend, because what reads the name as structure is the
+            # mesh topic and the S3 object key rather than this renderer.
+            #
             # ``routes_free_camera_tokens=False``: unlike the MuJoCo and Newton
             # backends, this one's ``get_frame`` looks a camera up in
             # ``self._cameras`` directly with no token check, so ``"default"``

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -4457,7 +4457,13 @@ class MuJoCoSimEngine(
         mount points before placing a camera; robot bodies are namespaced
         ``<robot>/<body>`` (e.g. ``so101/gripper`` is the SO101 wrist mount).
 
-        Validation: ``name`` must be a non-empty ``str`` containing no NUL, and
+        Validation: ``name`` must be a non-empty ``str`` containing no NUL, must
+        carry no structure its own frames cannot travel under - no ``*``, ``$``,
+        ``#``, ``?`` or ``+``, and no empty, ``.`` or ``..`` path segment, since
+        the mesh publishes each frame on ``strands/<peer_id>/camera/<name>`` and
+        the IoT offload joins the name into the S3 object key
+        (:func:`~strands_robots.utils.camera_frame_key_error`; a namespaced name
+        such as ``arm0/wrist_cam`` is still accepted) - and
         must not be one of the free-camera routing tokens
         (:data:`~strands_robots.utils.FREE_CAMERA_TOKENS` - ``None``, ``""``,
         ``"default"``, ``"free"``). ``render``/``render_depth``/``get_frame``
@@ -4465,10 +4471,10 @@ class MuJoCoSimEngine(
         so a camera created under any of them could never be rendered from even
         though it is registered, compiled into the model and listed by
         ``list_cameras``; a non-string name is additionally not addressable
-        through the agent-tool surface. Both halves of the name rule come from
+        through the agent-tool surface. All three halves of the name rule come from
         the shared :func:`~strands_robots.utils.camera_name_error`, which every
         backend's ``add_camera`` reads, so the rule and its order are stated
-        once: the name is judged BEFORE any value, because a reserved name is
+        once: the name is judged BEFORE any value, because a name fault is
         the one fault no change of value can clear. The Newton backend refuses
         the same set because it routes the same tokens; the Isaac backend does
         not route them - its ``get_frame`` looks the name up directly - so it

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -1467,8 +1467,11 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         there is no upper cap.
 
         Args:
-            name: Unique camera name; a non-empty ``str`` containing no NUL and
-                not a free-camera routing token, the same rule and the same
+            name: Unique camera name; a non-empty ``str`` containing no NUL, no
+                structure its own frames cannot travel under (no ``*``, ``$``,
+                ``#``, ``?``, ``+`` and no empty, ``.`` or ``..`` path segment -
+                a namespaced ``arm0/wrist_cam`` is accepted) and not a
+                free-camera routing token: the same rule and the same
                 order the MuJoCo backend's ``add_camera`` applies
                 (:func:`~strands_robots.utils.camera_name_error`, judged before
                 any value below). Duplicate
@@ -1496,8 +1499,8 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
 
         # The whole name rule, in the one order ``camera_name_error`` owns and
         # the MuJoCo backend's ``add_camera`` reads too: a value that cannot be
-        # a registry key, then a ``str`` this backend's render entry points
-        # resolve past. Both guards precede every value rule below, so the two
+        # a registry key, then a name whose frames could not travel under it,
+        # then a ``str`` this backend's render entry points resolve past. Both guards precede every value rule below, so the two
         # backends name the same cause for the same request - the reserved-name
         # test used to sit after the pose, fov and pixel-dimension rules here,
         # and a request with a routing token AND a bad value was refused by both

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -2938,15 +2938,123 @@ def entity_name_error(method: str, param_name: str, name: Any) -> str | None:
     return None
 
 
+#: Characters a camera's frame consumers read as transport structure rather than
+#: as part of the camera's name. ``*`` and ``$`` open a Zenoh wildcard; ``#`` and
+#: ``?`` are forbidden in a Zenoh key expression outright; ``#`` and ``+`` are
+#: MQTT wildcards, which a publish topic may not carry - the same three
+#: characters :func:`~strands_robots.mesh.security.validate_mesh_identifier` keeps out of a
+#: ``peer_id``, for the
+#: same reason. See :func:`camera_frame_key_error`.
+_CAMERA_WIRE_CHARS: Final = ("*", "$", "#", "?", "+")
+
+#: Path segments that do not name a level of the key a frame is written under:
+#: ``..`` walks out of it, ``.`` stays put and an empty one is no level at all,
+#: so none of the three addresses the camera. Matched with a pattern rather than
+#: by splitting the name, because a guard must not run the caller's own code
+#: while judging their value - a ``str`` subclass owes its ``split`` nothing, and
+#: :func:`entity_name_error` accepts one.
+_CAMERA_PARENT_SEGMENT: Final = re.compile(r"(?:\A|/)\.\.(?:/|\Z)")
+_CAMERA_CURRENT_SEGMENT: Final = re.compile(r"(?:\A|/)\.(?:/|\Z)")
+_CAMERA_EMPTY_SEGMENT: Final = re.compile(r"\A/|//|/\Z")
+
+
+def camera_frame_key_error(method: str, param_name: str, name: Any) -> str | None:
+    """Return an error message if ``name`` cannot key the frames it will publish.
+
+    The simulation-side counterpart to :func:`camera_token_error`. Both guard the
+    same fact - a camera's name is the key its frames travel under - but they
+    guard it at doors whose accepted domains genuinely differ. A ``cameras``
+    mapping's key is a label the caller invents, so that door requires a bare
+    token. A simulation camera's name is additionally the backend's own
+    namespaced entity name: a camera belonging to a robot is
+    ``<robot>/<camera>`` (``arm0/wrist_cam``), the form
+    :meth:`~strands_robots.mesh.core.Mesh._publish_sim_cameras` strips the
+    robot prefix from and ``docs/recording.md`` documents recording under, so
+    ``/`` there is structure the backend put in the name and cannot be refused.
+
+    What is refused is the structure no consumer can carry, whatever the name is
+    namespaced by. Measured on this tree (zenoh 1.10.1, one ``create_world`` on
+    the MuJoCo backend, then ``CameraOffloader(bucket="b", prefix="frames")``):
+
+    * **A wildcard.** A camera named ``'**'`` published its frames on
+      ``strands/rover01/camera/**``, a key expression a ``put`` is routed by
+      *intersection*: it matched a peer subscribed to
+      ``strands/rover01/camera/wrist``, so one camera's frames were delivered to
+      every peer asking for a different one.
+    * **A character the transport forbids.** ``'cam#1'``, ``'cam?1'`` and
+      ``'$*'`` each made ``zenoh.KeyExpr`` refuse the topic outright (``'#' and '?'
+      are forbidden characters``), and an empty chunk - ``'a//b'``,
+      ``'/wrist'`` - refused it the same way. The publish loop logs that at debug
+      and moves on, so the camera registers, compiles, renders and simply never
+      reaches the mesh, with nothing reporting a fault.
+    * **A relative segment.** ``s3_key_for('rover01', '..', 123)`` returned
+      ``'frames/rover01/../123.jpg'``, which resolves to ``'frames/123.jpg'`` -
+      outside the peer's own prefix. ``'.'`` and ``'sub/../etc'`` resolve to a
+      key that is not the one requested either, so two distinct cameras can
+      write to one object.
+
+    This is deliberately not the bare-token alphabet. A name carrying a space, a
+    dot inside a segment or a non-ASCII letter addresses its camera and keys its
+    frames intact, and refusing those would be a decision about naming style;
+    :func:`entity_name_error` records the same boundary for the entity names it
+    guards. Every name this refuses is refused by :func:`camera_token_error` too,
+    so the stricter door stays a strict subset of this one.
+
+    Args:
+        method: The calling method, for the message prefix (e.g. ``"add_camera"``).
+        param_name: The parameter being validated, for the message.
+        name: The claimed camera name. Anything at all; a value that cannot be a
+            registry key is refused first by :func:`entity_name_error`.
+
+    Returns:
+        An error message naming the value, the character or segment, and the
+        consumer that reads it as structure, or ``None`` when *name* keys its
+        frames intact.
+    """
+    if (err := entity_name_error(method, param_name, name)) is not None:
+        return err
+    rendered = refusal_repr(name)
+    for char in _CAMERA_WIRE_CHARS:
+        if char in name:
+            return (
+                f"{method}: {param_name}={rendered} must not contain {char!r}; a camera's frames "
+                "are published on 'strands/<peer_id>/camera/<name>', where '*' and '$' open a "
+                "wildcard a put is routed by intersection - so the frames reach peers asking for "
+                "a different camera - and '#', '?' and '+' are characters a Zenoh key expression "
+                "or an MQTT publish topic cannot carry at all, which drops the frames silently."
+            )
+    if _CAMERA_EMPTY_SEGMENT.search(name) is not None:
+        return (
+            f"{method}: {param_name}={rendered} must not contain an empty path segment; a "
+            "camera's frames are published on 'strands/<peer_id>/camera/<name>', and an "
+            "empty topic level is not a key any transport accepts, so the frames are "
+            "dropped silently."
+        )
+    for pattern, segment in ((_CAMERA_PARENT_SEGMENT, ".."), (_CAMERA_CURRENT_SEGMENT, ".")):
+        if pattern.search(name) is not None:
+            return (
+                f"{method}: {param_name}={rendered} must not contain a '{segment}' path segment; "
+                "the frame offload joins the name into the object key "
+                "'<prefix>/<peer_id>/<name>/<ts>.jpg', which '..' walks out of and '.' collapses, "
+                "so the frames land under a key that does not address this camera."
+            )
+    return None
+
+
 def camera_name_error(method: str, param_name: str, name: Any, *, routes_free_camera_tokens: bool) -> str | None:
     """Return an error message if ``name`` cannot address the camera it claims.
 
     The whole name rule for a camera creation site, in one place and in one
     order: :func:`entity_name_error` first (a value that cannot be a registry
-    key at all), then :func:`reserved_camera_name_error` (a ``str`` this
+    key at all), then :func:`camera_frame_key_error` (a name whose frames cannot
+    travel under it), then :func:`reserved_camera_name_error` (a ``str`` this
     backend's own render entry points resolve past). Every ``add_camera``
     reads it, so the order is a property of the rule rather than of whichever
     body a caller reached.
+
+    The three are disjoint on this tree - no value trips more than one - so the
+    order is what a caller reads rather than a precedence between rules, and it
+    runs before every *value* rule for the reason stated below.
 
     That order was the defect this composition removes. The two guards had been
     applied separately at each site, and the sites disagreed about where the
@@ -2989,6 +3097,8 @@ def camera_name_error(method: str, param_name: str, name: Any, *, routes_free_ca
         address a camera on this backend.
     """
     if (err := entity_name_error(method, param_name, name)) is not None:
+        return err
+    if (err := camera_frame_key_error(method, param_name, name)) is not None:
         return err
     if routes_free_camera_tokens:
         return reserved_camera_name_error(method, param_name, name)

--- a/tests/simulation/test_reserved_camera_name_at_creation.py
+++ b/tests/simulation/test_reserved_camera_name_at_creation.py
@@ -554,7 +554,7 @@ class TestTheComposedRuleIsTheOnlyNameGuard:
         assert camera_name_error("add_camera", "name", name, routes_free_camera_tokens=True) is not None
 
     def test_every_add_camera_reads_the_composed_rule_and_none_re_spells_it(self) -> None:
-        """Structural pin: the two halves are not applied separately any more.
+        """Structural pin: the halves are not applied separately any more.
 
         Applying them separately is exactly how the order came to differ, so a
         site that calls either half directly is the defect returning, not a style
@@ -575,7 +575,7 @@ class TestTheComposedRuleIsTheOnlyNameGuard:
                 where = f"{path.relative_to(_package_root())}:{node.lineno}"
                 if "camera_name_error" in called:
                     readers.append(where)
-                for half in ("entity_name_error", "reserved_camera_name_error"):
+                for half in ("entity_name_error", "camera_frame_key_error", "reserved_camera_name_error"):
                     if half in called:
                         offenders.append(f"{where} calls {half} directly")
         assert len(readers) >= 3, f"expected every backend add_camera to read the rule, found {readers}"

--- a/tests/simulation/test_sim_camera_name_keys_the_frames_it_publishes.py
+++ b/tests/simulation/test_sim_camera_name_keys_the_frames_it_publishes.py
@@ -1,0 +1,285 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests: ``add_camera`` refuses a name its own frames cannot travel under.
+
+A simulation camera's name is not only a registry key. When the world is on the
+mesh, every frame it renders is published on ``strands/<peer_id>/camera/<name>``
+and, with the IoT offload enabled, written to
+``<prefix>/<peer_id>/<name>/<ts>.jpg`` -- so the name is read as transport
+structure by both consumers. Until this fix ``add_camera`` accepted any string:
+measured on this tree (zenoh 1.10.1, one ``create_world``), ``'**'``, ``'*'``,
+``'a$b'``, ``'cam#1'``, ``'cam?1'``, ``'a+b'``, ``'a//b'``, ``'/wrist'``,
+``'..'``, ``'.'`` and ``'sub/../etc'`` all returned ``status="success"``,
+registered, and compiled into the model.
+
+What each one then did to a consumer is the subject of
+``TestTheConsumerThatReadsTheNameAsStructure``: a wildcard is routed by
+intersection, so one camera's frames reach a peer subscribed to another; a
+character Zenoh forbids makes the topic unpublishable, and the publish loop logs
+that at debug, so the camera renders forever and never reaches the mesh; a
+``..`` segment walks the object key out of the peer's own prefix.
+
+The rule is deliberately narrower than
+:func:`~strands_robots.utils.camera_token_error`, which the hardware ``cameras``
+mapping applies. A sim camera name carries the backend's own namespacing --
+``arm0/wrist_cam`` is the form ``docs/recording.md`` documents recording under --
+so ``/`` is structure the backend put there and cannot be refused, and a name
+with a space or an inner dot keys its frames intact. Only what no consumer can
+carry is refused; ``TestTheStricterDoorStaysAStrictSuperset`` pins that
+relationship in both directions.
+
+These tests need no GL: ``add_camera`` compiles the spec but renders nothing, and
+the Newton and Isaac halves need neither optional package because the guard runs
+before the method touches a solver (the unbound-method stand-in pattern
+``tests/simulation/newton/test_add_camera_numeric_validation.py`` uses).
+"""
+
+from __future__ import annotations
+
+import posixpath
+import threading
+import types
+from typing import Any, cast
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.newton.simulation import NewtonSimEngine
+from strands_robots.utils import camera_frame_key_error, camera_token_error
+
+# One row per reserved character or segment, with the phrase the refusal must
+# answer it with -- not one row per spelling of the same fault.
+UNUSABLE = [
+    pytest.param("*", "must not contain '*'", id="zenoh-wildcard"),
+    pytest.param("**", "must not contain '*'", id="zenoh-multi-wildcard"),
+    pytest.param("arm0/**", "must not contain '*'", id="wildcard-under-a-namespace"),
+    pytest.param("a$b", "must not contain '$'", id="zenoh-verbatim-wildcard-marker"),
+    pytest.param("cam#1", "must not contain '#'", id="mqtt-multi-wildcard"),
+    pytest.param("cam?1", "must not contain '?'", id="zenoh-forbidden-character"),
+    pytest.param("a+b", "must not contain '+'", id="mqtt-single-level-wildcard"),
+    pytest.param("..", "'..' path segment", id="parent-of-the-peer-prefix"),
+    pytest.param(".", "'.' path segment", id="the-peer-prefix-itself"),
+    pytest.param("sub/../etc", "'..' path segment", id="parent-inside-a-namespaced-name"),
+    pytest.param("a//b", "empty path segment", id="empty-topic-level"),
+    pytest.param("/wrist", "empty path segment", id="leading-separator"),
+    pytest.param("wrist/", "empty path segment", id="trailing-separator"),
+]
+
+#: Names that must keep working. The last three are the point of the narrower
+#: rule: the namespaced form the backend itself produces, and two names the
+#: stricter ``cameras``-mapping door refuses on style while every frame consumer
+#: carries them unchanged.
+USABLE = ["wrist", "front_cam", "cam-2", "0", "arm0/wrist_cam", "a b", "wrist.rgb"]
+
+
+class TestTheDomain:
+    """The rule, read directly, before any backend applies it."""
+
+    @pytest.mark.parametrize(("name", "phrase"), UNUSABLE)
+    def test_a_name_no_consumer_could_carry_is_refused(self, name: str, phrase: str) -> None:
+        message = camera_frame_key_error("add_camera", "name", name)
+        assert message is not None, name
+        assert phrase in message, message
+        assert repr(name) in message, message
+
+    @pytest.mark.parametrize("name", USABLE)
+    def test_a_name_that_keys_its_frames_intact_is_accepted(self, name: str) -> None:
+        assert camera_frame_key_error("add_camera", "name", name) is None
+
+    @pytest.mark.parametrize("name", [None, 7, "", ["wrist"]])
+    def test_a_value_that_is_no_name_at_all_is_left_to_the_addressability_domain(self, name: Any) -> None:
+        """A non-name is refused for not being one, not for its punctuation."""
+        message = camera_frame_key_error("add_camera", "name", name)
+        assert message is not None
+        assert "must not contain" not in message, message
+
+    def test_a_hostile_str_subclass_is_judged_without_running_its_code(self) -> None:
+        """The guard reads the name with a pattern, never with the caller's methods.
+
+        ``entity_name_error`` accepts a ``str`` subclass - it is a string by every
+        operation the registry performs - so the segment rule cannot be spelled
+        ``name.split("/")``: that runs an override while judging the value, which
+        is the read ``tests/test_refusal_messages_never_raise.py`` scans for.
+        """
+
+        class Hostile(str):
+            def split(self, *args: Any, **kwargs: Any) -> list[str]:
+                raise RuntimeError("the caller's code ran")
+
+        assert camera_frame_key_error("add_camera", "name", Hostile("a/../b")) is not None
+        assert camera_frame_key_error("add_camera", "name", Hostile("arm0/wrist_cam")) is None
+
+    @pytest.mark.parametrize(("name", "_phrase"), UNUSABLE)
+    def test_the_message_names_the_method_and_stays_ascii(self, name: str, _phrase: str) -> None:
+        message = camera_frame_key_error("add_camera", "name", name)
+        assert message is not None
+        assert message.startswith("add_camera: name=")
+        message.encode("ascii")
+
+
+class TestTheStricterDoorStaysAStrictSuperset:
+    """Two doors, one fact, and a stated difference between their domains.
+
+    The ``cameras`` mapping's key is a label the caller invents, so that door
+    requires a bare token; a sim camera's name carries the backend's namespacing,
+    so this one cannot. Pinning both directions is what keeps the pair from
+    drifting into two unrelated alphabets.
+    """
+
+    @pytest.mark.parametrize(("name", "_phrase"), UNUSABLE)
+    def test_the_token_rule_refuses_everything_this_rule_refuses(self, name: str, _phrase: str) -> None:
+        assert camera_token_error("Robot(cameras=...)", "camera name", name) is not None
+
+    @pytest.mark.parametrize("name", ["arm0/wrist_cam", "a b", "wrist.rgb"])
+    def test_and_refuses_more_than_it_does(self, name: str) -> None:
+        """The names that make the two domains genuinely different."""
+        assert camera_token_error("Robot(cameras=...)", "camera name", name) is not None
+        assert camera_frame_key_error("add_camera", "name", name) is None
+
+
+@pytest.fixture
+def sim():
+    pytest.importorskip("mujoco")
+    from strands_robots.simulation.mujoco.simulation import Simulation
+
+    s = Simulation(tool_name="test_sim_camera_frame_key", mesh=False)
+    assert s.create_world()["status"] == "success"
+    yield s
+    s.cleanup()
+
+
+def _compiled_camera_names(sim) -> list[str]:
+    import mujoco
+
+    model = sim._world._model
+    return [mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_CAMERA, i) for i in range(model.ncam)]
+
+
+def _newton_add_camera(name: Any, **kwargs: Any) -> dict[str, Any]:
+    """Call Newton's unbound ``add_camera`` with a stand-in for ``self``.
+
+    The guard runs before the method touches a solver, so the stand-in carries
+    only what the body reads and neither ``newton`` nor ``warp`` is needed.
+    """
+    stub = types.SimpleNamespace(
+        _world=types.SimpleNamespace(cameras={}),
+        _model=types.SimpleNamespace(body_label=("ground", "ball")),
+        _lock=threading.RLock(),
+    )
+    request: dict[str, Any] = {"position": [1.0, 1.0, 1.0], "target": [0.0, 0.0, 0.0]}
+    request.update(kwargs)
+    result = NewtonSimEngine.add_camera(cast(NewtonSimEngine, stub), name, **request)
+    return {**result, "registry": dict(stub._world.cameras)}
+
+
+def _isaac_engine():
+    from strands_robots.simulation.isaac.simulation import IsaacConfig, IsaacSimulation
+
+    engine = IsaacSimulation.__new__(IsaacSimulation)
+    engine._config = IsaacConfig()
+    engine._lock = threading.RLock()
+    engine._world = None
+    engine._world_created = True
+    engine._robots = {}
+    engine._objects = {}
+    engine._cameras = {}
+    engine._prim_registry = []
+    engine._cam_out_size = {}
+    engine._camera_warmup_steps = 0
+    engine._sim_time = 0.0
+    engine._step_count = 0
+    engine._main_tid = threading.get_ident()
+    engine._create_camera_prim = lambda **kwargs: (object(), 24.0)  # type: ignore[method-assign]
+    return engine
+
+
+class TestEveryBackendAppliesIt:
+    """One request, one verdict, one sentence, whichever engine is held.
+
+    Isaac is included even though it opts out of the free-camera routing rule:
+    that rule follows from what *its* renderer resolves, and this one follows
+    from what the mesh publishes, which is the same for all three.
+    """
+
+    @pytest.mark.parametrize(("name", "phrase"), UNUSABLE)
+    def test_mujoco_refuses_and_creates_nothing(self, sim, name: str, phrase: str) -> None:
+        result = sim.add_camera(name=name, position=[0.5, 0.5, 0.5], target=[0.0, 0.0, 0.0])
+        assert result["status"] == "error", (name, result)
+        assert phrase in result["content"][0]["text"]
+        assert name not in sim._world.cameras
+        assert name not in _compiled_camera_names(sim)
+
+    @pytest.mark.parametrize(("name", "phrase"), UNUSABLE)
+    def test_newton_refuses_with_the_same_sentence(self, sim, name: str, phrase: str) -> None:
+        newton = _newton_add_camera(name)
+        mujoco_result = sim.add_camera(name=name, position=[1.0, 1.0, 1.0], target=[0.0, 0.0, 0.0])
+        assert newton["status"] == "error"
+        assert newton["registry"] == {}
+        assert newton["content"][0]["text"] == mujoco_result["content"][0]["text"]
+
+    @pytest.mark.parametrize(("name", "phrase"), UNUSABLE)
+    def test_isaac_refuses_it_too(self, name: str, phrase: str) -> None:
+        engine = _isaac_engine()
+        result = engine.add_camera(name, position=[2.0, 2.0, 2.0], target=[0.0, 0.0, 0.0])
+        assert result["status"] == "error", (name, result)
+        assert phrase in result["content"][0]["text"]
+        assert engine._cameras == {}
+
+    @pytest.mark.parametrize("name", USABLE)
+    def test_a_usable_name_still_registers_on_every_backend(self, sim, name: str) -> None:
+        result = sim.add_camera(name=name, position=[0.5, 0.5, 0.5], target=[0.0, 0.0, 0.0])
+        assert result["status"] == "success", (name, result)
+        assert name in sim._world.cameras
+        assert name in _compiled_camera_names(sim)
+        assert _newton_add_camera(name)["status"] == "success"
+        assert _isaac_engine().add_camera(name, position=[2.0, 2.0, 2.0])["status"] == "success"
+
+
+class TestTheConsumerThatReadsTheNameAsStructure:
+    """Why the rule: what each refused name did to a consumer before the fix."""
+
+    def test_a_wildcard_name_publishes_where_another_cameras_subscriber_listens(self) -> None:
+        """Zenoh routes a ``put`` by intersection, so ``'**'`` is not a name."""
+        zenoh = pytest.importorskip("zenoh")
+        asking_for_wrist = zenoh.KeyExpr("strands/rover01/camera/wrist")
+        for name in ("*", "**"):
+            published_on = zenoh.KeyExpr(f"strands/rover01/camera/{name}")
+            assert published_on.intersects(asking_for_wrist), name
+            assert camera_frame_key_error("add_camera", "name", name) is not None
+        # '$' opens one too: '$*' matches inside a chunk, so 'a$*b' is delivered
+        # to the peer subscribed to the real camera 'a_b'.
+        assert zenoh.KeyExpr("strands/rover01/camera/a$*b").intersects(zenoh.KeyExpr("strands/rover01/camera/a_b"))
+        assert camera_frame_key_error("add_camera", "name", "a$*b") is not None
+        # The control: a real name reaches only the peer that asked for it.
+        assert not zenoh.KeyExpr("strands/rover01/camera/front").intersects(asking_for_wrist)
+
+    @pytest.mark.parametrize("name", ["cam#1", "cam?1", "a$b", "a//b", "/wrist", "wrist/"])
+    def test_a_forbidden_character_makes_the_topic_unpublishable(self, name: str) -> None:
+        """The frames are not misrouted, they are never published at all."""
+        zenoh = pytest.importorskip("zenoh")
+        with pytest.raises(Exception):  # noqa: B017 -- zenoh raises its own ZError type
+            zenoh.KeyExpr(f"strands/rover01/camera/{name}")
+        assert camera_frame_key_error("add_camera", "name", name) is not None
+
+    def test_and_the_publish_loop_reports_nothing_when_it_fails(self) -> None:
+        """Which is why the door has to refuse it: the failure is logged at debug."""
+        from strands_robots.mesh import Mesh
+
+        inner = types.SimpleNamespace(is_connected=True, name="so101", config=types.SimpleNamespace(cameras={}))
+        mesh = Mesh(types.SimpleNamespace(tool_name_str="so101", robot=inner), peer_id="rover01")
+        frame = np.full((48, 64, 3), 128, dtype=np.uint8)
+        with patch("strands_robots.mesh.core.put", side_effect=RuntimeError("Invalid Key Expr")) as mock_put:
+            mesh._encode_and_publish_frames({"cam#1": frame}, ["cam#1"])
+        assert mock_put.call_args[0][0] == "strands/rover01/camera/cam#1"
+
+    @pytest.mark.parametrize(("name", "resolved"), [("..", "frames/123.jpg"), (".", "frames/rover01/123.jpg")])
+    def test_a_relative_segment_writes_outside_the_key_it_asked_for(self, name: str, resolved: str) -> None:
+        from strands_robots.mesh.iot.camera_offload import CameraOffloader
+
+        offloader = CameraOffloader(bucket="fleet-frames", prefix="frames")
+        key = offloader.s3_key_for("rover01", name, 123)
+        assert posixpath.normpath(key) == resolved
+        assert camera_frame_key_error("add_camera", "name", name) is not None
+        # The control: a usable name writes exactly where it says it does.
+        assert offloader.s3_key_for("rover01", "wrist", 123) == "frames/rover01/wrist/123.jpg"


### PR DESCRIPTION
![add_camera frame-key structure](https://raw.githubusercontent.com/cagataycali/robots/79820ce9db35195f3da0c98660f62b9c95d08201/pr_camera_frame_key.png)

## What
`add_camera` accepted any string, but the name is the key the camera's frames travel under: the mesh publishes each frame on `strands/<peer_id>/camera/<name>` and the IoT offload joins it into `<prefix>/<peer_id>/<name>/<ts>.jpg`. All 16 names above reported `status="success"`, registered and compiled into the model.

## Why
A wildcard name is routed by intersection, so `'**'` published where a peer subscribed to `camera/wrist` listens. A character Zenoh forbids (`#`, `?`, `$`, an empty chunk) makes the topic unpublishable, and the publish loop logs that at debug - the camera renders forever and never reaches the mesh. `s3_key_for('rover01', '..', 123)` resolves to `frames/123.jpg`, outside the peer's own prefix.

The shared `camera_name_error` now also applies a new `camera_frame_key_error`, so MuJoCo, Newton and Isaac inherit one rule. It is deliberately narrower than the bare-token rule the hardware `cameras` mapping uses: a sim name carries the backend's own namespacing, so `arm0/wrist_cam` (the form `docs/recording.md` documents) still registers, compiles and renders - right-hand panel - as do `'a b'` and `'wrist.rgb'`. The segment rule is a pattern, not `name.split('/')`, because a guard must not run the caller's code while judging their value.

## Tests
`tests/simulation/test_sim_camera_name_keys_the_frames_it_publishes.py`: 110 cells - the domain, the three backends, the strict-subset relation to `camera_token_error`, and the consumer measurements (zenoh key-expression intersection and rejection, the resolved S3 key). Unwiring the guard fails 39 of them. Full suite 52418 passed / 316 skipped, coverage 96.07%; ruff + mypy clean on `strands_robots tests tests_integ`.