### PR TITLE
test(drivers/ur): grade every rollout exit reason and both connect failures

### DIFF
--- a/changelog.d/3573-ur-rollout-exit-reasons.md
+++ b/changelog.d/3573-ur-rollout-exit-reasons.md
@@ -1,0 +1,33 @@
+### Tests: the UR rollout's exit reasons and both connect failures are graded
+
+`tests/drivers/ur/test_ur_driver_over_a_fake_controller.py` drove the paths where
+the arm answers. Four of `_Rollout._run`'s exits and both halves of
+`URDriver.connect_eagerly`'s failure ladder were graded by nothing: 43 of
+`drivers/ur.py`'s 459 statements uncovered.
+
+`exit_reason` is what an operator reads to learn why an arm stopped moving, so the
+ungraded set was the half that matters most. Six cells over it, in the file that
+already owns this driver's controller double:
+
+* `duration` -- a rollout with no step budget ends on its clock, and reports that
+  rather than a refusal (`refusal` stays `None`).
+* `policy` from a *raised* step, distinct from the already-graded "returned no
+  action dict": the exception class and its message identify the fault, and
+  nothing reaches `servoJ`.
+* `stopped` before the first step, and `stopped` at the pacing tick after a stop
+  landed *inside* a write -- the setpoint already on the wire is counted, and the
+  tick answers the stop instead of commanding another step. The second is armed
+  from the rollout thread through the double's mode-read hook, so it lands in the
+  window the loop's comment describes rather than near it.
+* A controller that does not answer RTDE receive is reported by address, and the
+  control side is not dialled at all.
+* A control side that refuses releases the receive interface it opened. The driver
+  records `_receive` only once both sides open, so an interface left connected
+  there is unreachable afterwards -- `cleanup` releases what was recorded.
+
+Measured by mutation: six changes to the behaviours these cells grade, five
+detected singly. The sixth -- deleting the loop's top-of-loop stop read -- is
+absorbed by the pre-write re-read, which is by design (that comment says the
+re-read "cannot be the only one"); removing both fails the cell on `steps`.
+
+`drivers/ur.py`: 43 -> 27 missing, 91% -> 94%. No production statement changed.

--- a/tests/drivers/ur/test_ur_driver_over_a_fake_controller.py
+++ b/tests/drivers/ur/test_ur_driver_over_a_fake_controller.py
@@ -30,6 +30,7 @@ from strands_robots.drivers.ur import (
     SERVOJ_GAIN,
     SERVOJ_LOOKAHEAD_TIME,
     URDriver,
+    _Rollout,
 )
 from tests.mocks.ur_rtde import (
     MEASURED_Q,
@@ -50,6 +51,29 @@ def _connected(fake: FakeRTDE, **kwargs: object) -> URDriver:
     return driver
 
 
+def _reachable_setpoint() -> dict[str, float]:
+    """A setpoint one step off the measured pose, so the step gate admits it."""
+    return {name: q + 0.001 for name, q in zip(JOINT_NAMES, MEASURED_Q, strict=True)}
+
+
+def _rollout(driver: URDriver, policy: Any) -> _Rollout:
+    """One rollout the test starts itself, so a stop can be placed exactly.
+
+    ``run_policy`` owns the thread it starts, which is what the cells above
+    drive. Two of the loop's exits are decided in the window between a stop and
+    the next setpoint, and placing a stop inside that window needs a reference
+    to the rollout before it runs.
+    """
+    return _Rollout(
+        driver=driver,
+        policy=policy,
+        instruction="",
+        duration=30.0,
+        n_steps=None,
+        period=1.0 / 200.0,
+    )
+
+
 class TestConnecting:
     """Reachability, and the mode interrogation that decides usability."""
 
@@ -63,6 +87,53 @@ class TestConnecting:
         driver = _connected(fake_rtde)
         assert driver.connect_eagerly() is None
         assert len(fake_rtde.controls) == 1, "a second connect must not open a second interface"
+
+    def test_a_controller_that_does_not_answer_the_receive_side_is_reported_by_address(
+        self, monkeypatch: pytest.MonkeyPatch, fake_rtde: FakeRTDE
+    ) -> None:
+        """An unreachable controller is a reason the caller can read, not a traceback.
+
+        The control side is not dialled at all: the receive interface is what
+        decides reachability, so a failure there ends the attempt.
+        """
+
+        def refuse(host: str, frequency: float | None = None) -> object:
+            raise OSError(f"no route to {host}")
+
+        monkeypatch.setattr("rtde_receive.RTDEReceiveInterface", refuse)
+        driver = URDriver(tool_name="ur5e", port=HOST)
+
+        reason = driver.connect_eagerly()
+
+        assert reason is not None
+        assert "did not answer RTDE receive" in reason
+        assert HOST in reason and "no route to" in reason
+        assert not driver.is_connected
+        assert fake_rtde.controls == [], "an arm that did not answer must not be dialled for control"
+
+    def test_a_control_side_that_refuses_releases_the_receive_side_it_opened(
+        self, monkeypatch: pytest.MonkeyPatch, fake_rtde: FakeRTDE
+    ) -> None:
+        """The half-open attempt is closed rather than left on the controller.
+
+        The receive interface is only recorded on the driver once BOTH sides
+        open, so one left connected here is unreachable afterwards: the driver
+        reports not-connected, and ``cleanup`` releases what it recorded.
+        """
+
+        def refuse(host: str, frequency: float | None = None) -> object:
+            raise OSError("control port busy")
+
+        monkeypatch.setattr("rtde_control.RTDEControlInterface", refuse)
+        driver = URDriver(tool_name="ur5e", port=HOST)
+
+        reason = driver.connect_eagerly()
+
+        assert reason is not None
+        assert "did not answer RTDE control" in reason
+        assert "control port busy" in reason
+        assert not driver.is_connected
+        assert fake_rtde.receive.disconnected, "the receive interface this attempt opened must be released"
 
     def test_a_protective_stopped_controller_is_refused_before_control_opens(
         self, monkeypatch: pytest.MonkeyPatch, fake_rtde: FakeRTDE
@@ -313,6 +384,85 @@ class TestRollingOutAPolicy:
         envelope = driver.run_policy(lambda observation: {}, **kwargs)  # type: ignore[arg-type]
         assert envelope["status"] == "error"
         assert quoted in text_of(envelope)
+
+    def test_a_wall_clock_budget_ends_the_rollout_when_the_clock_runs_out(self, fake_rtde: FakeRTDE) -> None:
+        """``duration`` is an exit reason of its own, and not a refusal.
+
+        A rollout given no step budget ends on its clock, and an operator
+        polling the status has to be able to tell that from the arm turning a
+        setpoint away.
+        """
+        driver = _connected(fake_rtde, control_frequency=200.0)
+
+        def hold(observation: dict[str, float]) -> dict[str, float]:
+            return {"elbow_joint": observation["elbow_joint"]}
+
+        assert driver.run_policy(hold, duration=0.05)["status"] == "success"
+        _wait_for_exit(driver)
+
+        snapshot = json_of(driver.get_task_status())
+        assert snapshot["exit_reason"] == "duration"
+        assert snapshot["refusal"] is None, "a budget that ran out is not a refusal"
+        assert snapshot["steps"] >= 1, "the loop must step before its clock runs out"
+
+    def test_a_policy_that_raises_ends_the_rollout_naming_the_exception(self, fake_rtde: FakeRTDE) -> None:
+        """A policy fault is reported, and it does not reach the wire.
+
+        The loop catches it broadly on purpose - a policy's exceptions are not
+        enumerable - so the class and the message are what identify the fault to
+        whoever polls the status.
+        """
+        driver = _connected(fake_rtde, control_frequency=200.0)
+
+        def boom(observation: dict[str, float]) -> dict[str, float]:
+            raise RuntimeError("the planner lost its goal")
+
+        assert driver.run_policy(boom, n_steps=3)["status"] == "success"
+        _wait_for_exit(driver)
+
+        snapshot = json_of(driver.get_task_status())
+        assert snapshot["exit_reason"] == "policy"
+        assert "RuntimeError" in snapshot["refusal"]
+        assert "the planner lost its goal" in snapshot["refusal"]
+        assert snapshot["steps"] == 0
+        assert fake_rtde.control.servoj_calls == [], "a policy that raised commanded nothing"
+
+    def test_a_rollout_stopped_before_its_first_step_commands_nothing(self, fake_rtde: FakeRTDE) -> None:
+        """The stop is read at the top of the loop, before the first setpoint."""
+        driver = _connected(fake_rtde, control_frequency=200.0)
+        rollout = _rollout(driver, lambda observation: _reachable_setpoint())
+
+        rollout.request_stop()
+        rollout.start()
+
+        assert rollout.join(5.0), "the loop did not exit"
+        snapshot = rollout.snapshot()
+        assert snapshot["exit_reason"] == "stopped"
+        assert snapshot["steps"] == 0
+        assert fake_rtde.control.servoj_calls == [], "a stopped rollout must not write one setpoint first"
+
+    def test_a_stop_during_a_write_ends_the_rollout_at_that_tick(self, fake_rtde: FakeRTDE) -> None:
+        """The setpoint already going out is the last one - the tick does not write again.
+
+        The stop is armed from the rollout thread one statement before
+        ``send_action``, so it lands past the loop's pre-write re-read and inside
+        the mode gate's round trip: the write completes and is counted, and the
+        pacing tick answers the stop instead of pacing another step.
+        """
+        driver = _connected(fake_rtde, control_frequency=200.0)
+
+        def policy(observation: dict[str, float]) -> dict[str, float]:
+            fake_rtde.receive.on_next_mode_read = rollout.request_stop
+            return _reachable_setpoint()
+
+        rollout = _rollout(driver, policy)
+        rollout.start()
+
+        assert rollout.join(5.0), "the loop did not exit"
+        snapshot = rollout.snapshot()
+        assert snapshot["exit_reason"] == "stopped"
+        assert snapshot["steps"] == 1, "the setpoint already on the wire is counted"
+        assert len(fake_rtde.control.servoj_calls) == 1, "the tick after a stop must not command another step"
 
 
 class TestStopping:


### PR DESCRIPTION
## What

`exit_reason` is what an operator reads to learn why a UR arm stopped moving. Four of `_Rollout._run`'s exits and both halves of `connect_eagerly`'s failure ladder were graded by nothing. Six cells, in the file that already owns this driver's controller double.

```mermaid
flowchart TD
  A[loop top] -->|stop set| S1["stopped (NEW)"]
  A --> B{budget}
  B -->|steps reached| N["n_steps"]
  B -->|clock out| D["duration (NEW)"]
  B --> P[policy step]
  P -->|raised| R1["policy + exception (NEW)"]
  P -->|no action dict| R2["policy"]
  P -->|stop set| S2["stopped"]
  P --> W[send_action]
  W -->|refused| F["refused"]
  W --> T{tick}
  T -->|stop set| S3["stopped at the tick (NEW)"]
  T --> A
```

| cell | pins |
|---|---|
| `duration` | ends on its clock, `refusal` stays `None` |
| `policy` raised | class + message reported, nothing reaches `servoJ` |
| stopped pre-first-step | 0 steps, 0 setpoints |
| stopped at the tick | stop landed *inside* the write: 1 step counted, no second setpoint |
| receive refuses | reported by address; control side not dialled |
| control refuses | the receive interface it opened is released (otherwise unreachable - `_receive` is recorded only once both open) |

## Tests

Mutation-measured, since a coverage change has no pre-fix failure: six changes to the graded behaviours, **five detected singly**. The sixth - deleting the loop's top-of-loop stop read - is absorbed by the pre-write re-read, which is by design ("this check cannot be the only one"); removing *both* fails the cell on `steps` (1 != 0).

`drivers/ur.py`: **43 -> 27 missing, 91% -> 94%**. No production statement changed. `tests/drivers/` 3223 -> 3229 passing; ruff + `mypy strands_robots tests tests_integ` clean.

LOC delta: +183 (tests +150, changelog +33), 0 production lines.