### PR TITLE
fix(policies/wbc): allow_missing_models is checked, not read by truthiness

### DIFF
--- a/changelog.d/3574-wbc-allow-missing-models-checked.md
+++ b/changelog.d/3574-wbc-allow-missing-models-checked.md
@@ -1,0 +1,12 @@
+### Fixed: `WBCPolicy(allow_missing_models=...)` is checked, not read by truthiness
+
+`WBCPolicy.__init__` checked `walk` with `boolean_flag_error` and read
+`allow_missing_models` beside it by truthiness. Every non-empty string is
+truthy, so `"false"` - the spelling a JSON `policy_config` reaches for to ask
+for the eager ONNX load - selected the test seam instead: no session was
+loaded, construction succeeded, and the missing checkpoint surfaced at the
+first `get_actions` as a refusal advising `allow_missing_models=False`, the
+value the caller believed they had passed. `None`, `0` and `[]` took the
+loading branch while spelling neither posture. A non-boolean is now refused at
+construction, naming the parameter, ahead of the load it gates; `WBCGaitPolicy`
+forwards the flag to the base class, so one check covers both providers.

--- a/docs/policies/wbc.md
+++ b/docs/policies/wbc.md
@@ -96,6 +96,13 @@ WBCPolicy(
 A missing `onnxruntime` or a missing checkpoint raises `RuntimeError` at
 construction - WBC never falls back to silent zero torques.
 
+`walk` and `allow_missing_models` each select a posture, so both are checked
+rather than read by truthiness: a non-boolean raises `ValueError` naming the
+parameter. A string such as `"false"` - the spelling a JSON `policy_config`
+reaches for - is truthy, and before the check `allow_missing_models="false"`
+selected the test seam, skipping the eager load and deferring the missing
+checkpoint to the first `get_actions` call.
+
 ### Config value domain
 
 `WBCConfig` refuses an unusable *value* at construction, because every numeric

--- a/strands_robots/policies/wbc/policy.py
+++ b/strands_robots/policies/wbc/policy.py
@@ -208,7 +208,12 @@ class WBCPolicy(Policy):
             construction. Assignment is the only route: ``**kwargs`` below
             absorbs unknown keywords, so a session passed to this constructor is
             dropped. Production callers leave this ``False`` so a missing
-            checkpoint fails loudly at construction.
+            checkpoint fails loudly at construction. Checked with
+            :func:`~strands_robots.utils.boolean_flag_error` like ``walk``: it
+            selects a posture, and read by truthiness a string spelling of
+            ``False`` selected the seam, so the eager load the caller asked for
+            was skipped and the missing checkpoint surfaced only at the first
+            ``get_actions`` - as a refusal advising the value they had passed.
         **kwargs: Forward-compatibility absorber for the smart-string / registry
             resolution path. Per the #300 contract, providers MUST ignore
             unknown kwargs rather than raising.
@@ -216,7 +221,8 @@ class WBCPolicy(Policy):
     Raises:
         RuntimeError: If ``onnxruntime`` is missing, or a checkpoint file is
             absent, when ``allow_missing_models`` is ``False``.
-        ValueError: If the resolved config dimensions are inconsistent.
+        ValueError: If ``walk`` or ``allow_missing_models`` is not a boolean,
+            or the resolved config dimensions are inconsistent.
     """
 
     def __init__(
@@ -233,6 +239,12 @@ class WBCPolicy(Policy):
         # alone - and bool() is where "false", a spelling of the balance-only
         # posture, became the locomotion one. See boolean_flag_error.
         if error := boolean_flag_error(walk, "walk", "WBCPolicy"):
+            raise ValueError(error)
+        # Same domain for the seam flag in the same signature. Read by
+        # truthiness, "false" took the `allow_missing_models` branch below, so
+        # the eager load this spelling asks for was skipped and the refusal
+        # arrived one call later, naming the value the caller had passed.
+        if error := boolean_flag_error(allow_missing_models, "allow_missing_models", "WBCPolicy"):
             raise ValueError(error)
         self._walk = walk
         self._robot_state_keys: list[str] = []

--- a/tests/policies/wbc/test_allow_missing_models_is_checked_not_read_by_truthiness.py
+++ b/tests/policies/wbc/test_allow_missing_models_is_checked_not_read_by_truthiness.py
@@ -1,0 +1,112 @@
+"""``allow_missing_models`` is checked at construction, not read by truthiness.
+
+:class:`~strands_robots.policies.wbc.WBCPolicy` takes two posture flags in one
+signature. ``walk`` was checked with
+:func:`~strands_robots.utils.boolean_flag_error`; ``allow_missing_models`` sat
+beside it and was read by ``if not allow_missing_models``. Every non-empty
+string is truthy, so ``"false"`` - the spelling a JSON ``policy_config`` reaches
+for to ask for the eager load - selected the test seam instead: no session was
+loaded, construction succeeded, and the missing checkpoint surfaced at the first
+``get_actions`` as a refusal advising ``allow_missing_models=False``, the value
+the caller believed they had passed. ``None``, ``0`` and ``[]`` took the loading
+branch without ever being a declared spelling of it.
+
+The check lives on the base class only. :class:`~strands_robots.policies.wbc.WBCGaitPolicy`
+forwards the flag to ``super().__init__``, so one site covers both providers,
+and it precedes the load it gates so a refused value reaches no loader.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.wbc import WBCPolicy
+from strands_robots.policies.wbc.gait import WBCGaitPolicy
+from strands_robots.utils import boolean_flag_error
+
+#: Every value below is either a boolean or something the shared domain refuses.
+#: The refused half is derived from the domain rather than copied, so a spelling
+#: the domain later admits or refuses is graded without an edit here.
+_CANDIDATES: list[Any] = ["false", "False", "no", "off", "0", "none", "true", 1.5, [1], None, 0, 0.0, []]
+REFUSED: list[Any] = [v for v in _CANDIDATES if boolean_flag_error(v, "allow_missing_models", "WBCPolicy")]
+assert len(REFUSED) == len(_CANDIDATES), "every candidate is meant to be a non-boolean"
+
+
+def _ids(values: list[Any]) -> list[str]:
+    return [repr(v) for v in values]
+
+
+def _policy(**kwargs: Any) -> WBCPolicy:
+    """Construct with the caller's spelling, typed loosely so the check is what refuses."""
+    return WBCPolicy(**kwargs)
+
+
+def _gait_policy(**kwargs: Any) -> WBCGaitPolicy:
+    return WBCGaitPolicy(**kwargs)
+
+
+@pytest.mark.parametrize("value", REFUSED, ids=_ids(REFUSED))
+def test_a_non_boolean_is_refused_naming_the_parameter(value: Any) -> None:
+    """Neither posture is taken for a value that spells neither."""
+    with pytest.raises(ValueError, match="allow_missing_models"):
+        _policy(allow_missing_models=value)
+
+
+def test_the_refusal_is_the_shared_domain_verbatim() -> None:
+    """One owner for the wording, so this flag and ``walk`` cannot drift apart."""
+    expected = boolean_flag_error("false", "allow_missing_models", "WBCPolicy")
+    assert expected is not None
+    with pytest.raises(ValueError) as excinfo:
+        _policy(allow_missing_models="false")
+    assert str(excinfo.value) == expected
+
+
+def test_the_refusal_precedes_the_load_it_gates() -> None:
+    """A falsy non-boolean used to reach the ONNX loader; now it reaches nothing.
+
+    ``0`` is the sharp case: it is falsy, so before the check it took the
+    loading branch and the caller read a ``RuntimeError`` about ``onnxruntime``
+    or the checkpoint - a diagnosis of the environment for a mistake in the
+    argument. The refusal now names the argument, and it does so whether or not
+    the extra is installed.
+    """
+    with pytest.raises(ValueError, match="allow_missing_models"):
+        _policy(checkpoint="/nonexistent/checkpoint", allow_missing_models=0)
+
+
+def test_walk_is_named_first_when_both_flags_are_wrong() -> None:
+    """The two checks are ordered; the earlier parameter is the one reported."""
+    with pytest.raises(ValueError, match="walk"):
+        _policy(walk="false", allow_missing_models="false")
+
+
+def test_the_gait_variant_forwards_to_the_same_check() -> None:
+    """``WBCGaitPolicy`` forwards the flag, so the base class's check covers it."""
+    expected = boolean_flag_error("false", "allow_missing_models", "WBCPolicy")
+    with pytest.raises(ValueError) as excinfo:
+        _gait_policy(allow_missing_models="false")
+    assert str(excinfo.value) == expected
+
+
+@pytest.mark.parametrize("value", [True, np.bool_(True)], ids=["True", "np.bool_(True)"])
+def test_the_seam_is_still_honoured_for_a_boolean_true(value: Any) -> None:
+    """Over-reach control: the documented seam still skips the eager load."""
+    policy = _policy(allow_missing_models=value)
+    assert policy.policy_session is None
+    assert policy.walk_session is None
+
+
+@pytest.mark.parametrize("value", [False, np.bool_(False)], ids=["False", "np.bool_(False)"])
+def test_a_boolean_false_still_reaches_the_loader(value: Any) -> None:
+    """Over-reach control: ``False`` is honoured - it loads, and fails loudly.
+
+    The loader refuses with ``RuntimeError`` here because either
+    ``onnxruntime`` is absent or the checkpoint is: both are the documented
+    "missing checkpoint fails loudly at construction" behaviour, and neither is
+    the argument refusal above.
+    """
+    with pytest.raises(RuntimeError):
+        _policy(checkpoint="/nonexistent/checkpoint", allow_missing_models=value)


### PR DESCRIPTION
## What

`WBCPolicy.__init__` refuses a non-boolean `allow_missing_models` at construction with `boolean_flag_error` - the domain the same signature already applies to `walk` - placed before the ONNX load the flag gates.

## Why

Two posture flags in one signature: `walk` was checked and `allow_missing_models` beside it was read by `if not allow_missing_models`. Every non-empty string is truthy, so the spelling a JSON `policy_config` reaches for to ask for the eager load selected the test seam instead.

Measured on `fb159ba`:

| `allow_missing_models` | constructed | sessions loaded | truthy |
|---|---|---|---|
| `"false"`, `"False"`, `"no"`, `"off"`, `"0"`, `"none"` | yes | **no** | True |
| `1.5` | yes | no | True |
| `None`, `0`, `[]` | reached the loader (`RuntimeError`, onnxruntime absent) | - | False |

The `"false"` caller then reads, at the first `get_actions`:

```
WBCPolicy has no ONNX session loaded. Construct with a valid checkpoint
(allow_missing_models=False), or construct with allow_missing_models=True and ...
```

which advises the value they believe they passed. That is the refusal-inherits-the-inversion shape the posture-flag rule in AGENTS.md names: the branch is reachable only where its advice is not actionable. `WBCGaitPolicy` forwards the flag to `super().__init__`, so it had the same reading and the one check covers both providers.

## Four corners

`tests/policies/wbc/test_allow_missing_models_is_checked_not_read_by_truthiness.py`, 21 cells. The refused set is derived from `boolean_flag_error` itself rather than copied.

| tests | production | result |
|---|---|---|
| pre | pre | 751 passed (wbc suite + shared posture grader) |
| **new** | pre | **16 failed**, 5 passed |
| new | new | 21 passed |
| pre | new | 751 passed - no pre-existing cell moved |

The 5 that pass on both trees are the over-reach controls: `True` / `np.bool_(True)` still skip the load, `False` / `np.bool_(False)` still reach it. The 16 are the 13 non-boolean values, the verbatim-wording cell, the ordering cell (a falsy `0` is refused by name rather than reaching the loader), and the gait-variant cell.

Not a row in `tests/policies/test_posture_flags_are_checked_not_coerced.py` on purpose: its table asserts the value is *stored*, and this flag is consumed inline - storing it would add an attribute with no reader.

## Gate

| check | result |
|---|---|
| `ruff check` + `ruff format --check` on touched files | clean |
| `mypy` on `policy.py` + the new test | no issues |
| `tests/policies/wbc/` + shared posture grader | 772 passed, 6 failed - the 6 are `Gr00tPolicy` rows needing `pyzmq`, byte-identical on `main` |
| `tests/test_changelog_fragments.py` | 28 passed |
| whole-tree grader roster (141 graders, `--continue-on-collection-errors`) | 4187 passed, 63 failed, 153 errors - **all 216 byte-identical node ids on `main` `fb159ba`**, every one an absent extra (`lerobot`, `awsiot`, `torch`, `serial`, `psutil`, `mujoco`); 0 name `wbc` |

## Overlap

`check_merge_base_overlap.py --paths` names #3343 on `policy.py`. Its hunk is the `_extract_state` docstring at 601-618; this one is `__init__` at 230-240 and the class docstring. Disjoint, merge-order only.

## Cost

Production: `+2` executable statements, a comment, two docstring sentences. Tests: `+1` file (21 cells). Docs: `+7` in `docs/policies/wbc.md` beside the parameter block that shows the flag. Fragment: `changelog.d/3574-wbc-allow-missing-models-checked.md`, pushed while still a draft so no approval can be dismissed by it.

Auto-merge (squash) armed.

## Round log

- round 0: opened as draft, fragment pushed, whole-tree gate attributed, marked ready.